### PR TITLE
fix: set sampled bit in traceparent header

### DIFF
--- a/src/utils/otel/trace-context.ts
+++ b/src/utils/otel/trace-context.ts
@@ -80,5 +80,5 @@ export function addTraceContextHttpHeaders(
    * https://www.w3.org/TR/trace-context-2/#trace-flags
    * https://www.w3.org/TR/trace-context-2/#random-trace-id-flag
    */
-  fn.call(ctx, "traceparent", `00-${span.traceId}-${span.spanId}-02`);
+  fn.call(ctx, "traceparent", `00-${span.traceId}-${span.spanId}-03`);
 }


### PR DESCRIPTION
This previously signaled incorrectly that trace data was not recorded, which breaks trace correlation. Now signals correctly that the data was recorded