### PR TITLE
ENG-5578 Adapt trace-id, session-id and traceparent header 

### DIFF
--- a/src/api/session.ts
+++ b/src/api/session.ts
@@ -1,5 +1,5 @@
-import { isSupported, getItem, setItem, removeItem, SESSION_ID_BYTES } from "../utils";
-import { debug, generateUniqueId, now } from "../utils";
+import { isSupported, getItem, setItem, removeItem, generateSessionId } from "../utils";
+import { debug, now } from "../utils";
 import { info, warn } from "../utils";
 
 interface Session {
@@ -19,6 +19,9 @@ export let sessionId: string | null = null;
 export function trackSessions(sessionInactivityTimeoutMillis?: number, sessionTerminationTimeoutMillis?: number): void {
   if (!isSupported) {
     debug("Storage API is not available and session tracking is therefore not supported.");
+
+    // we still generate a session ID to ensure that the session ID is always available
+    sessionId = generateSessionId();
     return;
   }
 
@@ -43,7 +46,7 @@ export function trackSessions(sessionInactivityTimeoutMillis?: number, sessionTe
       session.lastActivityTime = now();
     } else {
       session = {
-        id: generateUniqueId(SESSION_ID_BYTES),
+        id: generateSessionId(),
         startTime: now(),
         lastActivityTime: now(),
       };
@@ -56,9 +59,10 @@ export function trackSessions(sessionInactivityTimeoutMillis?: number, sessionTe
   }
 }
 
+/**
+ * The session will be terminated. This only takes effect on the next physical page load.
+ */
 export function terminateSession() {
-  sessionId = null;
-
   if (!isSupported) {
     return;
   }

--- a/src/utils/id.ts
+++ b/src/utils/id.ts
@@ -1,7 +1,9 @@
+import * as localStorage from "./local-storage";
+
 export const SPAN_ID_BYTES = 8;
 export const TRACE_ID_BYTES = 16;
 export const PAGE_LOAD_ID_BYTES = TRACE_ID_BYTES;
-export const SESSION_ID_BYTES = TRACE_ID_BYTES;
+export const SESSION_ID_BYTES = SPAN_ID_BYTES;
 export const TAB_ID_BYTES = SPAN_ID_BYTES;
 
 const SHARED_CHAR_CODES_ARRAY = Array(32);
@@ -14,4 +16,17 @@ export function generateUniqueId(byteCount: number): string {
     }
   }
   return String.fromCharCode.apply(null, SHARED_CHAR_CODES_ARRAY.slice(0, byteCount * 2));
+}
+
+export function generateSessionId(): string {
+  // if the browser does support local storage the session is tracked over multiple page loads
+  const sessionFlags = localStorage.isSupported ? "00" : "01";
+  return `${sessionFlags}${generateUniqueId(SESSION_ID_BYTES - 1)}`;
+}
+
+export function generateTraceId(sessionId: string | null): string {
+  if (!sessionId) {
+    return `D04200${generateUniqueId(TRACE_ID_BYTES - 3)}`;
+  }
+  return `D04200${sessionId}${generateUniqueId(TRACE_ID_BYTES - SESSION_ID_BYTES - 3)}`;
 }

--- a/src/utils/id_test.ts
+++ b/src/utils/id_test.ts
@@ -1,5 +1,6 @@
-import { expect, describe, it } from "vitest";
-import { generateUniqueId } from "./id";
+import { expect, describe, it, vi } from "vitest";
+import { generateSessionId, generateTraceId, generateUniqueId } from "./id";
+import * as localStorage from "./local-storage";
 
 // Create a wrapper function for testing
 function generateId(length: number): string {
@@ -14,28 +15,92 @@ function generateId(length: number): string {
   return generateUniqueId(Math.ceil(length / 2)).substring(0, length);
 }
 
-describe("generateId", () => {
-  it("returns a string of the expected length", () => {
-    const id = generateId(10);
-    expect(id).toHaveLength(10);
+describe("id", () => {
+  describe("generateUniqueId", () => {
+    it("returns a string of the expected length", () => {
+      const id = generateId(10);
+      expect(id).toHaveLength(10);
+    });
+
+    it("returns a unique ID on each call", () => {
+      const id1 = generateId(10);
+      const id2 = generateId(10);
+      expect(id1).not.toBe(id2);
+    });
+
+    it("throws an error if length is less than 1", () => {
+      expect(() => generateId(0)).toThrow("Length must be greater than 0");
+    });
+
+    it("throws an error if length is not a number", () => {
+      expect(() => generateId("abc" as any)).toThrow("Length must be a number");
+    });
+
+    it("handles large lengths without errors", () => {
+      const id = generateId(1000);
+      expect(id).toHaveLength(1000);
+    });
   });
 
-  it("returns a unique ID on each call", () => {
-    const id1 = generateId(10);
-    const id2 = generateId(10);
-    expect(id1).not.toBe(id2);
+  describe("generateSessionId", () => {
+    it("returns a session ID of the expected length", () => {
+      const sessionId = generateSessionId();
+      expect(sessionId).toHaveLength(16);
+    });
+
+    it("returns a session ID with proper flags when storage is supported", () => {
+      vi.spyOn(localStorage, "isSupported", "get").mockReturnValue(true);
+
+      const sessionId = generateSessionId();
+      expect(sessionId.startsWith("00")).toBe(true);
+    });
+
+    it("returns a session ID with proper flags when storage is NOT supported", () => {
+      vi.spyOn(localStorage, "isSupported", "get").mockReturnValue(false);
+
+      const sessionId = generateSessionId();
+      expect(sessionId.startsWith("01")).toBe(true);
+    });
+
+    it("returns a unique session ID on each call", () => {
+      const sessionId1 = generateSessionId();
+      const sessionId2 = generateSessionId();
+
+      expect(sessionId1).not.toBe(sessionId2);
+    });
   });
 
-  it("throws an error if length is less than 1", () => {
-    expect(() => generateId(0)).toThrow("Length must be greater than 0");
-  });
+  describe("generateTraceId", () => {
+    it("returns a trace ID of the expected length", () => {
+      const traceId = generateTraceId(null);
 
-  it("throws an error if length is not a number", () => {
-    expect(() => generateId("abc" as any)).toThrow("Length must be a number");
-  });
+      expect(traceId).toHaveLength(32);
+    });
 
-  it("handles large lengths without errors", () => {
-    const id = generateId(1000);
-    expect(id).toHaveLength(1000);
+    it("returns a trace ID with correct prefix", () => {
+      const traceId = generateTraceId("abcdef1234567890");
+
+      expect(traceId.substring(0, 6)).toEqual("D04200");
+    });
+
+    it("returns a unique trace ID on each call", () => {
+      const sessiondId = "abcdef1234567890";
+      const traceId1 = generateTraceId("abcdef1234567890");
+      const traceId2 = generateTraceId("abcdef1234567890");
+
+      expect(traceId1).not.toBe(traceId2);
+      expect(traceId1.substring(6, 22)).toBe(sessiondId);
+      expect(traceId2.substring(6, 22)).toBe(sessiondId);
+    });
+
+    it("returns a unique trace ID when session id is not set", () => {
+      const traceId1 = generateTraceId(null);
+      const sessionId1 = traceId1.substring(6, 22);
+      const traceId2 = generateTraceId(null);
+      const sessionId2 = traceId2.substring(6, 22);
+
+      expect(traceId1).not.toBe(traceId2);
+      expect(sessionId1).not.toBe(sessionId2);
+    });
   });
 });

--- a/src/utils/otel/span.ts
+++ b/src/utils/otel/span.ts
@@ -1,13 +1,14 @@
 import { KeyValue, Span, SpanStatus } from "../../../types/otlp";
 import { nowNanos } from "../time";
-import { generateUniqueId, SPAN_ID_BYTES, TRACE_ID_BYTES } from "../id";
+import { generateTraceId, generateUniqueId, SPAN_ID_BYTES } from "../id";
 import { SPAN_KIND_CLIENT, SPAN_STATUS_UNSET } from "../../semantic-conventions";
+import { sessionId } from "../../api/session";
 
 export type InProgressSpan = Omit<Span, "endTimeUnixNano">;
 
 export function startSpan(name: string): InProgressSpan {
   return {
-    traceId: generateUniqueId(TRACE_ID_BYTES),
+    traceId: generateTraceId(sessionId),
     spanId: generateUniqueId(SPAN_ID_BYTES),
     name,
     // Always CLIENT for now https://github.com/open-telemetry/opentelemetry-proto/blob/ac3242b03157295e4ee9e616af53b81517b06559/opentelemetry/proto/trace/v1/trace.proto#L143-L169

--- a/src/utils/otel/trace-context.ts
+++ b/src/utils/otel/trace-context.ts
@@ -75,10 +75,12 @@ export function addTraceContextHttpHeaders(
    * Random Trace ID: 00000010 - IF set the component guarantees that the seven right most bytes of the trace-id
    * are randomly generated. Downstream processors are then able to rely on this for technical things like shard keys.
    *
+   * NOTE: For now we just send the "sampled" flag because not all components support the random trace ID flag.
+   *
    * References:
    * https://www.w3.org/TR/trace-context-2/#traceparent-header
    * https://www.w3.org/TR/trace-context-2/#trace-flags
    * https://www.w3.org/TR/trace-context-2/#random-trace-id-flag
    */
-  fn.call(ctx, "traceparent", `00-${span.traceId}-${span.spanId}-03`);
+  fn.call(ctx, "traceparent", `00-${span.traceId}-${span.spanId}-01`);
 }


### PR DESCRIPTION
* The session-id is reduced to 8 byte (1 byte is used a session flags to identify it the session could be stored on the device)
* The trace-id is now containing the session-id and a prefix to distinguish it from our regular trace ids
* 