### PR TITLE
fix: fetch instrumentation timing issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ This currently also requires the use of Next.js
   key: `maxToleranceForResourceTimingsMillis`<br>
   type: `number`<br>
   optional: `true`<br>
-  default: `3000`<br>
+  default: `50`<br>
   The number of milliseconds of tolerance between resolution of a http request promise and the end time of performanceEntries
   applied when matching a request to its respective performance entry. A higher value might increase match frequency at
   the cost of potential incorrect matches. Matching is performed based on request timing and url.

--- a/src/instrumentations/http/fetch.ts
+++ b/src/instrumentations/http/fetch.ts
@@ -12,6 +12,7 @@ import {
   startSpan,
 } from "../../utils/otel";
 import {
+  ERROR_TYPE,
   HTTP_REQUEST_METHOD,
   HTTP_REQUEST_METHOD_ORIGINAL,
   HTTP_RESPONSE_STATUS_CODE,
@@ -166,7 +167,10 @@ function tryCaptureHttpHeaders(headers: Headers, span: InProgressSpan, getAttrib
 
 function addResponseData(span: InProgressSpan, response: Response) {
   const status = response.status;
-  setSpanStatus(span, status >= 200 && status < 400 ? SPAN_STATUS_UNSET : SPAN_STATUS_ERROR, response.statusText);
+  setSpanStatus(span, status >= 200 && status < 400 ? SPAN_STATUS_UNSET : SPAN_STATUS_ERROR);
+  if (status === 0) {
+    addAttribute(span.attributes, ERROR_TYPE, response.type);
+  }
   addAttribute(span.attributes, HTTP_RESPONSE_STATUS_CODE, String(status));
   tryCaptureHttpHeaders(response.headers, span, (k) => httpResponseHeaderKey(k));
 }

--- a/src/semantic-conventions.ts
+++ b/src/semantic-conventions.ts
@@ -31,6 +31,9 @@ export const EXCEPTION_MESSAGE = "exception.message";
 export const EXCEPTION_TYPE = "exception.type";
 export const EXCEPTION_STACKTRACE = "exception.stacktrace";
 
+// Error Attribute Keys
+export const ERROR_TYPE = "error.type";
+
 // URL Attribute Keys
 export const URL_DOMAIN = "url.domain";
 export const URL_FRAGMENT = "url.fragment";

--- a/src/vars.ts
+++ b/src/vars.ts
@@ -129,7 +129,7 @@ export type Vars = {
    * applied when matching a request to its respective performance entry. A higher value might increase match frequency at
    * the cost of potential incorrect matches. Matching is performed based on request timing and url.
    *
-   * @default 3000
+   * @default 50
    */
   maxToleranceForResourceTimingsMillis: number;
 
@@ -160,7 +160,7 @@ export const vars: Vars = {
   wrapTimers: true,
   propagateTraceHeadersCorsURLs: [],
   maxWaitForResourceTimingsMillis: 10000,
-  maxToleranceForResourceTimingsMillis: 3000,
+  maxToleranceForResourceTimingsMillis: 50,
   headersToCapture: [],
   pageViewInstrumentation: {
     trackVirtualPageViews: true,

--- a/test/e2e/spec/01-fetch-instrumentation/01-fetch-instrumentation.test.ts
+++ b/test/e2e/spec/01-fetch-instrumentation/01-fetch-instrumentation.test.ts
@@ -49,7 +49,6 @@ describe("Fetch Instrumentation", () => {
           ],
           status: {
             code: 0,
-            message: "OK",
           },
         })
       );
@@ -75,7 +74,6 @@ describe("Fetch Instrumentation", () => {
           ]),
           status: {
             code: 0,
-            message: "OK",
           },
         })
       );
@@ -101,7 +99,6 @@ describe("Fetch Instrumentation", () => {
           ]),
           status: {
             code: 0,
-            message: "OK",
           },
         })
       );
@@ -160,10 +157,9 @@ describe("Fetch Instrumentation", () => {
               attributes: expect.arrayContaining(expectedAttributes),
             }),
           ]),
-          status: {
+          status: expect.objectContaining({
             code: 2,
-            message: expect.not.stringContaining("Ok"),
-          },
+          }),
         })
       );
     });


### PR DESCRIPTION
* improves the reporting of canceled requests
* improves the precision of requests span timings
  Notable changes include
  * Record all matching resource timings observed by the performance observer and select the most fitting only after the request is done
  * Add 300ms delay after request is done for performance observer to report matches
  * Avoid re-use of timings across multiple requests
  * Greatly reduce `maxToleranceForResourceTimingsMillis` config option (This might not even be necessary at all, generally it seemed to actually decrease matching accuracy)