### PR TITLE
Add sampling facility for Web-SDK sessions

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -323,6 +323,21 @@ These functionalities requires the use of Next.js:
 
 #### Session Tracking
 
+- **Session Sampling Rate**<br>
+  key: `sessionSamplingRate`<br>
+  type: `number`<br>
+  optional: `true`<br>
+  default: `100`<br>
+  The percentage of sessions for which telemetry data is recorded and transmitted.
+  Must be a number between 0 and 100.
+
+  - `0`: No sessions are recorded or transferred.
+  - `100`: All sessions are recorded and transferred (default).
+  - Any other value: That percentage of sessions are recorded and transferred.
+
+  The sampling decision is deterministic per session ID, so a given session will always produce the same
+  sampling outcome.
+
 - **Session Inactivity Timeout**<br>
   key: `sessionInactivityTimeoutMillis`<br>
   type: `number`<br>

--- a/README.md
+++ b/README.md
@@ -60,6 +60,18 @@ init({
 });
 ```
 
+#### Session Sampling
+
+You can control the percentage of user sessions that produce telemetry by setting `sessionSamplingRate` (0–100, default 100):
+
+```ts
+init({
+  serviceName: "my-website",
+  endpoint: { url: "{OTLP via HTTP endpoint}", authToken: "{authToken}" },
+  sessionSamplingRate: 50, // Only 50% of sessions will be recorded
+});
+```
+
 For more detailed instructions, refer to [`INSTALL.md`](./INSTALL.md).
 
 ## Development

--- a/src/api/init.ts
+++ b/src/api/init.ts
@@ -12,6 +12,7 @@ import {
 import {
   fetch,
   generateUniqueId,
+  isSessionSampledIn,
   isSafeServiceName,
   PAGE_LOAD_ID_BYTES,
   warn,
@@ -23,7 +24,7 @@ import {
   pick,
   loc,
 } from "../utils";
-import { trackSessions } from "./session";
+import { sessionId, trackSessions } from "./session";
 import { startWebVitalsInstrumentation } from "../instrumentations/web-vitals";
 import { startErrorInstrumentation } from "../instrumentations/errors";
 import { addAttribute } from "../utils/otel";
@@ -92,6 +93,17 @@ export function init(opts: InitOptions) {
   initializeSignalAttributes(opts);
   initializeTabId();
   trackSessions(opts.sessionInactivityTimeoutMillis, opts.sessionTerminationTimeoutMillis);
+
+  if (opts.sessionSamplingRate != null) {
+    const rate = Math.max(0, Math.min(100, opts.sessionSamplingRate));
+    vars.isSessionSampled = sessionId != null ? isSessionSampledIn(sessionId, rate) : rate > 0;
+  }
+
+  if (!vars.isSessionSampled) {
+    debug("Session is not sampled. No telemetry will be transmitted for this session.");
+    hasBeenInitialised = true;
+    return;
+  }
 
   if (isInstrumentationEnabled("@dash0/navigation", opts)) {
     startNavigationInstrumentation();

--- a/src/transport/index.ts
+++ b/src/transport/index.ts
@@ -21,6 +21,8 @@ function isRateLimited() {
 }
 
 export function sendLog(log: LogRecord): void {
+  if (!vars.isSessionSampled) return;
+
   if (isRateLimited()) {
     debug("Transport rate limit. Will not send item.", log);
     return;
@@ -49,6 +51,7 @@ function sendLogs(logs: LogRecord[]): void {
 
 export function sendSpan(span: Span | undefined): void {
   if (!span) return;
+  if (!vars.isSessionSampled) return;
 
   if (isRateLimited()) {
     debug("Transport rate limit. Will not send item.", span);

--- a/src/types/options.ts
+++ b/src/types/options.ts
@@ -39,6 +39,16 @@ export type InitOptions = {
   enabledInstrumentations?: InstrumentationName[];
 
   /**
+   * The percentage of sessions for which telemetry data is recorded and transmitted.
+   * Must be a number between 0 and 100.
+   * - 0: No sessions are recorded/transferred.
+   * - 100: All sessions are recorded/transferred (default).
+   * - Any other value: That percentage of sessions are recorded/transferred.
+   * The sampling decision is deterministic per session ID.
+   */
+  sessionSamplingRate?: number;
+
+  /**
    * The  session inactivity timeout. Session inactivity is the maximum
    * allowed time to pass between two page loads before the session is considered
    * to be expired. Also think of cache time-to-idle configuration options.

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -16,3 +16,4 @@ export * from "./url";
 export * from "./pick";
 export * from "./sanitize";
 export * from "./wrap";
+export * from "./session-sampling";

--- a/src/utils/session-sampling.ts
+++ b/src/utils/session-sampling.ts
@@ -1,0 +1,15 @@
+import { crc32 } from "./crc32";
+
+/**
+ * Determines whether a session should be sampled based on the session ID
+ * and a configured sampling rate.
+ *
+ * @param sessionId The hex session ID string
+ * @param samplingRate A number between 0 and 100 (inclusive)
+ * @returns true if the session should be sampled (data collected), false otherwise
+ */
+export function isSessionSampledIn(sessionId: string, samplingRate: number): boolean {
+  if (samplingRate <= 0) return false;
+  if (samplingRate >= 100) return true;
+  return crc32(sessionId) % 100 < samplingRate;
+}

--- a/src/utils/session-sampling_test.ts
+++ b/src/utils/session-sampling_test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import { isSessionSampledIn } from "./session-sampling";
+import { generateSessionId } from "./session-id";
+
+describe("isSessionSampledIn", () => {
+  it("returns false when sampling rate is 0", () => {
+    expect(isSessionSampledIn("00abcdef01234567", 0)).toBe(false);
+  });
+
+  it("returns true when sampling rate is 100", () => {
+    expect(isSessionSampledIn("00abcdef01234567", 100)).toBe(true);
+  });
+
+  it("returns deterministic results for the same session ID and rate", () => {
+    const sessionId = "00abcdef01234567";
+    const rate = 50;
+    const result1 = isSessionSampledIn(sessionId, rate);
+    const result2 = isSessionSampledIn(sessionId, rate);
+    expect(result1).toBe(result2);
+  });
+
+  it("produces different results for different session IDs", () => {
+    const results = new Set<boolean>();
+    // Generate enough IDs to get both true and false with high probability
+    for (let i = 0; i < 100; i++) {
+      results.add(isSessionSampledIn(generateSessionId(), 50));
+    }
+    expect(results.size).toBe(2);
+  });
+
+  it("produces roughly correct distribution over many session IDs", () => {
+    const rate = 30;
+    const total = 10000;
+    let sampledIn = 0;
+
+    for (let i = 0; i < total; i++) {
+      if (isSessionSampledIn(generateSessionId(), rate)) {
+        sampledIn++;
+      }
+    }
+
+    const actualRate = sampledIn / total;
+    // Allow 5% tolerance
+    expect(actualRate).toBeGreaterThan(0.25);
+    expect(actualRate).toBeLessThan(0.35);
+  });
+
+  it("handles edge case: rate just above 0", () => {
+    // With rate=1, about 1% of sessions should be sampled in
+    let sampledIn = 0;
+    const total = 10000;
+    for (let i = 0; i < total; i++) {
+      if (isSessionSampledIn(generateSessionId(), 1)) {
+        sampledIn++;
+      }
+    }
+    const actualRate = sampledIn / total;
+    expect(actualRate).toBeGreaterThan(0.0);
+    expect(actualRate).toBeLessThan(0.05);
+  });
+
+  it("handles edge case: rate just below 100", () => {
+    // With rate=99, about 99% of sessions should be sampled in
+    let sampledIn = 0;
+    const total = 10000;
+    for (let i = 0; i < total; i++) {
+      if (isSessionSampledIn(generateSessionId(), 99)) {
+        sampledIn++;
+      }
+    }
+    const actualRate = sampledIn / total;
+    expect(actualRate).toBeGreaterThan(0.95);
+    expect(actualRate).toBeLessThan(1.0);
+  });
+
+  it("returns false for negative sampling rates", () => {
+    expect(isSessionSampledIn("00abcdef01234567", -10)).toBe(false);
+  });
+
+  it("returns true for sampling rates above 100", () => {
+    expect(isSessionSampledIn("00abcdef01234567", 150)).toBe(true);
+  });
+});

--- a/src/vars.ts
+++ b/src/vars.ts
@@ -171,6 +171,12 @@ export type Vars = {
    * experimental - in rare cases causes Chrome to crash to use at your own risk.
    */
   enableTransportCompression: boolean;
+
+  /**
+   * Whether the current session is sampled in (true) or out (false).
+   * Determined at init time based on sessionSamplingRate and the session ID.
+   */
+  isSessionSampled: boolean;
 };
 
 export const vars: Vars = {
@@ -198,4 +204,5 @@ export const vars: Vars = {
     includeParts: [],
   },
   enableTransportCompression: false,
+  isSessionSampled: true,
 };

--- a/test/e2e/spec/07-session-sampling/07-session-sampling.test.ts
+++ b/test/e2e/spec/07-session-sampling/07-session-sampling.test.ts
@@ -1,0 +1,40 @@
+import { getOTLPRequests, sharedAfterEach, sharedBeforeEach } from "../shared";
+import { browser } from "@wdio/globals";
+import { delay, retry } from "../utils";
+import { expectLogMatching, expectNoBrowserErrors } from "../expectations";
+
+describe("Session Sampling", () => {
+  beforeEach(sharedBeforeEach);
+  afterEach(sharedAfterEach);
+
+  it("transmits telemetry when sessionSamplingRate is 100", async () => {
+    await browser.url("/e2e/spec/07-session-sampling/page.html?sampling-rate=100");
+    await expect(await browser.getTitle()).toMatch(/session-sampling test/);
+
+    await retry(async () => {
+      await expectLogMatching(
+        expect.objectContaining({
+          attributes: expect.arrayContaining([
+            { key: "event.name", value: { stringValue: "browser.page_view" } },
+            { key: "session.id", value: { stringValue: expect.any(String) } },
+          ]),
+        })
+      );
+    });
+
+    expectNoBrowserErrors();
+  });
+
+  it("does not transmit any telemetry when sessionSamplingRate is 0", async () => {
+    await browser.url("/e2e/spec/07-session-sampling/page.html?sampling-rate=0");
+    await expect(await browser.getTitle()).toMatch(/session-sampling test/);
+
+    // Wait long enough for any telemetry to arrive if it were being sent.
+    await delay(5000);
+
+    const requests = await getOTLPRequests();
+    expect(requests).toHaveLength(0);
+
+    expectNoBrowserErrors();
+  });
+});

--- a/test/e2e/spec/07-session-sampling/page.html
+++ b/test/e2e/spec/07-session-sampling/page.html
@@ -1,0 +1,39 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <title>session-sampling test</title>
+
+    <script>
+      (function (d, a, s, h, z, e, r, o) {
+        d[a] ||
+          ((z = d[a] =
+            function () {
+              h.push(arguments);
+            }),
+          (z._t = new Date()),
+          (z._v = 1),
+          (h = z._q = []));
+      })(window, "dash0");
+
+      const url = new URL(window.location.href);
+      const samplingRate = parseInt(url.searchParams.get("sampling-rate") || "100", 10);
+
+      dash0("init", {
+        serviceName: "dash0.com",
+        serviceVersion: "1.2.3",
+        environment: "prod",
+        endpoint: {
+          url: `http://${window.location.hostname}:8011?cors=true`,
+          authToken: "auth_abc123",
+          dataset: "production",
+        },
+        sessionSamplingRate: samplingRate,
+      });
+    </script>
+    <script defer crossorigin="anonymous" src="/dist/dash0.iife.js"></script>
+  </head>
+  <body>
+    <h1>Session Sampling Test</h1>
+  </body>
+</html>


### PR DESCRIPTION
This PR adds a way to configure the Web SDK to sample sessions based on their session-id.
This mechanism is similar to head-based sampling on backend traces, where a modulo function is applied to the session-id, sampling in/out sessions based on a percentage.

## Summary

  - Add sessionSamplingRate option (0–100) to control what percentage of user sessions produce telemetry
  - Sampling decision is deterministic per session ID using CRC32 modulo, so a given session always gets the same result
  - Unsampled sessions skip instrumentation startup entirely and have a transport-layer guard as defense-in-depth

## Test plan

  - Unit tests for isSessionSampledIn covering edge cases (0, 100, negative, >100), determinism, and statistical distribution
  - All 210 existing unit tests still pass
  - Build succeeds with no type errors