### PR TITLE
fix(fetch): do not wrap body for responses that cant have a body

### DIFF
--- a/src/instrumentations/http/fetch.ts
+++ b/src/instrumentations/http/fetch.ts
@@ -194,7 +194,8 @@ function wrapResponse(
   let fallbackTs: number = perf.now();
   const body = originalResponse.body;
 
-  if (!body) {
+  // For some reason browsers return a response body on responses that can't be constructed with one. In that case we can't wrap the body stream
+  if (!body || !responseCanHaveBody(originalResponse)) {
     onDone();
     return originalResponse;
   }
@@ -313,4 +314,9 @@ function addTraceContextHttpHeaders(
       addW3CTraceContextHttpHeaders(fn, ctx, span);
     }
   }
+}
+
+function responseCanHaveBody(response: Response) {
+  const status = response.status;
+  return status >= 200 && status != 204 && status != 205 && status != 304;
 }

--- a/test/e2e/server/index.mjs
+++ b/test/e2e/server/index.mjs
@@ -118,6 +118,15 @@ app.all("/ajax", (req, res) => {
   }, 100);
 });
 
+app.get("/ajax-requests", (_, res) => {
+  res.json(ajaxRequests);
+});
+
+app.delete("/ajax-requests", (_, res) => {
+  ajaxRequests.length = 0;
+  res.send("OK");
+});
+
 // AWS endpoints for X-Ray testing
 app.get("/aws", (req, res) => {
   const response = uuidV4();
@@ -193,13 +202,17 @@ app.post("/form", (req, res) => {
   }, 100);
 });
 
-app.get("/ajax-requests", (_, res) => {
-  res.json(ajaxRequests);
+// Response status endpoints
+app.all("/204", (req, res) => {
+  res.status(204).end();
 });
 
-app.delete("/ajax-requests", (_, res) => {
-  ajaxRequests.length = 0;
-  res.send("OK");
+app.all("/205", (req, res) => {
+  res.status(205).end();
+});
+
+app.all("/304", (req, res) => {
+  res.status(304).end();
 });
 
 getServerPorts().forEach((port) =>

--- a/test/e2e/spec/01-fetch-instrumentation/01-fetch-instrumentation.test.ts
+++ b/test/e2e/spec/01-fetch-instrumentation/01-fetch-instrumentation.test.ts
@@ -174,12 +174,14 @@ describe("Fetch Instrumentation", () => {
     await btn.click();
 
     await retry(async () => {
-      expect.objectContaining({
-        attributes: expect.arrayContaining([
-          { key: "url.full", value: { stringValue: expect.stringContaining("/ajax?assert-body") } },
-          { key: "http.response.status_code", value: { stringValue: "200" } },
-        ]),
-      });
+      await expectSpanMatching(
+        expect.objectContaining({
+          attributes: expect.arrayContaining([
+            { key: "url.full", value: { stringValue: expect.stringContaining("/ajax?assert-body") } },
+            { key: "http.response.status_code", value: { stringValue: "200" } },
+          ]),
+        })
+      );
     });
     expectNoBrowserErrors();
   });
@@ -192,12 +194,50 @@ describe("Fetch Instrumentation", () => {
     await btn.click();
 
     await retry(async () => {
-      expect.objectContaining({
-        attributes: expect.arrayContaining([
-          { key: "url.full", value: { stringValue: expect.stringContaining("/ajax?assert-body") } },
-          { key: "http.response.status_code", value: { stringValue: "200" } },
-        ]),
-      });
+      await expectSpanMatching(
+        expect.objectContaining({
+          attributes: expect.arrayContaining([
+            { key: "url.full", value: { stringValue: expect.stringContaining("/ajax?assert-body") } },
+            { key: "http.response.status_code", value: { stringValue: "200" } },
+          ]),
+        })
+      );
+    });
+    expectNoBrowserErrors();
+  });
+
+  it("must handle responses with no body status code", async () => {
+    await browser.url("/e2e/spec/01-fetch-instrumentation/page.html");
+    await expect(browser).toHaveTitle("fetch instrumentation test");
+
+    const btn = await $("button=Multi-Fetch With No Body Response");
+    await btn.click();
+
+    await retry(async () => {
+      await expectSpanMatching(
+        expect.objectContaining({
+          attributes: expect.arrayContaining([
+            { key: "url.full", value: { stringValue: expect.stringContaining("/204") } },
+            { key: "http.response.status_code", value: { stringValue: "204" } },
+          ]),
+        })
+      );
+      await expectSpanMatching(
+        expect.objectContaining({
+          attributes: expect.arrayContaining([
+            { key: "url.full", value: { stringValue: expect.stringContaining("/205") } },
+            { key: "http.response.status_code", value: { stringValue: "205" } },
+          ]),
+        })
+      );
+      await expectSpanMatching(
+        expect.objectContaining({
+          attributes: expect.arrayContaining([
+            { key: "url.full", value: { stringValue: expect.stringContaining("/304") } },
+            { key: "http.response.status_code", value: { stringValue: "304" } },
+          ]),
+        })
+      );
     });
     expectNoBrowserErrors();
   });

--- a/test/e2e/spec/01-fetch-instrumentation/page.html
+++ b/test/e2e/spec/01-fetch-instrumentation/page.html
@@ -100,6 +100,10 @@
         });
         return fetch(req);
       }
+
+      function onFetchWithNoBodyResponse() {
+        return Promise.all([fetch("/204"), fetch("/205"), fetch("/304")]);
+      }
     </script>
   </head>
   <body>
@@ -111,5 +115,6 @@
     <button onclick="onFailingFetch()">Failing Fetch</button>
     <button onclick="onFetchWithBodyFromInit()">Fetch With Body From Init</button>
     <button onclick="onFetchWithBodyFromRequest()">Fetch With Body From Request</button>
+    <button onclick="onFetchWithNoBodyResponse()">Multi-Fetch With No Body Response</button>
   </body>
 </html>


### PR DESCRIPTION
Responses with some status codes like 204 and 304 can't have a response body. Browsers are still providing a readable stream for them when returning the response from fetch, but a new response can't be constructed with a body from js for these status codes. This lead to some exceptions when instrumenting requests with responses carrying those status codes.

This adds a short cuircit to the response wrapping logic to avoid responses where we could not construct a copy with a wrapped body. Generally these should not have a body anyways so we don't need to try waiting for the body to be read either.