### PR TITLE
feat(fetch): dont mark aborted requests as failed

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - Unit Test specific file: `pnpm run test:unit src/utils/id_test.ts`
 - Unit Test with watch mode: `pnpm run:unit test:watch`
 - Unit Test with coverage: `pnpm run test:unit:coverage`
-- E2E Test: `pnpm run test:e2e` (run all e2e tests)
+- E2E Test: `pnpm run test:e2e:local` (run all e2e tests, locally for faster iteration without remote runs)
 
 ## Code Style
 
@@ -22,7 +22,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - Error handling: Use try/catch with specific error logging, defensive null checks, optional chaining
 - Functions: Pure functions where possible, small and focused with descriptive names
 - Unit Testing: Vitest with describe/it style syntax, include expect/describe/it imports from vitest
-- E2E Testing: Playwright with test syntax, include expect/test imports from @playwright/test
+- E2E Testing: webdriver io with mocha test framework
 - Formatting: Code is formatted with Prettier
 
 ## Project Structure
@@ -33,4 +33,4 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - `/src/instrumentations`: Hooks into public APIs and events that generate data
 - `/src/transport`: Data transmission to Dash0's servers
 - `/test/server`: Test server that serves E2E test files, and acts as a server receiving OTLP requests.
-- `/test/e2e`: End-to-End tests based on Playwright reside in this directory.
+- `/test/e2e`: End-to-End tests reside in this directory.

--- a/src/instrumentations/http/fetch.ts
+++ b/src/instrumentations/http/fetch.ts
@@ -29,6 +29,7 @@ import {
   HTTP_RESPONSE_STATUS_CODE,
   SPAN_STATUS_ERROR,
   SPAN_STATUS_UNSET,
+  WEB_REQUEST_CANCELLED,
 } from "../../semantic-conventions";
 import { vars, PropagatorType } from "../../vars";
 import { httpRequestHeaderKey, httpResponseHeaderKey } from "../../utils/otel/http";
@@ -129,12 +130,20 @@ function wrapFetch(original: typeof fetch) {
         () => performanceObserver.end(),
         (e) => {
           performanceObserver.cancel();
-          endSpanOnError(span, e);
+          if (request.signal?.aborted) {
+            endSpanOnAbort(span);
+          } else {
+            endSpanOnError(span, e);
+          }
         }
       );
     } catch (e) {
       performanceObserver.cancel();
-      endSpanOnError(span, e as Exception);
+      if (request.signal?.aborted) {
+        endSpanOnAbort(span);
+      } else {
+        endSpanOnError(span, e as Exception);
+      }
       throw e;
     }
   };
