### PR TITLE
fix: use session storage for tab tracking

### DIFF
--- a/src/utils/tab-id.ts
+++ b/src/utils/tab-id.ts
@@ -1,4 +1,4 @@
-import { getItem, isSupported, setItem } from "./local-storage";
+import { getItem, isSupported, setItem } from "./session-storage";
 import { debug, warn } from "./debug";
 import { generateUniqueId, TAB_ID_BYTES } from "./id";
 


### PR DESCRIPTION
This accidentally used local storage before, which is not unique per tab.