### PR TITLE
fix: dont attempt to call global timer functions if undefined

### DIFF
--- a/src/utils/timers.ts
+++ b/src/utils/timers.ts
@@ -75,5 +75,5 @@ function executeGlobally(this: keyof typeof globals) {
 
   // Note: Explicitly passing win as 'this' even though we are getting the function from 'globals'
 
-  return (globals[globalFunctionName] as any).apply(win, arguments);
+  return (globals[globalFunctionName] as any)?.apply(win, arguments);
 }


### PR DESCRIPTION
This addresses an exception caused when accidentially calling `sendEvent` on the server.
In that case `window.setInterval` would be undefined and `executeGlobally` would attempt to call `apply` on `undefined`

## Stacktrace
![Screenshot-20250604105555-1815x1058](https://github.com/user-attachments/assets/2940b079-ebcc-4251-a035-209e998916c5)
