### PR TITLE
chore: Change e2e-test-Server ports to 8010, 8011, 8012

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ They currently don't have a fully local setup, but can be executed locally again
 - Create a `.env` file based on `.env.example` and provide your sauce labs credentials.
 - Run the tests via `pnpm run test:e2e`
 
-#### Why do tests run on ports 5000, 5001 and 5002?
+#### Why do tests run on ports 8010, 8011 and 8012?
 
 We need multiple ports to properly test cors behaviour.
-5000 to 5002 are specifically chosen for their [behaviour in combination with localhost proxies](https://docs.saucelabs.com/secure-connections/sauce-connect-5/specifications/localhost-ports/#ports-for-proxying-localhost-traffic)
+8010 to 8012 are specifically chosen for their [behaviour in combination with localhost proxies](https://docs.saucelabs.com/secure-connections/sauce-connect-5/specifications/localhost-ports/#ports-for-proxying-localhost-traffic)

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "test:unit:watch": "vitest",
     "test:e2e": "wdio run ./test/e2e/wdio.conf.ts",
     "test:e2e:local": "wdio run ./test/e2e/wdio.local.conf.ts",
-    "test:e2e:server": "SERVER_PORTS='5000,5001,5002' node test/e2e/server/index.mjs",
+    "test:e2e:server": "SERVER_PORTS='8010,8011,8012' node test/e2e/server/index.mjs",
     "test:e2e:tunnel": "dotenv -- bash -c './.lambdatest/v3/LT --user $LT_USERNAME --key $LT_ACCESS_KEY'",
     "test:e2e:live": "run-p test:e2e:server test:e2e:tunnel",
     "test:coverage": "vitest run --coverage",

--- a/test/e2e/spec/00-page-load/empty.html
+++ b/test/e2e/spec/00-page-load/empty.html
@@ -23,7 +23,7 @@
           the_answer: 42,
         },
         endpoint: {
-          url: `http://${window.location.hostname}:5001?cors=true`,
+          url: `http://${window.location.hostname}:8011?cors=true`,
           authToken: "auth_abc123",
           dataset: "production",
         },

--- a/test/e2e/spec/01-fetch-instrumentation/page.html
+++ b/test/e2e/spec/01-fetch-instrumentation/page.html
@@ -20,12 +20,12 @@
         environment: "prod",
         endpoint: [
           {
-            url: `http://${window.location.hostname}:5001?cors=true`,
+            url: `http://${window.location.hostname}:8011?cors=true`,
             authToken: "auth_abc123",
             dataset: "production",
           },
         ],
-        propagateTraceHeadersCorsURLs: [new RegExp(`http:\/\/${window.location.hostname.replace(".", "\.")}:5002`)],
+        propagateTraceHeadersCorsURLs: [new RegExp(`http:\/\/${window.location.hostname.replace(".", "\.")}:8012`)],
         headersToCapture: [/x-test-header/],
         ignoreUrls: [/you-cant-see-this/],
       });
@@ -49,7 +49,7 @@
       }
 
       function onCrossOriginFetch() {
-        return fetch(`http://${window.location.hostname}:5002/ajax?cors=true`, { method: "POST" });
+        return fetch(`http://${window.location.hostname}:8012/ajax?cors=true`, { method: "POST" });
       }
 
       function onFetchWithRequest() {

--- a/test/e2e/spec/01-fetch-instrumentation/withZoneJs.html
+++ b/test/e2e/spec/01-fetch-instrumentation/withZoneJs.html
@@ -22,12 +22,12 @@
         environment: "prod",
         endpoint: [
           {
-            url: `http://${window.location.hostname}:5001?cors=true`,
+            url: `http://${window.location.hostname}:8011?cors=true`,
             authToken: "auth_abc123",
             dataset: "production",
           },
         ],
-        propagateTraceHeadersCorsURLs: [new RegExp(`http:\/\/${window.location.hostname.replace(".", "\.")}:5002`)],
+        propagateTraceHeadersCorsURLs: [new RegExp(`http:\/\/${window.location.hostname.replace(".", "\.")}:8012`)],
       });
     </script>
     <script defer crossorigin="anonymous" src="/dist/dash0.iife.js"></script>

