### PR TITLE
fix: page load timestamps

### DIFF
--- a/src/instrumentations/navigation/event.ts
+++ b/src/instrumentations/navigation/event.ts
@@ -9,7 +9,7 @@ import {
   PAGE_VIEW_TYPE,
   PAGE_VIEW_TYPE_VALUES,
 } from "../../semantic-conventions";
-import { doc, NO_VALUE_FALLBACK, nowNanos } from "../../utils";
+import { doc, NO_VALUE_FALLBACK } from "../../utils";
 import { addCommonAttributes } from "../../attributes";
 import { sendLog } from "../../transport";
 import { PageViewMeta, vars } from "../../vars";
@@ -20,7 +20,7 @@ function getPageViewMeta(url?: URL): PageViewMeta {
   return vars.pageViewInstrumentation.generateMetadata?.(url) ?? {};
 }
 
-export function transmitPageViewEvent(url?: URL, virtual?: boolean, replaced?: boolean) {
+export function transmitPageViewEvent(timeUnixNano: string, url?: URL, virtual?: boolean, replaced?: boolean) {
   const meta = getPageViewMeta(url);
 
   const attributes: KeyValue[] = [];
@@ -45,7 +45,7 @@ export function transmitPageViewEvent(url?: URL, virtual?: boolean, replaced?: b
   );
 
   const log: LogRecord = {
-    timeUnixNano: nowNanos(),
+    timeUnixNano: timeUnixNano,
     attributes: attributes,
     severityNumber: LOG_SEVERITIES.INFO,
     severityText: "INFO",

--- a/src/instrumentations/navigation/page-load.ts
+++ b/src/instrumentations/navigation/page-load.ts
@@ -1,4 +1,4 @@
-import { addEventListener, debug, doc, nowNanos, win, roundToTwoDecimals, error } from "../../utils";
+import { addEventListener, debug, doc, win, roundToTwoDecimals, error, toNanosTs, getTimeOrigin } from "../../utils";
 import { KeyValue, LogRecord } from "../../../types/otlp";
 import { EVENT_NAME, LOG_SEVERITIES, NAVIGATION_TIMING } from "../../semantic-conventions";
 import { sendLog } from "../../transport";
@@ -14,7 +14,7 @@ import { transmitPageViewEvent } from "./event";
  */
 export function startPageLoadInstrumentation() {
   try {
-    transmitPageViewEvent(win?.location.href ? new URL(win?.location.href) : undefined);
+    transmitPageViewEvent(getStartTimeUnixNanos(), win?.location.href ? new URL(win?.location.href) : undefined);
   } catch (e) {
     error("Failed to transmit initial page view event", e);
   }
@@ -62,7 +62,7 @@ function onLoaded() {
   addNavigationTiming(bodyAttributes, nt, "decodedBodySize");
 
   const log: LogRecord = {
-    timeUnixNano: nowNanos(),
+    timeUnixNano: getStartTimeUnixNanos(),
     attributes: attributes,
     severityNumber: LOG_SEVERITIES.INFO,
     severityText: "INFO",
@@ -89,4 +89,8 @@ function addNavigationTiming(attributes: KeyValue[], nt: PerformanceNavigationTi
   if (typeof value === "number" && !isNaN(value)) {
     addAttribute(attributes, field, Number.isInteger(value) ? value : roundToTwoDecimals(value));
   }
+}
+
+function getStartTimeUnixNanos(): string {
+  return toNanosTs(Math.round(getTimeOrigin()));
 }

--- a/src/instrumentations/navigation/page-transition.ts
+++ b/src/instrumentations/navigation/page-transition.ts
@@ -1,4 +1,4 @@
-import { debug, win, wrap } from "../../utils";
+import { debug, nowNanos, win, wrap } from "../../utils";
 import { vars } from "../../vars";
 import { transmitPageViewEvent } from "./event";
 
@@ -78,7 +78,7 @@ function onUrlChange(url?: string, replaced?: boolean) {
     const parsedUrl = new URL(url, win?.location.href);
     if (isLocationChange(parsedUrl)) {
       updateCurrentLocation(parsedUrl);
-      transmitPageViewEvent(parsedUrl, true, Boolean(replaced));
+      transmitPageViewEvent(nowNanos(), parsedUrl, true, Boolean(replaced));
     }
   } catch (e) {
     debug("Failed to handle url change", e);


### PR DESCRIPTION
We currently use `now()` as for load and timing logs, whereas we need to use the timestamp of the navigation start if that data is supposed to make sense.