### PR TITLE
fix: support all user attributes on identify

### DIFF
--- a/src/api/attributes.ts
+++ b/src/api/attributes.ts
@@ -1,5 +1,5 @@
 import { AnyValue } from "../../types/otlp";
-import { addAttribute, removeAttribute } from "../utils/otel";
+import { addAttribute, AttributeValueType, removeAttribute } from "../utils/otel";
 import { vars } from "../vars";
 
 /**
@@ -7,7 +7,7 @@ import { vars } from "../vars";
  * Note: if you need to ensure attributes are included with signals transmitted on initial page load, you should use
  * the "additionalSignalAttributes" property of the init call instead
  */
-export function addSignalAttribute(name: string, value: string | number | AnyValue) {
+export function addSignalAttribute(name: string, value: AttributeValueType | AnyValue) {
   addAttribute(vars.signalAttributes, name, value);
 }
 

--- a/src/api/identify.ts
+++ b/src/api/identify.ts
@@ -1,11 +1,13 @@
 import { vars } from "../vars";
 import { addAttribute, removeAttribute } from "../utils/otel";
-import { USER_EMAIL, USER_FULL_NAME, USER_ID, USER_NAME } from "../semantic-conventions";
+import { USER_EMAIL, USER_FULL_NAME, USER_HASH, USER_ID, USER_NAME, USER_ROLES } from "../semantic-conventions";
 
 type IdentifyOpts = {
   name?: string;
   fullName?: string;
   email?: string;
+  hash?: string;
+  roles?: string[];
 };
 
 export function identify(id?: string, opts?: IdentifyOpts) {
@@ -27,5 +29,15 @@ export function identify(id?: string, opts?: IdentifyOpts) {
   removeAttribute(vars.signalAttributes, USER_EMAIL);
   if (opts?.email != null) {
     addAttribute(vars.signalAttributes, USER_EMAIL, opts.email);
+  }
+
+  removeAttribute(vars.signalAttributes, USER_HASH);
+  if (opts?.hash != null) {
+    addAttribute(vars.signalAttributes, USER_HASH, opts.hash);
+  }
+
+  removeAttribute(vars.signalAttributes, USER_ROLES);
+  if (opts?.roles != null) {
+    addAttribute(vars.signalAttributes, USER_ROLES, opts.roles);
   }
 }

--- a/src/semantic-conventions.ts
+++ b/src/semantic-conventions.ts
@@ -5,12 +5,8 @@ export const DEPLOYMENT_ENVIRONMENT_NAME = "deployment.environment.name";
 export const DEPLOYMENT_NAME = "deployment.name";
 export const DEPLOYMENT_ID = "deployment.id";
 
-// Signal Attribute Keys
+// Misc Signal Attribute Keys
 export const EVENT_NAME = "event.name";
-export const USER_ID = "user.id";
-export const USER_NAME = "user.name";
-export const USER_FULL_NAME = "user.full_name";
-export const USER_EMAIL = "user.email";
 export const PAGE_LOAD_ID = "page.load.id";
 export const SESSION_ID = "session.id";
 export const USER_AGENT = "user_agent.original";
@@ -18,7 +14,14 @@ export const WINDOW_WIDTH = "browser.window.width";
 export const WINDOW_HEIGHT = "browser.window.height";
 export const NETWORK_CONNECTION_TYPE = "network.connection.subtype";
 export const EXCEPTION_COMPONENT_STACK = "exception.component_stack";
-export const COMPONENT = "component";
+
+// User Attribute Keys
+export const USER_ID = "user.id";
+export const USER_NAME = "user.name";
+export const USER_FULL_NAME = "user.full_name";
+export const USER_EMAIL = "user.email";
+export const USER_HASH = "user.hash";
+export const USER_ROLES = "user.roles";
 
 // Exception Attribute Keys
 export const EXCEPTION_MESSAGE = "exception.message";

--- a/src/utils/otel/attributes.ts
+++ b/src/utils/otel/attributes.ts
@@ -1,6 +1,6 @@
 import { AnyValue, KeyValue } from "../../../types/otlp";
 
-type AttributeValueType = string | number | boolean | Array<string | number | boolean>;
+export type AttributeValueType = string | number | boolean | Array<string | number | boolean>;
 
 function toAnyValue(value: AttributeValueType | AnyValue): AnyValue {
   let anyValue: AnyValue = {};
@@ -26,7 +26,7 @@ export function toKeyValue(key: string, value: AttributeValueType | AnyValue): K
   };
 }
 
-export function addAttribute(attributes: KeyValue[], key: string, value: string | number | AnyValue) {
+export function addAttribute(attributes: KeyValue[], key: string, value: AttributeValueType | AnyValue) {
   attributes.push(toKeyValue(key, value));
 }
 


### PR DESCRIPTION
`user.hash` and `user.roles` we're previously not supported on the `identify` api call.
This adds them