### PR TITLE
ci: handle cancelled e2e tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,10 +88,10 @@ jobs:
       - test-e2e
     steps:
       - name: Successful tests
-        if: ${{ !(contains(needs.*.result, 'failure')) }}
+        if: ${{ !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
         run: exit 0
       - name: Failing tests
-        if: ${{ contains(needs.*.result, 'failure') }}
+        if: ${{ failure() || contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
         run: exit 1
 
   release:


### PR DESCRIPTION
The previous condition for the e2e test matrix gate was only checking for failed tests, this effectively treats cancelled tests as passing. We now also check for cancelled ones explicitly to handle them as failed