### PR TITLE
fix: the calculation of the CRC32 checksum

### DIFF
--- a/src/utils/crc32.ts
+++ b/src/utils/crc32.ts
@@ -9,11 +9,16 @@ for (let i = 0; i < 256; i++) {
   TABLE[i] = c >>> 0;
 }
 
-export function crc32(str: string): number {
+export function crc32(hexStr: string): number {
+  const bytes = new Uint8Array(hexStr.length / 2);
+  for (let i = 0; i < hexStr.length; i += 2) {
+    bytes[i / 2] = parseInt(hexStr.substring(i, i + 2), 16);
+  }
+
   let crc = 0xffffffff;
-  for (let i = 0; i < str.length; i++) {
-    const byte = str.charCodeAt(i);
-    crc = (crc >>> 8) ^ TABLE[(crc ^ byte) & 0xff]!;
+  for (let i = 0; i < bytes.length; i++) {
+    const byte = bytes[i];
+    crc = (crc >>> 8) ^ TABLE[(crc ^ byte!) & 0xff]!;
   }
   return (crc ^ 0xffffffff) >>> 0;
 }

--- a/src/utils/span-id_test.ts
+++ b/src/utils/span-id_test.ts
@@ -24,7 +24,8 @@ describe("generateSpanId", () => {
   });
 
   it("return a span id with the correct prefix", () => {
-    expect(generateSpanId("abcdef1234567890abcdef1234567890").substring(0, 8)).toEqual("3d5a507a");
-    expect(generateSpanId("1234567890abcdef1234567890abcdef").substring(0, 8)).toEqual("c24261eb");
+    expect(generateSpanId("abcdef1234567890abcdef1234567890").substring(0, 8)).toEqual("07d06023");
+    expect(generateSpanId("1234567890abcdef1234567890abcdef").substring(0, 8)).toEqual("75df3ddf");
+    expect(generateSpanId("d0420000a7a996090df1cac9a99d3cb7").substring(0, 8)).toEqual("120e82be");
   });
 });


### PR DESCRIPTION
# Comparison with GO
In GO we calculate the same checksum
<img width="755" height="784" alt="image" src="https://github.com/user-attachments/assets/6d88c816-6dac-4fb0-b0d1-f0f9960c843f" />
