### PR TITLE
fix: replace ts-deepmerge with inline implementation (CVE-2026-12644)

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,11 +68,9 @@
     "url": "https://github.com/dash0hq/dash0-sdk-web/issues"
   },
   "dependencies": {
-    "web-vitals": "^5.0.3",
-    "ts-deepmerge": "^7.0.3"
+    "web-vitals": "^5.0.3"
   },
   "devDependencies": {
-    "dotenv-cli": "^8.0.0",
     "@babel/core": "^7.26.10",
     "@babel/preset-env": "^7.26.9",
     "@release-it/conventional-changelog": "^10.0.1",
@@ -94,8 +92,8 @@
     "@wdio/mocha-framework": "^9.12.5",
     "@wdio/sauce-service": "^9.12.5",
     "@wdio/spec-reporter": "^9.12.3",
-    "wdio-lambdatest-service": "^4.0.0",
     "body-parser": "^2.2.0",
+    "dotenv-cli": "^8.0.0",
     "eslint": "^9.24.0",
     "express": "^5.1.0",
     "google-closure-compiler": "^20240317.0.0",
@@ -112,6 +110,7 @@
     "typescript": "^5.8.3",
     "uuid": "^11.1.0",
     "vitest": "^3.1.1",
+    "wdio-lambdatest-service": "^4.0.0",
     "webdriverio": "^9.12.5"
   },
   "resolutions": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,9 +11,6 @@ importers:
 
   .:
     dependencies:
-      ts-deepmerge:
-        specifier: ^7.0.3
-        version: 7.0.3
       web-vitals:
         specifier: ^5.0.3
         version: 5.0.3
@@ -4720,10 +4717,6 @@ packages:
     engines: {node: '>=18.12'}
     peerDependencies:
       typescript: '>=4.8.4'
-
-  ts-deepmerge@7.0.3:
-    resolution: {integrity: sha512-Du/ZW2RfwV/D4cmA5rXafYjBQVuvu4qGiEEla4EmEHVHgRdx68Gftx7i66jn2bzHPwSVZY36Ae6OuDn9el4ZKA==}
-    engines: {node: '>=14.13.1'}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -10393,8 +10386,6 @@ snapshots:
   ts-api-utils@2.1.0(typescript@5.8.3):
     dependencies:
       typescript: 5.8.3
-
-  ts-deepmerge@7.0.3: {}
 
   tslib@2.8.1: {}
 

--- a/src/api/init.ts
+++ b/src/api/init.ts
@@ -30,7 +30,6 @@ import { startErrorInstrumentation } from "../instrumentations/errors";
 import { addAttribute } from "../utils/otel";
 import { instrumentFetch } from "../instrumentations/http/fetch";
 import { startNavigationInstrumentation } from "../instrumentations/navigation";
-import { merge } from "ts-deepmerge";
 import { initializeTabId } from "../utils/tab-id";
 import { InitOptions, InstrumentationName } from "../types/options";
 import { BrowserBuildEnv, pickFirstString } from "./browser-env";
@@ -284,4 +283,27 @@ function isInstrumentationEnabled(name: InstrumentationName, opts: InitOptions):
   if (!instrumentations) return true;
 
   return instrumentations.includes(name);
+}
+
+function merge<T extends Record<string, unknown>>(target: T, source: Partial<T>): T {
+  const result = { ...target };
+  for (const key of Object.keys(source) as Array<keyof T>) {
+    const srcVal = source[key];
+    const dstVal = target[key];
+    if (srcVal !== undefined) {
+      if (
+        srcVal !== null &&
+        typeof srcVal === "object" &&
+        !Array.isArray(srcVal) &&
+        typeof dstVal === "object" &&
+        dstVal !== null &&
+        !Array.isArray(dstVal)
+      ) {
+        result[key] = { ...dstVal, ...srcVal } as T[keyof T];
+      } else {
+        result[key] = srcVal as T[keyof T];
+      }
+    }
+  }
+  return result;
 }


### PR DESCRIPTION
## Summary

- Removes the `ts-deepmerge` production dependency due to [CVE-2026-12644](https://www.cve.org/CVERecord?id=CVE-2026-12644)
- The library had a single call site in `src/api/init.ts`, merging SDK default vars with user-provided init options
- The merge only needs to go one level deep (the only nested object is `pageViewInstrumentation`), making a ~15-line inline implementation sufficient — too simple to justify a dependency

## Test plan

- [x] All 257 unit tests pass
- [x] Build succeeds (lint, prettier, tsc, rollup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)