@@ -275,6 +284,11 @@ function wrapResponse(
 function endSpanOnError(span: InProgressSpan, error: Exception) {
   recordException(span, error);
   sendSpan(endSpan(span, errorToSpanStatus(error), undefined));
+}
+
+function endSpanOnAbort(span: InProgressSpan) {
+  addAttribute(span.attributes, WEB_REQUEST_CANCELLED, true);
+  sendSpan(endSpan(span, undefined, undefined));
 }
 
 function determinePropagatorTypes(url: string): PropagatorType[] {

--- a/src/instrumentations/http/fetch_test.ts
+++ b/src/instrumentations/http/fetch_test.ts
@@ -1,6 +1,12 @@
 import { expect, vi, beforeEach, afterEach } from "vitest";
 import { vars } from "../../vars";
 import { instrumentFetch } from "./fetch";
+import { sendSpan } from "../../transport";
+import type { Span } from "../../types/otlp";
+
+vi.mock("../../transport", () => ({
+  sendSpan: vi.fn(),
+}));
 
 describe("fetch test", () => {
   let fetchMock: any;
@@ -187,5 +193,122 @@ describe("fetch test", () => {
     const fetchHeaders = (fetchMock.mock.calls[0]!.at(1)! as { headers: Headers }).headers;
     expect(fetchHeaders.get("traceparent")).not.toBeNull();
     expect(fetchHeaders.get("X-Amzn-Trace-Id")).toBeNull();
+  });
+
+  describe("aborted requests", () => {
+    const sendSpanMock = sendSpan as unknown as ReturnType<typeof vi.fn>;
+    const NativeRequest = Request;
+
+    const lastSpan = (): Span => {
+      const calls = sendSpanMock.mock.calls;
+      return calls[calls.length - 1]![0] as Span;
+    };
+
+    const hasAttribute = (span: Span, key: string, expectedValue: unknown) =>
+      span.attributes.some((a) => a.key === key && JSON.stringify(a.value) === JSON.stringify(expectedValue));
+
+    beforeEach(() => {
+      sendSpanMock.mockClear();
+      // jsdom's Request rejects its own AbortSignal instances (known jsdom bug).
+      // Stub Request with a minimal implementation that preserves signals verbatim.
+      class FakeRequest {
+        url: string;
+        method: string;
+        headers: Headers;
+        signal: AbortSignal | undefined;
+        constructor(input: string | FakeRequest, init?: RequestInit) {
+          if (input instanceof FakeRequest) {
+            this.url = input.url;
+            this.method = init?.method ?? input.method;
+            this.headers = new Headers(init?.headers ?? input.headers);
+            this.signal = init?.signal ?? input.signal;
+          } else {
+            this.url = String(input);
+            this.method = init?.method ?? "GET";
+            this.headers = new Headers(init?.headers);
+            this.signal = init?.signal ?? undefined;
+          }
+        }
+      }
+      vi.stubGlobal("Request", FakeRequest);
+    });
+
+    afterEach(() => {
+      vi.stubGlobal("Request", NativeRequest);
+    });
+
+    it("marks fetch as cancelled when the abort signal fires before the response arrives", async () => {
+      const controller = new AbortController();
+      fetchMock.mockImplementation(
+        (_input: RequestInfo, init?: RequestInit) =>
+          new Promise((_resolve, reject) => {
+            const signal = init?.signal;
+            if (signal?.aborted) {
+              reject(new DOMException("aborted", "AbortError"));
+              return;
+            }
+            signal?.addEventListener("abort", () => reject(new DOMException("aborted", "AbortError")));
+          })
+      );
+
+      instrumentFetch();
+      // eslint-disable-next-line no-restricted-globals
+      const pending = fetch("http://localhost:3000/api/test", { signal: controller.signal });
+      controller.abort();
+      await expect(pending).rejects.toBeInstanceOf(DOMException);
+
+      expect(sendSpanMock).toHaveBeenCalledTimes(1);
+      const span = lastSpan();
+      expect(span.status?.code).toBe(0);
+      expect(span.status?.message).toBeUndefined();
+      expect(hasAttribute(span, "dash0.web.request.cancelled", { boolValue: true })).toBe(true);
+      expect(span.events.find((e) => e.name === "exception")).toBeUndefined();
+    });
+
+    it("marks fetch as cancelled when the abort signal fires while reading the response body", async () => {
+      const controller = new AbortController();
+      const body = new ReadableStream({
+        start(streamController) {
+          streamController.enqueue(new Uint8Array([0x68, 0x69]));
+          controller.signal.addEventListener("abort", () => {
+            streamController.error(new DOMException("aborted", "AbortError"));
+          });
+        },
+      });
+
+      fetchMock.mockImplementation(() => Promise.resolve(new Response(body, { status: 200 })));
+
+      instrumentFetch();
+      // eslint-disable-next-line no-restricted-globals
+      const response = await fetch("http://localhost:3000/api/test", { signal: controller.signal });
+      const reader = response.body!.getReader();
+      await reader.read();
+      controller.abort();
+      await expect(reader.read()).rejects.toBeInstanceOf(DOMException);
+
+      expect(sendSpanMock).toHaveBeenCalledTimes(1);
+      const span = lastSpan();
+      // status was set from the 200 response and should not be overwritten
+      expect(span.status?.code).toBe(0);
+      expect(span.status?.message).toBeUndefined();
+      expect(hasAttribute(span, "dash0.web.request.cancelled", { boolValue: true })).toBe(true);
+      expect(hasAttribute(span, "http.response.status_code", { stringValue: "200" })).toBe(true);
+      expect(span.events.find((e) => e.name === "exception")).toBeUndefined();
+    });
+
+    it("still treats non-abort rejections as failures", async () => {
+      fetchMock.mockImplementation(() => Promise.reject(new TypeError("network down")));
+
+      instrumentFetch();
+      // eslint-disable-next-line no-restricted-globals
+      await expect(fetch("http://localhost:3000/api/test")).rejects.toBeInstanceOf(TypeError);
+
+      expect(sendSpanMock).toHaveBeenCalledTimes(1);
+      const span = lastSpan();
+      expect(span.status?.code).toBe(2);
+      expect(span.status?.message).toBe("network down");
+      expect(hasAttribute(span, "dash0.web.request.cancelled", { boolValue: true })).toBe(false);
+      expect(span.events.some((e) => e.name === "exception")).toBe(true);
+    });
   });
 });

--- a/src/semantic-conventions.ts
+++ b/src/semantic-conventions.ts
@@ -10,6 +10,7 @@ export const DEPLOYMENT_ID = "deployment.id";
 export const EVENT_NAME = "event.name";
 export const WEB_EVENT_TITLE = "dash0.web.event.title";
 export const WEB_EVENT_ID = "dash0.web.event.id";
+export const WEB_REQUEST_CANCELLED = "dash0.web.request.cancelled";
 export const PAGE_LOAD_ID = "page.load.id";
 export const SESSION_ID = "session.id";
 export const USER_AGENT = "user_agent.original";

--- a/test/e2e/server/index.mjs
+++ b/test/e2e/server/index.mjs
@@ -202,6 +202,30 @@ app.post("/form", (req, res) => {
   }, 100);
 });
 