--- a/test/e2e/spec/02-web-vitals/page.html
+++ b/test/e2e/spec/02-web-vitals/page.html
@@ -20,7 +20,7 @@
         serviceVersion: "1.2.3",
         environment: "prod",
         endpoint: {
-          url: `http://${window.location.hostname}:5001?cors=true`,
+          url: `http://${window.location.hostname}:8011?cors=true`,
           authToken: "auth_abc123",
           dataset: "production",
         },

--- a/test/e2e/spec/03-error-instrumentation/page.html
+++ b/test/e2e/spec/03-error-instrumentation/page.html
@@ -20,7 +20,7 @@
         serviceVersion: "1.2.3",
         environment: "prod",
         endpoint: {
-          url: `http://${window.location.hostname}:5001?cors=true`,
+          url: `http://${window.location.hostname}:8011?cors=true`,
           authToken: "auth_abc123",
           dataset: "production",
         },

--- a/test/e2e/spec/04-events-api/page.html
+++ b/test/e2e/spec/04-events-api/page.html
@@ -20,7 +20,7 @@
         serviceVersion: "1.2.3",
         environment: "prod",
         endpoint: {
-          url: `http://${window.location.hostname}:5001?cors=true`,
+          url: `http://${window.location.hostname}:8011?cors=true`,
           authToken: "auth_abc123",
           dataset: "production",
         },

--- a/test/e2e/spec/shared.ts
+++ b/test/e2e/spec/shared.ts
@@ -27,7 +27,7 @@ type OTLPRequest = {
 };
 
 export async function getOTLPRequests(): Promise<OTLPRequest[]> {
-  const resp = await fetch("http://127.0.0.1:5001/otlp-requests");
+  const resp = await fetch("http://127.0.0.1:8011/otlp-requests");
   if (!resp.ok) {
     throw new Error("Failed to retrieve OTLP requests");
   }
@@ -36,7 +36,7 @@ export async function getOTLPRequests(): Promise<OTLPRequest[]> {
 }
 
 export async function clearOTLPRequests() {
-  const resp = await fetch("http://127.0.0.1:5001/otlp-requests", {
+  const resp = await fetch("http://127.0.0.1:8011/otlp-requests", {
     method: "DELETE",
   });
   if (!resp.ok) {
@@ -45,7 +45,7 @@ export async function clearOTLPRequests() {
 }
 
 export async function clearAjaxRequests() {
-  const resp = await fetch("http://127.0.0.1:5001/ajax-requests", {
+  const resp = await fetch("http://127.0.0.1:8011/ajax-requests", {
     method: "DELETE",
   });
   if (!resp.ok) {

--- a/test/e2e/wdio.conf.ts
+++ b/test/e2e/wdio.conf.ts
@@ -125,7 +125,7 @@ export const config: WebdriverIO.Config = {
 
   logLevel: "info",
   bail: 0,
-  baseUrl: "http://localhost.lambdatest.com:5001",
+  baseUrl: "http://localhost.lambdatest.com:8011",
   waitforTimeout: 10000,
   connectionRetryTimeout: 120000,
   connectionRetryCount: 3,
@@ -151,7 +151,7 @@ export const config: WebdriverIO.Config = {
         stdio: "inherit",
         env: {
           ...process.env,
-          SERVER_PORTS: "5000,5001,5002",
+          SERVER_PORTS: "8010,8011,8012",
           SERVER_BASE_URL: config.baseUrl,
         },
       });

--- a/test/e2e/wdio.local.conf.ts
+++ b/test/e2e/wdio.local.conf.ts
@@ -25,7 +25,7 @@ export const config: WebdriverIO.Config = {
 
   logLevel: "info",
   bail: 0,
-  baseUrl: "http://127.0.0.1:5001",
+  baseUrl: "http://127.0.0.1:8011",
   waitforTimeout: 10000,
   connectionRetryTimeout: 120000,
   connectionRetryCount: 3,
@@ -45,7 +45,7 @@ export const config: WebdriverIO.Config = {
         stdio: "inherit",
         env: {
           ...process.env,
-          SERVER_PORTS: "5000,5001,5002",
+          SERVER_PORTS: "8010,8011,8012",
         },
       });
 


### PR DESCRIPTION
On Macs the port "5000" is used for the airplay receiver

I changed the ports 5000-5002 to **8010-8012** which should not conflict with any other dash0 local application