+// Long-delay endpoint for abort-before-response tests. Responds well after the test
+// is expected to abort the request.
+app.all("/delay-fetch", (_req, res) => {
+  const timer = setTimeout(() => res.send("late"), 30_000);
+  res.on("close", () => clearTimeout(timer));
+});
+
+// Streaming endpoint for abort-during-body tests. Sends headers and chunks at a
+// steady cadence until the client aborts. The initial chunk is large enough to
+// defeat any TCP/HTTP buffering on Windows Chrome so the browser delivers it to
+// JS immediately; periodic follow-up chunks keep the connection alive.
+app.all("/stream-slowly", (_req, res) => {
+  res.status(200).set("Content-Type", "application/octet-stream");
+  res.write(Buffer.alloc(8 * 1024, 0));
+  const interval = setInterval(() => {
+    if (!res.writable) {
+      clearInterval(interval);
+      return;
+    }
+    res.write(Buffer.alloc(64, 0));
+  }, 100);
+  res.on("close", () => clearInterval(interval));
+});
+
 // Response status endpoints
 app.all("/204", (req, res) => {
   res.status(204).end();

--- a/test/e2e/spec/01-fetch-instrumentation/01-fetch-instrumentation.test.ts
+++ b/test/e2e/spec/01-fetch-instrumentation/01-fetch-instrumentation.test.ts
@@ -242,6 +242,51 @@ describe("Fetch Instrumentation", () => {
     expectNoBrowserErrors();
   });
 
+  it("must mark fetches aborted before the response as cancelled, not failed", async () => {
+    await browser.url("/e2e/spec/01-fetch-instrumentation/page.html");
+    await expect(browser).toHaveTitle("fetch instrumentation test");
+
+    const btn = await $("button=Aborted Fetch Before Response");
+    await btn.click();
+
+    await retry(async () => {
+      await expectSpanMatching(
+        expect.objectContaining({
+          attributes: expect.arrayContaining([
+            { key: "url.full", value: { stringValue: expect.stringContaining("/delay-fetch") } },
+            { key: "dash0.web.request.cancelled", value: { boolValue: true } },
+          ]),
+          status: expect.objectContaining({ code: 0 }),
+          events: expect.not.arrayContaining([expect.objectContaining({ name: "exception" })]),
+        })
+      );
+    });
+    expectNoBrowserErrors();
+  });
+
+  it("must mark fetches aborted while reading the body as cancelled, not failed", async () => {
+    await browser.url("/e2e/spec/01-fetch-instrumentation/page.html");
+    await expect(browser).toHaveTitle("fetch instrumentation test");
+
+    const btn = await $("button=Aborted Fetch During Body");
+    await btn.click();
+
+    await retry(async () => {
+      await expectSpanMatching(
+        expect.objectContaining({
+          attributes: expect.arrayContaining([
+            { key: "url.full", value: { stringValue: expect.stringContaining("/stream-slowly") } },
+            { key: "http.response.status_code", value: { stringValue: "200" } },
+            { key: "dash0.web.request.cancelled", value: { boolValue: true } },
+          ]),
+          status: expect.objectContaining({ code: 0 }),
+          events: expect.not.arrayContaining([expect.objectContaining({ name: "exception" })]),
+        })
+      );
+    });
+    expectNoBrowserErrors();
+  });
+
   describe("with zonejs", () => {
     it("must not add any work to non-root zones", async () => {
       await browser.url("/e2e/spec/01-fetch-instrumentation/withZoneJs.html");

--- a/test/e2e/spec/01-fetch-instrumentation/page.html
+++ b/test/e2e/spec/01-fetch-instrumentation/page.html
@@ -104,6 +104,30 @@
       function onFetchWithNoBodyResponse() {
         return Promise.all([fetch("/204"), fetch("/205"), fetch("/304")]);
       }
+
+      function onAbortedFetchBeforeResponse() {
+        const controller = new AbortController();
+        const p = fetch("/delay-fetch?abort-before-response", { signal: controller.signal }).catch(() => {});
+        controller.abort();
+        return p;
+      }
+
+      function onAbortedFetchDuringBody() {
+        const controller = new AbortController();
+        return fetch("/stream-slowly?abort-during-body", { signal: controller.signal }).then(async (response) => {
+          const reader = response.body.getReader();
+          await reader.read();
+          controller.abort();
+          try {
+            while (true) {
+              const { done } = await reader.read();
+              if (done) break;
+            }
+          } catch (_) {
+            // Expected: read rejects once the underlying transport is aborted.
+          }
+        });
+      }
     </script>
   </head>
   <body>
@@ -116,5 +140,7 @@
     <button onclick="onFetchWithBodyFromInit()">Fetch With Body From Init</button>
     <button onclick="onFetchWithBodyFromRequest()">Fetch With Body From Request</button>
     <button onclick="onFetchWithNoBodyResponse()">Multi-Fetch With No Body Response</button>
+    <button onclick="onAbortedFetchBeforeResponse()">Aborted Fetch Before Response</button>
+    <button onclick="onAbortedFetchDuringBody()">Aborted Fetch During Body</button>
   </body>
 </html>


### PR DESCRIPTION
This stops marking http requests as failed if they were aborted via an abort signal. Aborting via signal should be considered an intentional action by the client, not a failure.
In order to still mark the request as aborted instead of successfully completed a new attribute `dash0.web.request.cancelled` is introduced and added to aborted requests