### PR TITLE
feat: add startView API, XMLHttpRequest instrumentation, and opt-in interaction capture

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -125,7 +125,8 @@ These can all be passed via the Dash0 Web SDK's `init` call.
 
 ### Backend Correlation
 
-The SDK supports trace context propagation to correlate frontend requests with backend services. You can configure
+The SDK supports trace context propagation to correlate frontend requests with backend services, for both `fetch`
+and `XMLHttpRequest` (including libraries built on XHR, such as axios's default browser adapter). You can configure
 different header types (`traceparent`, `X-Amzn-Trace-Id`) for different endpoints using the `propagators` configuration.
 
 > Misconfiguration of cross origin trace correlation can lead to request failures. Please make sure to carefully

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -668,6 +668,49 @@ sendEvent("user_action", {
 dash0("sendEvent", "user_action", { data: "button_clicked", severity: "INFO" });
 ```
 
+#### `startView(nameOrOptions)`
+
+Manually records a page view. Side-effect free: this never calls `history.pushState` /
+`history.replaceState` and never mutates `location`. Use this for single-page applications that
+own their own router and cannot let the SDK touch navigation state — for example, an Electron
+app that serves the whole application from one root URL, where automatic page-view tracking
+would report every screen as `/`.
+
+The emitted page view is indistinguishable from an automatic virtual page view downstream (same
+`browser.page_view` event, same `type` value); the only difference is that it is never
+accompanied by a `change_state` value, since no history mutation occurred.
+
+**Parameters:**
+
+- `nameOrOptions` (string | object): Either the view name directly, or an options object:
+  - `name` (string): The name of the view, e.g. `/settings`. Transmitted as the page view's title.
+  - `url` (string, optional): Overrides the url reflected in `page.url.*` attributes for this
+    view. Accepts an absolute or relative url; relative urls are resolved against the current
+    `location.href`. Falls back to the real `location.href` if omitted or invalid. Display-only —
+    never navigates or mutates history/location.
+  - `attributes` (Record<string, AttributeValueType | AnyValue>, optional): Additional attributes
+    to include with the page view.
+
+**Example:**
+
+```js
+// Module
+import { startView } from "@dash0/sdk-web";
+
+startView({
+  name: "/settings",
+  attributes: {
+    "app.screen": "settings",
+  },
+});
+
+// String shorthand
+startView("/checkout");
+
+// Script
+dash0("startView", { name: "/settings", attributes: { "app.screen": "settings" } });
+```
+
 ### Error Reporting
 
 #### `reportError(error, opts)`

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -243,7 +243,7 @@ The SDK enumerates the env vars above under every framework prefix the bundler e
   optional: `true`<br>
   default: `undefined`<br>
   List of instrumentations to enable. Defaults to `undefined`, enabling all instrumentations.
-  Supported values: `'@dash0/navigation' | '@dash0/web-vitals' | '@dash0/error' | '@dash0/fetch'`
+  Supported values: `'@dash0/navigation' | '@dash0/web-vitals' | '@dash0/error' | '@dash0/fetch' | '@dash0/xhr'`
   Please note that some dash0 features might not work as expected if instrumentations are disabled.
 
 - **Ignore URLs**<br>

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -243,7 +243,7 @@ The SDK enumerates the env vars above under every framework prefix the bundler e
   optional: `true`<br>
   default: `undefined`<br>
   List of instrumentations to enable. Defaults to `undefined`, enabling all instrumentations.
-  Supported values: `'@dash0/navigation' | '@dash0/web-vitals' | '@dash0/error' | '@dash0/fetch'`
+  Supported values: `'@dash0/navigation' | '@dash0/web-vitals' | '@dash0/error' | '@dash0/fetch' | '@dash0/interactions'`
   Please note that some dash0 features might not work as expected if instrumentations are disabled.
 
 - **Ignore URLs**<br>
@@ -540,6 +540,68 @@ The SDK auto-detects VCS (version control) context from the build environment an
   Additionally generate virtual page views when these url parts change.
   - "HASH" changes to the urls hash / fragment
   - "SEARCH" changes to the urls search / query parameters
+
+#### Interaction instrumentation
+
+Opt-in automatic capture of click interactions (Datadog RUM `trackUserInteractions` parity). Disabled by default --
+set `interactionInstrumentation.enabled: true` to turn it on. When enabled, a single capture-phase listener on
+`window` observes clicks anywhere on the page (no per-element wiring, no listener leakage) and emits a
+`browser.interaction` web event per click with a derived, privacy-conscious interaction name and a compact
+target-element selector.
+
+- **Enable Interaction Instrumentation**<br>
+  key: `interactionInstrumentation.enabled`<br>
+  type: `boolean`<br>
+  optional: `true`<br>
+  default: `false`<br>
+  Whether the SDK should automatically capture click interactions. Also requires `'@dash0/interactions'` to be
+  present in `enabledInstrumentations` when that option is explicitly set (it is included by default when
+  `enabledInstrumentations` is left `undefined`).
+- **Action Name Attribute**<br>
+  key: `interactionInstrumentation.actionNameAttribute`<br>
+  type: `string`<br>
+  optional: `true`<br>
+  default: `"data-dash0-action-name"`<br>
+  The element attribute the SDK checks first (on the clicked element or any of its ancestors) when deriving a
+  human-readable interaction name. Set this attribute on interactive elements for full control over the captured
+  name, e.g. `<button data-dash0-action-name="Save Settings">`.
+
+**Name derivation priority** (first match wins, walking from the clicked element up to 10 ancestors, stopping at
+the first `FORM`, `BODY`, `HTML`, or `HEAD` boundary):
+
+1. `custom_attribute` -- the configured `actionNameAttribute`, on the target or a qualifying ancestor.
+2. `standard_attribute` -- attribute-derived names checked on the target then ancestors: for `button`/`submit`/`reset`
+   inputs, `.value`; then `aria-label`, `aria-labelledby` (resolved via the referenced element(s)' text), `alt`,
+   `title`, or `placeholder`.
+3. `text_content` -- visible text: first the text of clickable-tag elements (`BUTTON`, `LABEL`, `A`, or
+   `role="button"`) found while walking up from the target, then the target's own visible text. This fallback never
+   applies when the click target itself is an `INPUT`, `TEXTAREA`, `SELECT`, or `OPTION` element, since their text
+   content is user data rather than an action label.
+4. `blank` -- an empty name, if nothing above matched.
+
+Attribute-derived sources always outrank text: the full phase order is custom attribute → standard attributes
+(walk) → text content (walk, then target) → blank. Each captured event's `name_source` attribute reflects which
+phase produced the name.
+
+**Privacy defaults (not configurable):** the SDK never reads the value of `password`, `text`, `textarea`, or
+`select` elements -- only `button`/`submit`/`reset` inputs expose their value for name derivation, and the
+text-content fallback above never applies to `INPUT`/`TEXTAREA`/`SELECT`/`OPTION` targets. Derived names are
+whitespace-normalized and truncated to 100 characters. The target-element selector is independently capped at 128
+characters.
+
+Note: capturing interaction events requires both `interactionInstrumentation.enabled: true` **and**
+`'@dash0/interactions'` present in `enabledInstrumentations` if that option is explicitly set to a non-default
+list -- either gate alone is not sufficient.
+
+```ts
+init({
+  serviceName: "my-website",
+  endpoint: { url: "{OTLP via HTTP endpoint}", authToken: "{authToken}" },
+  interactionInstrumentation: {
+    enabled: true,
+  },
+});
+```
 
 ## API
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
 # Dash0 Web SDK
 
+> [!NOTE] > **About this fork:** This is a personal fork of [`dash0hq/dash0-sdk-web`](https://github.com/dash0hq/dash0-sdk-web),
+> maintained by [@parker-edwards](https://github.com/parker-edwards) in a personal capacity. It contains preview
+> features that are **not part of the official Dash0 Web SDK**: a side-effect-free manual page-view API (`startView`),
+> `XMLHttpRequest` instrumentation with trace-context propagation, and opt-in automatic click instrumentation.
+> These may be proposed upstream in the future, but there is no committed timeline, and nothing in this repository
+> is endorsed or supported by Dash0. For production use, prefer the official
+> [`@dash0/sdk-web`](https://www.npmjs.com/package/@dash0/sdk-web) package.
+
 This SDK enables users of Dash0's web monitoring features to instrument a website or single-page-application to capture
 and transmit telemetry to Dash0.
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Features include:
 
 - Page view instrumentation
 - Navigation timing instrumentation
-- HTTP request instrumentation
+- HTTP request instrumentation (fetch and XMLHttpRequest)
 - Error tracking
 
 ## Getting started

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Dash0 Web SDK
 
-> **About this fork:** I am a Solution Architect for Dash0, and this is a fork that contains features that are, for now, **not part of the official Dash0 Web SDK**: a side-effect-free manual page-view API (`startView`), `XMLHttpRequest` instrumentation with trace-context propagation, and opt-in automatic click instrumentation. I do hope to upstream these features, but for now, these features should be testesd in non-critical environments.
-
 This SDK enables users of Dash0's web monitoring features to instrument a website or single-page-application to capture
 and transmit telemetry to Dash0.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Dash0 Web SDK
 
-> [!NOTE] > **About this fork:** This is a personal fork of [`dash0hq/dash0-sdk-web`](https://github.com/dash0hq/dash0-sdk-web),
+> **About this fork:** This is a personal fork of [`dash0hq/dash0-sdk-web`](https://github.com/dash0hq/dash0-sdk-web),
 > maintained by [@parker-edwards](https://github.com/parker-edwards) in a personal capacity. It contains preview
 > features that are **not part of the official Dash0 Web SDK**: a side-effect-free manual page-view API (`startView`),
 > `XMLHttpRequest` instrumentation with trace-context propagation, and opt-in automatic click instrumentation.

--- a/README.md
+++ b/README.md
@@ -1,12 +1,6 @@
 # Dash0 Web SDK
 
-> **About this fork:** This is a personal fork of [`dash0hq/dash0-sdk-web`](https://github.com/dash0hq/dash0-sdk-web),
-> maintained by [@parker-edwards](https://github.com/parker-edwards) in a personal capacity. It contains preview
-> features that are **not part of the official Dash0 Web SDK**: a side-effect-free manual page-view API (`startView`),
-> `XMLHttpRequest` instrumentation with trace-context propagation, and opt-in automatic click instrumentation.
-> These may be proposed upstream in the future, but there is no committed timeline, and nothing in this repository
-> is endorsed or supported by Dash0. For production use, prefer the official
-> [`@dash0/sdk-web`](https://www.npmjs.com/package/@dash0/sdk-web) package.
+> **About this fork:** I am a Solution Architect for Dash0, and this is a fork that contains features that are, for now, **not part of the official Dash0 Web SDK**: a side-effect-free manual page-view API (`startView`), `XMLHttpRequest` instrumentation with trace-context propagation, and opt-in automatic click instrumentation. I do hope to upstream these features, but for now, these features should be testesd in non-critical environments.
 
 This SDK enables users of Dash0's web monitoring features to instrument a website or single-page-application to capture
 and transmit telemetry to Dash0.

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "@wdio/mocha-framework": "^9.12.5",
     "@wdio/sauce-service": "^9.12.5",
     "@wdio/spec-reporter": "^9.12.3",
+    "axios": "^1.18.1",
     "body-parser": "^2.2.0",
     "dotenv-cli": "^8.0.0",
     "eslint": "^9.24.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,6 +78,9 @@ importers:
       '@wdio/spec-reporter':
         specifier: ^9.12.3
         version: 9.12.3
+      axios:
+        specifier: ^1.18.1
+        version: 1.18.1
       body-parser:
         specifier: ^2.2.0
         version: 2.2.0
@@ -1779,8 +1782,8 @@ packages:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
 
-  axios@1.9.0:
-    resolution: {integrity: sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==}
+  axios@1.18.1:
+    resolution: {integrity: sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==}
 
   b4a@1.6.7:
     resolution: {integrity: sha512-OnAYlL5b7LEkALw87fUVafQw5rVR9RjwGd4KUwNQ6DrrNmaVaUCgLipfVlzrPQ4tWOR9P0IXGNOx50jYCCdSJg==}
@@ -2753,8 +2756,8 @@ packages:
   fn.name@1.1.0:
     resolution: {integrity: sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==}
 
-  follow-redirects@1.15.9:
-    resolution: {integrity: sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==}
+  follow-redirects@1.16.0:
+    resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
     engines: {node: '>=4.0'}
     peerDependencies:
       debug: '*'
@@ -2772,6 +2775,10 @@ packages:
 
   form-data@4.0.2:
     resolution: {integrity: sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==}
+    engines: {node: '>= 6'}
+
+  form-data@4.0.6:
+    resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
     engines: {node: '>= 6'}
 
   formdata-polyfill@4.0.10:
@@ -3010,6 +3017,10 @@ packages:
 
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.4:
+    resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
 
   he@1.2.0:
@@ -4077,6 +4088,10 @@ packages:
 
   proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
+
+  proxy-from-env@2.1.0:
+    resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
+    engines: {node: '>=10'}
 
   pump@3.0.2:
     resolution: {integrity: sha512-tUPXtzlGM8FE3P0ZL6DVs/3P58k9nk8/jZeQCurTJylQA8qFYzHFfhBJkuqyE0FifOsQ0uKWekiZ5g8wtr28cw==}
@@ -6264,7 +6279,7 @@ snapshots:
   '@lambdatest/node-tunnel@4.0.9':
     dependencies:
       adm-zip: 0.5.16
-      axios: 1.9.0
+      axios: 1.18.1
       get-port: 1.0.0
       https-proxy-agent: 5.0.1
       split: 1.0.1
@@ -7081,13 +7096,15 @@ snapshots:
     dependencies:
       possible-typed-array-names: 1.1.0
 
-  axios@1.9.0:
+  axios@1.18.1:
     dependencies:
-      follow-redirects: 1.15.9
-      form-data: 4.0.2
-      proxy-from-env: 1.1.0
+      follow-redirects: 1.16.0
+      form-data: 4.0.6
+      https-proxy-agent: 5.0.1
+      proxy-from-env: 2.1.0
     transitivePeerDependencies:
       - debug
+      - supports-color
 
   b4a@1.6.7: {}
 
@@ -8262,7 +8279,7 @@ snapshots:
 
   fn.name@1.1.0: {}
 
-  follow-redirects@1.15.9: {}
+  follow-redirects@1.16.0: {}
 
   for-each@0.3.5:
     dependencies:
@@ -8278,6 +8295,14 @@ snapshots:
       asynckit: 0.4.0
       combined-stream: 1.0.8
       es-set-tostringtag: 2.1.0
+      mime-types: 2.1.35
+
+  form-data@4.0.6:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.4
       mime-types: 2.1.35
 
   formdata-polyfill@4.0.10:
@@ -8545,6 +8570,10 @@ snapshots:
       minimalistic-assert: 1.0.1
 
   hasown@2.0.2:
+    dependencies:
+      function-bind: 1.1.2
+
+  hasown@2.0.4:
     dependencies:
       function-bind: 1.1.2
 
@@ -9629,6 +9658,8 @@ snapshots:
 
   proxy-from-env@1.1.0: {}
 
+  proxy-from-env@2.1.0: {}
+
   pump@3.0.2:
     dependencies:
       end-of-stream: 1.4.4
@@ -10639,7 +10670,7 @@ snapshots:
       '@wdio/cli': 9.12.5
       '@wdio/logger': 7.26.0
       '@wdio/types': 9.12.3
-      axios: 1.9.0
+      axios: 1.18.1
       colors: 1.4.0
       form-data: 4.0.2
       source-map-support: 0.5.21

--- a/src/api/init.ts
+++ b/src/api/init.ts
@@ -122,6 +122,7 @@ export function init(opts: InitOptions) {
   if (isInstrumentationEnabled("@dash0/fetch", opts)) {
     instrumentFetch();
   }
+  // Both gates must pass: the instrumentation-name allowlist and the opt-in settings flag.
   if (isInstrumentationEnabled("@dash0/interactions", opts) && vars.interactionInstrumentation.enabled) {
     startInteractionInstrumentation();
   }

--- a/src/api/init.ts
+++ b/src/api/init.ts
@@ -29,6 +29,7 @@ import { startWebVitalsInstrumentation } from "../instrumentations/web-vitals";
 import { startErrorInstrumentation } from "../instrumentations/errors";
 import { addAttribute } from "../utils/otel";
 import { instrumentFetch } from "../instrumentations/http/fetch";
+import { instrumentXhr } from "../instrumentations/http/xhr";
 import { startNavigationInstrumentation } from "../instrumentations/navigation";
 import { initializeTabId } from "../utils/tab-id";
 import { InitOptions, InstrumentationName } from "../types/options";
@@ -119,6 +120,9 @@ export function init(opts: InitOptions) {
   }
   if (isInstrumentationEnabled("@dash0/fetch", opts)) {
     instrumentFetch();
+  }
+  if (isInstrumentationEnabled("@dash0/xhr", opts)) {
+    instrumentXhr();
   }
 
   hasBeenInitialised = true;

--- a/src/api/init.ts
+++ b/src/api/init.ts
@@ -30,6 +30,7 @@ import { startErrorInstrumentation } from "../instrumentations/errors";
 import { addAttribute } from "../utils/otel";
 import { instrumentFetch } from "../instrumentations/http/fetch";
 import { startNavigationInstrumentation } from "../instrumentations/navigation";
+import { startInteractionInstrumentation } from "../instrumentations/interactions";
 import { initializeTabId } from "../utils/tab-id";
 import { InitOptions, InstrumentationName } from "../types/options";
 import { BrowserBuildEnv, pickFirstString } from "./browser-env";
@@ -85,6 +86,7 @@ export function init(opts: InitOptions) {
         "headersToCapture",
         "urlAttributeScrubber",
         "pageViewInstrumentation",
+        "interactionInstrumentation",
         "enableTransportCompression",
       ])
     )
@@ -119,6 +121,9 @@ export function init(opts: InitOptions) {
   }
   if (isInstrumentationEnabled("@dash0/fetch", opts)) {
     instrumentFetch();
+  }
+  if (isInstrumentationEnabled("@dash0/interactions", opts) && vars.interactionInstrumentation.enabled) {
+    startInteractionInstrumentation();
   }
 
   hasBeenInitialised = true;

--- a/src/api/init_test.ts
+++ b/src/api/init_test.ts
@@ -201,9 +201,24 @@ describe("init", () => {
       expect(vars.interactionInstrumentation).toEqual({
         enabled: true,
         actionNameAttribute: "data-dash0-action-name",
+        captureScrolls: false,
+        captureKeyPresses: false,
+        captureChanges: false,
+      });
+    });
+
+    it("allows opting into scroll/key-press/change capture individually", async () => {
+      init({
+        ...baseOptions,
+        interactionInstrumentation: { enabled: true, captureScrolls: true, captureKeyPresses: true },
+      });
+
+      expect(vars.interactionInstrumentation).toEqual({
+        enabled: true,
+        actionNameAttribute: "data-dash0-action-name",
         captureScrolls: true,
         captureKeyPresses: true,
-        captureChanges: true,
+        captureChanges: false,
       });
     });
 
@@ -216,9 +231,9 @@ describe("init", () => {
       expect(vars.interactionInstrumentation).toEqual({
         enabled: true,
         actionNameAttribute: "data-custom-name",
-        captureScrolls: true,
-        captureKeyPresses: true,
-        captureChanges: true,
+        captureScrolls: false,
+        captureKeyPresses: false,
+        captureChanges: false,
       });
     });
   });

--- a/src/api/init_test.ts
+++ b/src/api/init_test.ts
@@ -34,6 +34,10 @@ vi.mock("../instrumentations/navigation", () => ({
   startNavigationInstrumentation: vi.fn(),
 }));
 
+vi.mock("../instrumentations/interactions", () => ({
+  startInteractionInstrumentation: vi.fn(),
+}));
+
 // Mock the utils module to control loc.hostname
 vi.mock("../utils", async () => {
   const actual = await vi.importActual("../utils");
@@ -47,6 +51,7 @@ import { startErrorInstrumentation } from "../instrumentations/errors";
 import { instrumentFetch } from "../instrumentations/http/fetch";
 import { startNavigationInstrumentation } from "../instrumentations/navigation";
 import { startWebVitalsInstrumentation } from "../instrumentations/web-vitals";
+import { startInteractionInstrumentation } from "../instrumentations/interactions";
 
 describe("init", () => {
   const baseOptions: InitOptions = {
@@ -74,6 +79,10 @@ describe("init", () => {
   });
 
   describe("instrumentation enablement", () => {
+    beforeEach(() => {
+      vars.interactionInstrumentation.enabled = true;
+    });
+
     it("should enable all instrumentations when enabledInstrumentations is undefined", async () => {
       init({
         ...baseOptions,
@@ -91,12 +100,14 @@ describe("init", () => {
       "@dash0/web-vitals",
       "@dash0/error",
       "@dash0/fetch",
+      "@dash0/interactions",
     ];
     const instrumentationMocks = {
       "@dash0/navigation": startNavigationInstrumentation,
       "@dash0/web-vitals": startWebVitalsInstrumentation,
       "@dash0/error": startErrorInstrumentation,
       "@dash0/fetch": instrumentFetch,
+      "@dash0/interactions": startInteractionInstrumentation,
     };
 
     instrumentations.forEach((instrumentation) => {
@@ -130,6 +141,70 @@ describe("init", () => {
         otherInstrumentations.forEach((name) => {
           expect(instrumentationMocks[name]).toHaveBeenCalled();
         });
+      });
+    });
+  });
+
+  describe("interaction instrumentation settings gate", () => {
+    it("does not start interactions when enabledInstrumentations includes it but interactionInstrumentation.enabled is false (default)", async () => {
+      init({
+        ...baseOptions,
+        enabledInstrumentations: ["@dash0/interactions"],
+      });
+
+      expect(startInteractionInstrumentation).not.toHaveBeenCalled();
+    });
+
+    it("does not start interactions when interactionInstrumentation.enabled is true but enabledInstrumentations excludes it", async () => {
+      init({
+        ...baseOptions,
+        enabledInstrumentations: ["@dash0/navigation"],
+        interactionInstrumentation: { enabled: true },
+      });
+
+      expect(startInteractionInstrumentation).not.toHaveBeenCalled();
+    });
+
+    it("starts interactions when both gates pass: enabledInstrumentations includes it and interactionInstrumentation.enabled is true", async () => {
+      init({
+        ...baseOptions,
+        enabledInstrumentations: ["@dash0/interactions"],
+        interactionInstrumentation: { enabled: true },
+      });
+
+      expect(startInteractionInstrumentation).toHaveBeenCalled();
+    });
+
+    it("starts interactions when enabledInstrumentations is undefined (all enabled) and interactionInstrumentation.enabled is true", async () => {
+      init({
+        ...baseOptions,
+        interactionInstrumentation: { enabled: true },
+      });
+
+      expect(startInteractionInstrumentation).toHaveBeenCalled();
+    });
+
+    it("preserves the default actionNameAttribute when only enabled is overridden (nested settings shallow-merge)", async () => {
+      init({
+        ...baseOptions,
+        interactionInstrumentation: { enabled: true },
+      });
+
+      expect(vars.interactionInstrumentation).toEqual({
+        enabled: true,
+        actionNameAttribute: "data-dash0-action-name",
+      });
+    });
+
+    it("allows overriding actionNameAttribute independently", async () => {
+      init({
+        ...baseOptions,
+        interactionInstrumentation: { enabled: true, actionNameAttribute: "data-custom-name" },
+      });
+
+      expect(vars.interactionInstrumentation).toEqual({
+        enabled: true,
+        actionNameAttribute: "data-custom-name",
       });
     });
   });

--- a/src/api/init_test.ts
+++ b/src/api/init_test.ts
@@ -30,6 +30,10 @@ vi.mock("../instrumentations/http/fetch", () => ({
   instrumentFetch: vi.fn(),
 }));
 
+vi.mock("../instrumentations/http/xhr", () => ({
+  instrumentXhr: vi.fn(),
+}));
+
 vi.mock("../instrumentations/navigation", () => ({
   startNavigationInstrumentation: vi.fn(),
 }));
@@ -45,6 +49,7 @@ vi.mock("../utils", async () => {
 
 import { startErrorInstrumentation } from "../instrumentations/errors";
 import { instrumentFetch } from "../instrumentations/http/fetch";
+import { instrumentXhr } from "../instrumentations/http/xhr";
 import { startNavigationInstrumentation } from "../instrumentations/navigation";
 import { startWebVitalsInstrumentation } from "../instrumentations/web-vitals";
 
@@ -84,6 +89,7 @@ describe("init", () => {
       expect(startWebVitalsInstrumentation).toHaveBeenCalled();
       expect(startErrorInstrumentation).toHaveBeenCalled();
       expect(instrumentFetch).toHaveBeenCalled();
+      expect(instrumentXhr).toHaveBeenCalled();
     });
 
     const instrumentations: InstrumentationName[] = [
@@ -91,12 +97,14 @@ describe("init", () => {
       "@dash0/web-vitals",
       "@dash0/error",
       "@dash0/fetch",
+      "@dash0/xhr",
     ];
     const instrumentationMocks = {
       "@dash0/navigation": startNavigationInstrumentation,
       "@dash0/web-vitals": startWebVitalsInstrumentation,
       "@dash0/error": startErrorInstrumentation,
       "@dash0/fetch": instrumentFetch,
+      "@dash0/xhr": instrumentXhr,
     };
 
     instrumentations.forEach((instrumentation) => {

--- a/src/api/init_test.ts
+++ b/src/api/init_test.ts
@@ -201,6 +201,9 @@ describe("init", () => {
       expect(vars.interactionInstrumentation).toEqual({
         enabled: true,
         actionNameAttribute: "data-dash0-action-name",
+        captureScrolls: true,
+        captureKeyPresses: true,
+        captureChanges: true,
       });
     });
 
@@ -213,6 +216,9 @@ describe("init", () => {
       expect(vars.interactionInstrumentation).toEqual({
         enabled: true,
         actionNameAttribute: "data-custom-name",
+        captureScrolls: true,
+        captureKeyPresses: true,
+        captureChanges: true,
       });
     });
   });

--- a/src/api/start-view.ts
+++ b/src/api/start-view.ts
@@ -1,0 +1,61 @@
+import { transmitManualPageViewEvent } from "../instrumentations/navigation/event";
+import { AttributeValueType } from "../utils/otel";
+import { AnyValue } from "../types/otlp";
+import { debug, nowNanos, win } from "../utils";
+import { vars } from "../vars";
+
+export type StartViewOptions = {
+  /**
+   * The name of the view, e.g. "/settings". Transmitted as the page view's title.
+   */
+  name: string;
+
+  /**
+   * Optionally override the url reflected in `page.url.*` attributes for this view.
+   * Accepts an absolute or relative url; relative urls are resolved against the current
+   * `location.href`. Falls back to the real `location.href` if omitted or invalid.
+   * This is display-only: calling startView never navigates or mutates history/location.
+   */
+  url?: string;
+
+  /**
+   * Additional attributes to include with the page view.
+   */
+  attributes?: Record<string, AttributeValueType | AnyValue>;
+};
+
+/**
+ * Manually records a page view, side-effect free: this never calls `history.pushState` /
+ * `history.replaceState` and never mutates `location`. Intended for single-page applications
+ * that own their own router and cannot let the SDK touch navigation state (e.g. Electron apps
+ * serving the whole app from one root URL, where automatic page-view tracking would report
+ * every screen as "/").
+ *
+ * The emitted event is indistinguishable from an automatic virtual page view downstream
+ * (same `browser.page_view` event name, same `type` value); the difference is only that it is
+ * never accompanied by a `change_state` value, since no history mutation occurred.
+ */
+export function startView(nameOrOptions: string | StartViewOptions) {
+  if (vars.endpoints.length === 0) {
+    debug("Dash0 SDK has not been initialized. Ignoring startView call.");
+    return;
+  }
+
+  const opts: StartViewOptions = typeof nameOrOptions === "string" ? { name: nameOrOptions } : nameOrOptions;
+
+  let url: URL | undefined;
+  if (opts.url != null) {
+    try {
+      url = new URL(opts.url, win?.location.href);
+    } catch (e) {
+      debug("Failed to parse startView url option. Falling back to the current location.", e);
+    }
+  }
+
+  transmitManualPageViewEvent({
+    timeUnixNano: nowNanos(),
+    title: opts.name,
+    url,
+    attributes: opts.attributes,
+  });
+}

--- a/src/api/start-view_test.ts
+++ b/src/api/start-view_test.ts
@@ -1,0 +1,80 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { KeyValue, LogRecord } from "../types/otlp";
+
+vi.mock("../transport", () => ({
+  sendLog: vi.fn(),
+}));
+
+import { sendLog } from "../transport";
+import { startView } from "./start-view";
+import { vars } from "../vars";
+
+const sendLogMock = sendLog as unknown as ReturnType<typeof vi.fn>;
+
+describe("startView", () => {
+  beforeEach(() => {
+    sendLogMock.mockClear();
+    vars.endpoints = [{ url: "https://example.com", authToken: "auth_abc123" }];
+    vars.pageViewInstrumentation = { trackVirtualPageViews: true, includeParts: [] };
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    vars.endpoints = [];
+  });
+
+  it("accepts a string shorthand and uses it as the title", () => {
+    startView("/settings");
+
+    expect(sendLogMock).toHaveBeenCalledTimes(1);
+    const log = sendLogMock.mock.calls[0]![0] as LogRecord;
+    const bodyValues = log.body?.kvlistValue?.values as KeyValue[];
+    expect(bodyValues).toEqual(expect.arrayContaining([{ key: "title", value: { stringValue: "/settings" } }]));
+  });
+
+  it("accepts an options object with name and attributes", () => {
+    startView({ name: "/settings", attributes: { "app.screen": "settings" } });
+
+    const log = sendLogMock.mock.calls[0]![0] as LogRecord;
+    const bodyValues = log.body?.kvlistValue?.values as KeyValue[];
+    expect(bodyValues).toEqual(expect.arrayContaining([{ key: "title", value: { stringValue: "/settings" } }]));
+    expect(log.attributes).toEqual(expect.arrayContaining([{ key: "app.screen", value: { stringValue: "settings" } }]));
+  });
+
+  it("parses a relative url option and reflects it in page.url.path", () => {
+    startView({ name: "/settings", url: "/settings" });
+
+    const log = sendLogMock.mock.calls[0]![0] as LogRecord;
+    expect(log.attributes).toEqual(
+      expect.arrayContaining([{ key: "page.url.path", value: { stringValue: "/settings" } }])
+    );
+  });
+
+  it("falls back to no url override and logs a debug message on an invalid url", () => {
+    startView({ name: "/settings", url: "http://" });
+
+    expect(sendLogMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not touch history or location", () => {
+    // eslint-disable-next-line no-restricted-globals
+    const originalHref = window.location.href;
+    // eslint-disable-next-line no-restricted-globals
+    const originalLength = window.history.length;
+
+    startView({ name: "/settings" });
+
+    // eslint-disable-next-line no-restricted-globals
+    expect(window.location.href).toBe(originalHref);
+    // eslint-disable-next-line no-restricted-globals
+    expect(window.history.length).toBe(originalLength);
+  });
+
+  it("is a no-op before init (no endpoints configured)", () => {
+    vars.endpoints = [];
+
+    startView("/settings");
+
+    expect(sendLogMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/entrypoint/npm-package.ts
+++ b/src/entrypoint/npm-package.ts
@@ -9,12 +9,14 @@ export * from "../api/events";
 export * from "../api/log-level";
 export { terminateSession } from "../api/session";
 export { reportError } from "../api/report-error";
+export { startView } from "../api/start-view";
 
 // Additional utility types
 export type { AttributeValueType } from "../utils/otel";
 export type { AnyValue } from "../types/otlp";
 export type { PageViewMeta, PropagatorConfig, PropagatorType } from "../vars";
 export type { UrlAttributeScrubber, UrlAttributeRecord } from "../attributes/url";
+export type { StartViewOptions } from "../api/start-view";
 
 export function init(opts: InitOptions): void {
   debug(`${INIT_MESSAGE} (via package)`);

--- a/src/entrypoint/npm-package_test.ts
+++ b/src/entrypoint/npm-package_test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from "vitest";
+import * as npmPackage from "./npm-package";
+
+describe("npm-package entrypoint", () => {
+  it("exports startView", () => {
+    expect(typeof npmPackage.startView).toBe("function");
+  });
+});

--- a/src/entrypoint/script.ts
+++ b/src/entrypoint/script.ts
@@ -8,6 +8,7 @@ import { terminateSession } from "../api/session";
 import { addSignalAttribute, removeSignalAttribute } from "../api/attributes";
 import { sendEvent } from "../api/events";
 import { setActiveLogLevel } from "../api/log-level";
+import { startView } from "../api/start-view";
 
 /**
  * All the APIs exposed through the script tag via `dash0('{{api name}}')`
@@ -22,6 +23,7 @@ const scriptApis = {
   removeSignalAttribute,
   setActiveLogLevel,
   sendEvent,
+  startView,
 } as const;
 
 type GlobalObject = {

--- a/src/instrumentations/http/fetch.ts
+++ b/src/instrumentations/http/fetch.ts
@@ -13,6 +13,7 @@ import { vars } from "../../vars";
 import { httpRequestHeaderKey, httpResponseHeaderKey } from "../../utils/otel/http";
 import { sendSpan } from "../../transport";
 import {
+  addInteractionAttributes,
   addResourceNetworkEvents,
   addResourceSize,
   addTraceContextHttpHeaders,
@@ -69,6 +70,7 @@ function wrapFetch(original: typeof fetch) {
     if (!isWellKnownMethod) {
       addAttribute(span.attributes, HTTP_REQUEST_METHOD_ORIGINAL, originalMethod);
     }
+    addInteractionAttributes(span);
 
     const propagatorTypes = determinePropagatorTypes(url);
     const shouldSetCorrelationHeaders = propagatorTypes.length > 0;

--- a/src/instrumentations/http/fetch.ts
+++ b/src/instrumentations/http/fetch.ts
@@ -1,27 +1,6 @@
-import {
-  debug,
-  observeResourcePerformance,
-  perf,
-  win,
-  setTimeout,
-  isSameOrigin,
-  wrap,
-  parseUrl,
-  clearTimeout,
-} from "../../utils";
-import { isUrlIgnored, matchesAny } from "../../utils/ignore-rules";
-import {
-  addAttribute,
-  setSpanStatus,
-  addW3CTraceContextHttpHeaders,
-  addXRayTraceContextHttpHeaders,
-  endSpan,
-  errorToSpanStatus,
-  Exception,
-  InProgressSpan,
-  recordException,
-  startSpan,
-} from "../../utils/otel";
+import { debug, observeResourcePerformance, perf, win, setTimeout, wrap, parseUrl, clearTimeout } from "../../utils";
+import { isUrlIgnored } from "../../utils/ignore-rules";
+import { addAttribute, endSpan, setSpanStatus, Exception, InProgressSpan, startSpan } from "../../utils/otel";
 import {
   ERROR_TYPE,
   HTTP_REQUEST_METHOD,
@@ -29,12 +8,20 @@ import {
   HTTP_RESPONSE_STATUS_CODE,
   SPAN_STATUS_ERROR,
   SPAN_STATUS_UNSET,
-  WEB_REQUEST_CANCELLED,
 } from "../../semantic-conventions";
-import { vars, PropagatorType } from "../../vars";
+import { vars } from "../../vars";
 import { httpRequestHeaderKey, httpResponseHeaderKey } from "../../utils/otel/http";
 import { sendSpan } from "../../transport";
-import { addResourceNetworkEvents, addResourceSize, HTTP_METHOD_OTHER, isWellKnownHttpMethod } from "./utils";
+import {
+  addResourceNetworkEvents,
+  addResourceSize,
+  addTraceContextHttpHeaders,
+  determinePropagatorTypes,
+  endSpanOnAbort,
+  endSpanOnError,
+  HTTP_METHOD_OTHER,
+  isWellKnownHttpMethod,
+} from "./utils";
 import { addCommonAttributes, addUrlAttributes } from "../../attributes";
 
 export function instrumentFetch() {
@@ -279,67 +266,6 @@ function wrapResponse(
     statusText: originalResponse.statusText,
     headers: originalResponse.headers,
   });
-}
-
-function endSpanOnError(span: InProgressSpan, error: Exception) {
-  recordException(span, error);
-  sendSpan(endSpan(span, errorToSpanStatus(error), undefined));
-}
-
-function endSpanOnAbort(span: InProgressSpan) {
-  addAttribute(span.attributes, WEB_REQUEST_CANCELLED, true);
-  sendSpan(endSpan(span, undefined, undefined));
-}
-
-function determinePropagatorTypes(url: string): PropagatorType[] {
-  const matchingTypes: PropagatorType[] = [];
-  const isUrlSameOrigin = isSameOrigin(url);
-
-  // For same-origin requests, always include traceparent + all configured propagators
-  if (isUrlSameOrigin) {
-    // Always add traceparent for same-origin requests
-    matchingTypes.push("traceparent");
-
-    // Add all other configured propagator types for same-origin requests
-    if (vars.propagators) {
-      for (const propagator of vars.propagators) {
-        if (propagator.type !== "traceparent" && !matchingTypes.includes(propagator.type)) {
-          matchingTypes.push(propagator.type);
-        }
-      }
-    }
-    return matchingTypes;
-  }
-
-  // For cross-origin requests, use new propagators config if available
-  if (vars.propagators) {
-    for (const propagator of vars.propagators) {
-      if (matchesAny(propagator.match, url)) {
-        // Avoid duplicates
-        if (!matchingTypes.includes(propagator.type)) {
-          matchingTypes.push(propagator.type);
-        }
-      }
-    }
-    return matchingTypes;
-  }
-
-  return [];
-}
-
-function addTraceContextHttpHeaders(
-  fn: (name: string, value: string) => void,
-  ctx: unknown,
-  span: InProgressSpan,
-  types: PropagatorType[]
-) {
-  for (const type of types) {
-    if (type === "xray") {
-      addXRayTraceContextHttpHeaders(fn, ctx, span);
-    } else {
-      addW3CTraceContextHttpHeaders(fn, ctx, span);
-    }
-  }
 }
 
 function responseCanHaveBody(response: Response) {

--- a/src/instrumentations/http/interaction-attribution_test.ts
+++ b/src/instrumentations/http/interaction-attribution_test.ts
@@ -1,0 +1,45 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { addInteractionAttributes } from "./utils";
+import type { InProgressSpan } from "../../utils/otel";
+import { USER_INTERACTION_ID, USER_INTERACTION_NAME } from "../../semantic-conventions";
+import { clearActiveInteractionForTests, registerActiveInteraction } from "../interactions/active-interaction";
+
+function newSpan(): InProgressSpan {
+  return { attributes: [] } as unknown as InProgressSpan;
+}
+
+describe("HTTP span interaction attribution", () => {
+  afterEach(() => {
+    clearActiveInteractionForTests();
+  });
+
+  it("stamps user_interaction.id and .name when a named interaction is active", () => {
+    const interaction = registerActiveInteraction("Fire 10 concurrent requests");
+
+    const span = newSpan();
+    addInteractionAttributes(span);
+
+    expect(span.attributes).toEqual(
+      expect.arrayContaining([
+        { key: USER_INTERACTION_ID, value: { stringValue: interaction.id } },
+        { key: USER_INTERACTION_NAME, value: { stringValue: "Fire 10 concurrent requests" } },
+      ])
+    );
+  });
+
+  it("stamps only the id when the interaction has no derived name", () => {
+    const interaction = registerActiveInteraction("");
+
+    const span = newSpan();
+    addInteractionAttributes(span);
+
+    expect(span.attributes).toEqual([{ key: USER_INTERACTION_ID, value: { stringValue: interaction.id } }]);
+  });
+
+  it("adds nothing when no interaction is active", () => {
+    const span = newSpan();
+    addInteractionAttributes(span);
+
+    expect(span.attributes).toEqual([]);
+  });
+});

--- a/src/instrumentations/http/utils.ts
+++ b/src/instrumentations/http/utils.ts
@@ -11,9 +11,15 @@ import {
 } from "../../utils/otel";
 import { domHRTimestampToNanos, hasKey, isSameOrigin, PerformanceTimingNames } from "../../utils";
 import { matchesAny } from "../../utils/ignore-rules";
-import { HTTP_RESPONSE_BODY_SIZE, WEB_REQUEST_CANCELLED } from "../../semantic-conventions";
+import {
+  HTTP_RESPONSE_BODY_SIZE,
+  USER_INTERACTION_ID,
+  USER_INTERACTION_NAME,
+  WEB_REQUEST_CANCELLED,
+} from "../../semantic-conventions";
 import { vars, PropagatorType } from "../../vars";
 import { sendSpan } from "../../transport";
+import { getActiveInteraction } from "../interactions/active-interaction";
 
 // SEE: https://github.com/open-telemetry/semantic-conventions/blob/main/docs/attributes-registry/http.md?plain=1#L67
 const KNOWN_HTTP_METHODS = ["GET", "HEAD", "POST", "PUT", "DELETE", "CONNECT", "OPTIONS", "TRACE", "PATCH"];
@@ -21,6 +27,23 @@ export const HTTP_METHOD_OTHER = "_OTHER";
 
 export function isWellKnownHttpMethod(method: string): boolean {
   return KNOWN_HTTP_METHODS.includes(method);
+}
+
+/**
+ * Stamps `user_interaction.id` (and `.name` when one was derived) onto an HTTP
+ * request span when the request was started while a user interaction (click)
+ * is active — attributing the request to the click that caused it, the same
+ * causality RUM products surface as "user actions". Shared by the XHR and
+ * fetch instrumentations so both report identical correlation attributes.
+ */
+export function addInteractionAttributes(span: InProgressSpan) {
+  const interaction = getActiveInteraction();
+  if (!interaction) return;
+
+  addAttribute(span.attributes, USER_INTERACTION_ID, interaction.id);
+  if (interaction.name) {
+    addAttribute(span.attributes, USER_INTERACTION_NAME, interaction.name);
+  }
 }
 
 export function addResourceNetworkEvents(span: InProgressSpan, resource: PerformanceResourceTiming) {

--- a/src/instrumentations/http/utils.ts
+++ b/src/instrumentations/http/utils.ts
@@ -1,6 +1,19 @@
-import { addAttribute, addSpanEvent, InProgressSpan } from "../../utils/otel";
-import { domHRTimestampToNanos, hasKey, PerformanceTimingNames } from "../../utils";
-import { HTTP_RESPONSE_BODY_SIZE } from "../../semantic-conventions";
+import {
+  addAttribute,
+  addSpanEvent,
+  addW3CTraceContextHttpHeaders,
+  addXRayTraceContextHttpHeaders,
+  endSpan,
+  errorToSpanStatus,
+  Exception,
+  InProgressSpan,
+  recordException,
+} from "../../utils/otel";
+import { domHRTimestampToNanos, hasKey, isSameOrigin, PerformanceTimingNames } from "../../utils";
+import { matchesAny } from "../../utils/ignore-rules";
+import { HTTP_RESPONSE_BODY_SIZE, WEB_REQUEST_CANCELLED } from "../../semantic-conventions";
+import { vars, PropagatorType } from "../../vars";
+import { sendSpan } from "../../transport";
 
 // SEE: https://github.com/open-telemetry/semantic-conventions/blob/main/docs/attributes-registry/http.md?plain=1#L67
 const KNOWN_HTTP_METHODS = ["GET", "HEAD", "POST", "PUT", "DELETE", "CONNECT", "OPTIONS", "TRACE", "PATCH"];
@@ -45,5 +58,66 @@ export function addResourceSize(span: InProgressSpan, resource: PerformanceResou
   const encodedLength = resource.encodedBodySize;
   if (encodedLength != undefined) {
     addAttribute(span.attributes, HTTP_RESPONSE_BODY_SIZE, encodedLength);
+  }
+}
+
+export function endSpanOnError(span: InProgressSpan, error: Exception) {
+  recordException(span, error);
+  sendSpan(endSpan(span, errorToSpanStatus(error), undefined));
+}
+
+export function endSpanOnAbort(span: InProgressSpan) {
+  addAttribute(span.attributes, WEB_REQUEST_CANCELLED, true);
+  sendSpan(endSpan(span, undefined, undefined));
+}
+
+export function determinePropagatorTypes(url: string): PropagatorType[] {
+  const matchingTypes: PropagatorType[] = [];
+  const isUrlSameOrigin = isSameOrigin(url);
+
+  // For same-origin requests, always include traceparent + all configured propagators
+  if (isUrlSameOrigin) {
+    // Always add traceparent for same-origin requests
+    matchingTypes.push("traceparent");
+
+    // Add all other configured propagator types for same-origin requests
+    if (vars.propagators) {
+      for (const propagator of vars.propagators) {
+        if (propagator.type !== "traceparent" && !matchingTypes.includes(propagator.type)) {
+          matchingTypes.push(propagator.type);
+        }
+      }
+    }
+    return matchingTypes;
+  }
+
+  // For cross-origin requests, use new propagators config if available
+  if (vars.propagators) {
+    for (const propagator of vars.propagators) {
+      if (matchesAny(propagator.match, url)) {
+        // Avoid duplicates
+        if (!matchingTypes.includes(propagator.type)) {
+          matchingTypes.push(propagator.type);
+        }
+      }
+    }
+    return matchingTypes;
+  }
+
+  return [];
+}
+
+export function addTraceContextHttpHeaders(
+  fn: (name: string, value: string) => void,
+  ctx: unknown,
+  span: InProgressSpan,
+  types: PropagatorType[]
+) {
+  for (const type of types) {
+    if (type === "xray") {
+      addXRayTraceContextHttpHeaders(fn, ctx, span);
+    } else {
+      addW3CTraceContextHttpHeaders(fn, ctx, span);
+    }
   }
 }

--- a/src/instrumentations/http/xhr.ts
+++ b/src/instrumentations/http/xhr.ts
@@ -21,6 +21,7 @@ import { vars, PropagatorType } from "../../vars";
 import { httpRequestHeaderKey, httpResponseHeaderKey } from "../../utils/otel/http";
 import { sendSpan } from "../../transport";
 import {
+  addInteractionAttributes,
   addResourceNetworkEvents,
   addResourceSize,
   addTraceContextHttpHeaders,
@@ -113,6 +114,7 @@ function wrapSend(original: XMLHttpRequest["send"]): XMLHttpRequest["send"] {
     if (!state.isWellKnownMethod) {
       addAttribute(span.attributes, HTTP_REQUEST_METHOD_ORIGINAL, state.originalMethod);
     }
+    addInteractionAttributes(span);
     state.span = span;
 
     if (state.propagatorTypes.length > 0) {

--- a/src/instrumentations/http/xhr.ts
+++ b/src/instrumentations/http/xhr.ts
@@ -1,9 +1,145 @@
-import { debug, win } from "../../utils";
+import { debug, observeResourcePerformance, parseUrl, win, wrap } from "../../utils";
+import { isUrlIgnored } from "../../utils/ignore-rules";
+import { addAttribute, endSpan, InProgressSpan, startSpan } from "../../utils/otel";
+import { HTTP_REQUEST_METHOD, HTTP_REQUEST_METHOD_ORIGINAL } from "../../semantic-conventions";
+import { vars, PropagatorType } from "../../vars";
+import { httpRequestHeaderKey } from "../../utils/otel/http";
+import { sendSpan } from "../../transport";
+import {
+  addResourceNetworkEvents,
+  addResourceSize,
+  addTraceContextHttpHeaders,
+  determinePropagatorTypes,
+  HTTP_METHOD_OTHER,
+  isWellKnownHttpMethod,
+} from "./utils";
+import { addCommonAttributes, addUrlAttributes } from "../../attributes";
+
+type XhrFailureKind = "error" | "timeout" | "abort";
+
+type XhrState = {
+  method: string;
+  originalMethod: string;
+  isWellKnownMethod: boolean;
+  url: string;
+  ignored: boolean;
+  span?: InProgressSpan;
+  propagatorTypes: PropagatorType[];
+  capturedRequestHeaders?: Record<string, string>;
+  completed: boolean;
+  failureKind?: XhrFailureKind;
+  performanceObserver?: ReturnType<typeof observeResourcePerformance>;
+};
+
+const XHR_STATE = Symbol("dash0XhrState");
+
+type InstrumentedXhr = XMLHttpRequest & { [XHR_STATE]?: XhrState };
 
 export function instrumentXhr() {
   if (!win || !win.XMLHttpRequest) {
     debug("Browser does not support XMLHttpRequest, skipping instrumentation");
     return;
   }
-  // Implementation added in Task 3.
+
+  const proto = win.XMLHttpRequest.prototype;
+  wrap(proto, "open", wrapOpen);
+  wrap(proto, "setRequestHeader", wrapSetRequestHeader);
+  wrap(proto, "send", wrapSend);
+}
+
+function wrapOpen(original: XMLHttpRequest["open"]): XMLHttpRequest["open"] {
+  return function (this: InstrumentedXhr, method: string, url: string | URL, ...rest: unknown[]) {
+    const stringUrl = String(url);
+    const originalMethod = method ?? "GET";
+    const isWellKnownMethodMatchingLeniently = isWellKnownHttpMethod(originalMethod.toUpperCase());
+    const normalizedMethod = isWellKnownMethodMatchingLeniently ? originalMethod.toUpperCase() : HTTP_METHOD_OTHER;
+
+    // A new open() call on a reused XHR instance resets state -- any prior span for this instance
+    // has already been sent (or will never be, if the previous request never completed) and this
+    // open() is treated as the start of a brand-new request with its own span.
+    this[XHR_STATE] = {
+      method: normalizedMethod,
+      originalMethod,
+      isWellKnownMethod: isWellKnownHttpMethod(originalMethod),
+      url: stringUrl,
+      ignored: isUrlIgnored(stringUrl),
+      propagatorTypes: determinePropagatorTypes(stringUrl),
+      completed: false,
+    };
+
+    return original.apply(this, [method, url, ...rest] as Parameters<XMLHttpRequest["open"]>);
+  };
+}
+
+function wrapSetRequestHeader(original: XMLHttpRequest["setRequestHeader"]): XMLHttpRequest["setRequestHeader"] {
+  return function (this: InstrumentedXhr, name: string, value: string) {
+    original.call(this, name, value);
+
+    const state = this[XHR_STATE];
+    if (!state || state.ignored) return;
+
+    (state.capturedRequestHeaders ??= {})[name] = value;
+  };
+}
+
+function wrapSend(original: XMLHttpRequest["send"]): XMLHttpRequest["send"] {
+  return function (this: InstrumentedXhr, body?: Document | XMLHttpRequestBodyInit | null) {
+    const state = this[XHR_STATE];
+    if (!state || state.ignored) {
+      return original.call(this, body as any);
+    }
+
+    const span = startSpan(`HTTP ${state.method}`);
+    addCommonAttributes(span.attributes);
+    addUrlAttributes(span.attributes, state.url);
+    addAttribute(span.attributes, HTTP_REQUEST_METHOD, state.method);
+    if (!state.isWellKnownMethod) {
+      addAttribute(span.attributes, HTTP_REQUEST_METHOD_ORIGINAL, state.originalMethod);
+    }
+    state.span = span;
+
+    if (state.propagatorTypes.length > 0) {
+      try {
+        addTraceContextHttpHeaders(
+          (name, value) => this.setRequestHeader(name, value),
+          this,
+          span,
+          state.propagatorTypes
+        );
+      } catch (e) {
+        // setRequestHeader throws InvalidStateError if called before open() succeeded, or after
+        // send(). This should not normally happen since we only reach here from within send()
+        // itself with state populated by a prior open(), but guard defensively.
+        debug("failed to inject trace context headers on XMLHttpRequest", e);
+      }
+    }
+
+    if (vars.headersToCapture.length > 0 && state.capturedRequestHeaders) {
+      for (const [name, value] of Object.entries(state.capturedRequestHeaders)) {
+        if (vars.headersToCapture.some((rxp) => rxp.test(name))) {
+          addAttribute(span.attributes, httpRequestHeaderKey(name), value);
+        }
+      }
+    }
+
+    const performanceObserver = observeResourcePerformance({
+      resourceMatcher: ({ initiatorType, name }) =>
+        initiatorType === "xmlhttprequest" && name === parseUrl(state.url).href,
+      maxWaitForResourceMillis: vars.maxWaitForResourceTimingsMillis,
+      maxToleranceForResourceTimingsMillis: vars.maxToleranceForResourceTimingsMillis,
+      onEnd: ({ duration, resource }) => {
+        if (resource) {
+          addResourceNetworkEvents(span, resource);
+          addResourceSize(span, resource);
+        }
+        sendSpan(endSpan(span, undefined, duration * 1000000));
+      },
+    });
+    state.performanceObserver = performanceObserver;
+    performanceObserver.start();
+
+    // Completion handling is added in Task 4.
+
+    return original.call(this, body as any);
+  };
 }

--- a/src/instrumentations/http/xhr.ts
+++ b/src/instrumentations/http/xhr.ts
@@ -1,4 +1,12 @@
-import { debug, observeResourcePerformance, parseUrl, win, wrap } from "../../utils";
+import {
+  addEventListener,
+  debug,
+  observeResourcePerformance,
+  parseUrl,
+  removeEventListener,
+  win,
+  wrap,
+} from "../../utils";
 import { isUrlIgnored } from "../../utils/ignore-rules";
 import { addAttribute, endSpan, InProgressSpan, recordException, setSpanStatus, startSpan } from "../../utils/otel";
 import {
@@ -37,6 +45,7 @@ type XhrState = {
   completed: boolean;
   failureKind?: XhrFailureKind;
   performanceObserver?: ReturnType<typeof observeResourcePerformance>;
+  listeners?: Array<[string, () => unknown]>;
 };
 
 const XHR_STATE = Symbol("dash0XhrState");
@@ -94,7 +103,7 @@ function wrapSend(original: XMLHttpRequest["send"]): XMLHttpRequest["send"] {
   return function (this: InstrumentedXhr, body?: Document | XMLHttpRequestBodyInit | null) {
     const state = this[XHR_STATE];
     if (!state || state.ignored) {
-      return original.call(this, body as any);
+      return original.call(this, body);
     }
 
     const span = startSpan(`HTTP ${state.method}`);
@@ -146,24 +155,47 @@ function wrapSend(original: XMLHttpRequest["send"]): XMLHttpRequest["send"] {
     state.performanceObserver = performanceObserver;
     performanceObserver.start();
 
-    this.addEventListener("error", () => {
-      state.failureKind = "error";
-    });
-    this.addEventListener("timeout", () => {
-      state.failureKind = "timeout";
-    });
-    this.addEventListener("abort", () => {
-      state.failureKind = "abort";
-    });
-    this.addEventListener("loadend", () => onLoadEnd(this, state));
+    // Keep references to the per-request listeners so onLoadEnd can remove them again -- loadend
+    // fires for every request outcome, so cleanup there prevents listeners (and their state/span
+    // closures) from accumulating on reused XHR instances.
+    state.listeners = [
+      [
+        "error",
+        () => {
+          state.failureKind = "error";
+        },
+      ],
+      [
+        "timeout",
+        () => {
+          state.failureKind = "timeout";
+        },
+      ],
+      [
+        "abort",
+        () => {
+          state.failureKind = "abort";
+        },
+      ],
+      ["loadend", () => onLoadEnd(this, state)],
+    ];
+    for (const [eventType, listener] of state.listeners) {
+      addEventListener(this, eventType, listener);
+    }
 
-    return original.call(this, body as any);
+    return original.call(this, body);
   };
 }
 
 function onLoadEnd(xhr: InstrumentedXhr, state: XhrState) {
   if (state.completed) return;
   state.completed = true;
+
+  // The request cycle is over -- remove the per-request listeners so they don't pile up on reused
+  // XHR instances.
+  for (const [eventType, listener] of state.listeners ?? []) {
+    removeEventListener(xhr, eventType, listener);
+  }
 
   const span = state.span;
   if (!span) return;
@@ -185,6 +217,7 @@ function onLoadEnd(xhr: InstrumentedXhr, state: XhrState) {
   }
 
   if (state.failureKind === "error" || state.failureKind === "timeout" || status === 0) {
+    // diverges from endSpanOnError because we additionally set ERROR_TYPE
     performanceObserver?.cancel();
     const failureKind = state.failureKind ?? "error";
     recordException(span, { name: failureKind, message: `XMLHttpRequest failed: ${state.url}` });

--- a/src/instrumentations/http/xhr.ts
+++ b/src/instrumentations/http/xhr.ts
@@ -1,0 +1,9 @@
+import { debug, win } from "../../utils";
+
+export function instrumentXhr() {
+  if (!win || !win.XMLHttpRequest) {
+    debug("Browser does not support XMLHttpRequest, skipping instrumentation");
+    return;
+  }
+  // Implementation added in Task 3.
+}

--- a/src/instrumentations/http/xhr.ts
+++ b/src/instrumentations/http/xhr.ts
@@ -1,15 +1,23 @@
 import { debug, observeResourcePerformance, parseUrl, win, wrap } from "../../utils";
 import { isUrlIgnored } from "../../utils/ignore-rules";
-import { addAttribute, endSpan, InProgressSpan, startSpan } from "../../utils/otel";
-import { HTTP_REQUEST_METHOD, HTTP_REQUEST_METHOD_ORIGINAL } from "../../semantic-conventions";
+import { addAttribute, endSpan, InProgressSpan, recordException, setSpanStatus, startSpan } from "../../utils/otel";
+import {
+  ERROR_TYPE,
+  HTTP_REQUEST_METHOD,
+  HTTP_REQUEST_METHOD_ORIGINAL,
+  HTTP_RESPONSE_STATUS_CODE,
+  SPAN_STATUS_ERROR,
+  SPAN_STATUS_UNSET,
+} from "../../semantic-conventions";
 import { vars, PropagatorType } from "../../vars";
-import { httpRequestHeaderKey } from "../../utils/otel/http";
+import { httpRequestHeaderKey, httpResponseHeaderKey } from "../../utils/otel/http";
 import { sendSpan } from "../../transport";
 import {
   addResourceNetworkEvents,
   addResourceSize,
   addTraceContextHttpHeaders,
   determinePropagatorTypes,
+  endSpanOnAbort,
   HTTP_METHOD_OTHER,
   isWellKnownHttpMethod,
 } from "./utils";
@@ -138,8 +146,86 @@ function wrapSend(original: XMLHttpRequest["send"]): XMLHttpRequest["send"] {
     state.performanceObserver = performanceObserver;
     performanceObserver.start();
 
-    // Completion handling is added in Task 4.
+    this.addEventListener("error", () => {
+      state.failureKind = "error";
+    });
+    this.addEventListener("timeout", () => {
+      state.failureKind = "timeout";
+    });
+    this.addEventListener("abort", () => {
+      state.failureKind = "abort";
+    });
+    this.addEventListener("loadend", () => onLoadEnd(this, state));
 
     return original.call(this, body as any);
   };
+}
+
+function onLoadEnd(xhr: InstrumentedXhr, state: XhrState) {
+  if (state.completed) return;
+  state.completed = true;
+
+  const span = state.span;
+  if (!span) return;
+
+  const performanceObserver = state.performanceObserver;
+
+  if (state.failureKind === "abort") {
+    performanceObserver?.cancel();
+    endSpanOnAbort(span);
+    return;
+  }
+
+  let status = 0;
+  try {
+    status = xhr.status;
+  } catch (_e) {
+    // Reading .status can throw in some environments if accessed at the wrong readyState.
+    status = 0;
+  }
+
+  if (state.failureKind === "error" || state.failureKind === "timeout" || status === 0) {
+    performanceObserver?.cancel();
+    const failureKind = state.failureKind ?? "error";
+    recordException(span, { name: failureKind, message: `XMLHttpRequest failed: ${state.url}` });
+    addAttribute(span.attributes, ERROR_TYPE, failureKind);
+    sendSpan(endSpan(span, { code: SPAN_STATUS_ERROR, message: `XMLHttpRequest failed: ${state.url}` }, undefined));
+    return;
+  }
+
+  setSpanStatus(span, status >= 200 && status < 400 ? SPAN_STATUS_UNSET : SPAN_STATUS_ERROR);
+  addAttribute(span.attributes, HTTP_RESPONSE_STATUS_CODE, String(status));
+  tryCaptureResponseHeaders(xhr, span);
+
+  if (!performanceObserver) {
+    sendSpan(endSpan(span, undefined, undefined));
+    return;
+  }
+  performanceObserver.end();
+}
+
+function tryCaptureResponseHeaders(xhr: XMLHttpRequest, span: InProgressSpan) {
+  try {
+    if (!vars.headersToCapture.length) return;
+
+    const raw = xhr.getAllResponseHeaders();
+    if (!raw) return;
+
+    raw
+      .split(/\r?\n/)
+      .filter((line) => line.length > 0)
+      .forEach((line) => {
+        const separatorIndex = line.indexOf(":");
+        if (separatorIndex === -1) return;
+
+        const name = line.substring(0, separatorIndex).trim();
+        const value = line.substring(separatorIndex + 1).trim();
+
+        if (vars.headersToCapture.some((rxp) => rxp.test(name))) {
+          addAttribute(span.attributes, httpResponseHeaderKey(name), value);
+        }
+      });
+  } catch (_e) {
+    debug("unable to capture http response headers due to CORS policy");
+  }
 }

--- a/src/instrumentations/http/xhr_test.ts
+++ b/src/instrumentations/http/xhr_test.ts
@@ -1,0 +1,213 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { vars } from "../../vars";
+import { instrumentXhr } from "./xhr";
+import { sendSpan } from "../../transport";
+import type { Span } from "../../types/otlp";
+
+vi.mock("../../transport", () => ({
+  sendSpan: vi.fn(),
+}));
+
+/**
+ * A controllable stand-in for the browser's XMLHttpRequest. jsdom's own XHR implementation does
+ * not give deterministic control over readyState transitions, response headers, or event timing,
+ * so we install this fake via vi.stubGlobal and drive it explicitly from each test.
+ */
+class FakeXMLHttpRequest extends EventTarget {
+  static readonly UNSENT = 0;
+  static readonly OPENED = 1;
+  static readonly HEADERS_RECEIVED = 2;
+  static readonly LOADING = 3;
+  static readonly DONE = 4;
+
+  readyState = FakeXMLHttpRequest.UNSENT;
+  status = 0;
+  statusText = "";
+  responseHeaders: Record<string, string> = {};
+  requestHeaders: Record<string, string> = {};
+  method?: string;
+  url?: string;
+  async?: boolean;
+  sentBody?: unknown;
+  onreadystatechange: (() => void) | null = null;
+
+  open(method: string, url: string, async?: boolean) {
+    this.method = method;
+    this.url = url;
+    this.async = async ?? true;
+    this.readyState = FakeXMLHttpRequest.OPENED;
+    this.requestHeaders = {};
+    this.status = 0;
+  }
+
+  setRequestHeader(name: string, value: string) {
+    this.requestHeaders[name] = value;
+  }
+
+  send(body?: unknown) {
+    this.sentBody = body;
+  }
+
+  getAllResponseHeaders(): string {
+    return Object.entries(this.responseHeaders)
+      .map(([k, v]) => `${k}: ${v}\r\n`)
+      .join("");
+  }
+
+  // --- Test-only helpers to drive the fake through a request lifecycle ---
+
+  respond(status: number, headers: Record<string, string> = {}) {
+    this.status = status;
+    this.statusText = String(status);
+    this.responseHeaders = headers;
+    this.readyState = FakeXMLHttpRequest.DONE;
+    this.dispatchEvent(new Event("loadend"));
+  }
+
+  triggerError() {
+    this.status = 0;
+    this.readyState = FakeXMLHttpRequest.DONE;
+    this.dispatchEvent(new Event("error"));
+    this.dispatchEvent(new Event("loadend"));
+  }
+
+  triggerTimeout() {
+    this.status = 0;
+    this.readyState = FakeXMLHttpRequest.DONE;
+    this.dispatchEvent(new Event("timeout"));
+    this.dispatchEvent(new Event("loadend"));
+  }
+
+  triggerAbort() {
+    this.status = 0;
+    this.readyState = FakeXMLHttpRequest.DONE;
+    this.dispatchEvent(new Event("abort"));
+    this.dispatchEvent(new Event("loadend"));
+  }
+}
+
+describe("xhr test", () => {
+  let NativeXHR: typeof XMLHttpRequest;
+
+  beforeEach(() => {
+    NativeXHR = globalThis.XMLHttpRequest;
+    vi.stubGlobal("XMLHttpRequest", FakeXMLHttpRequest);
+    vi.stubGlobal("location", { origin: "http://localhost:3000", href: "http://localhost:3000/" });
+  });
+
+  afterEach(() => {
+    vi.stubGlobal("XMLHttpRequest", NativeXHR);
+    vi.resetAllMocks();
+    vars.propagators = undefined;
+    vars.headersToCapture = [];
+    vars.ignoreUrls = [];
+  });
+
+  it("should inject traceparent header for same-origin requests", () => {
+    vars.propagators = [{ type: "traceparent", match: [] }];
+    instrumentXhr();
+
+    const xhr = new XMLHttpRequest() as unknown as FakeXMLHttpRequest;
+    xhr.open("GET", "/api/test");
+    xhr.send();
+
+    expect(xhr.requestHeaders["traceparent"]).toBeDefined();
+  });
+
+  it("should inject traceparent header for matching cross-origin requests", () => {
+    vars.propagators = [{ type: "traceparent", match: [new RegExp("http://foo.bar/")] }];
+    instrumentXhr();
+
+    const xhr = new XMLHttpRequest() as unknown as FakeXMLHttpRequest;
+    xhr.open("GET", "http://foo.bar/foo");
+    xhr.send();
+
+    expect(xhr.requestHeaders["traceparent"]).toBeDefined();
+  });
+
+  it("should inject xray header in X-Ray format for matching cross-origin requests", () => {
+    vars.propagators = [{ type: "xray", match: [new RegExp("http://foo.bar/")] }];
+    instrumentXhr();
+
+    const xhr = new XMLHttpRequest() as unknown as FakeXMLHttpRequest;
+    xhr.open("GET", "http://foo.bar/foo");
+    xhr.send();
+
+    expect(xhr.requestHeaders["X-Amzn-Trace-Id"]).toMatch(
+      /^Root=1-[0-9a-f]{8}-[0-9a-f]{24};Parent=[0-9a-f]{16};Sampled=1$/
+    );
+  });
+
+  it("should inject no headers for non-matching cross-origin requests", () => {
+    vars.propagators = [];
+    instrumentXhr();
+
+    const xhr = new XMLHttpRequest() as unknown as FakeXMLHttpRequest;
+    xhr.open("GET", "http://foo.bar/foo");
+    xhr.send();
+
+    expect(xhr.requestHeaders["traceparent"]).toBeUndefined();
+    expect(xhr.requestHeaders["X-Amzn-Trace-Id"]).toBeUndefined();
+  });
+
+  it("should not create a span or inject headers for ignored URLs", () => {
+    vars.ignoreUrls = [/you-cant-see-this/];
+    vars.propagators = [{ type: "traceparent", match: [] }];
+    instrumentXhr();
+
+    const xhr = new XMLHttpRequest() as unknown as FakeXMLHttpRequest;
+    xhr.open("GET", "/you-cant-see-this");
+    xhr.send();
+
+    expect(xhr.requestHeaders["traceparent"]).toBeUndefined();
+    expect(sendSpan).not.toHaveBeenCalled();
+  });
+
+  // unskipped in the completion commit (Task 4)
+  it.skip("should capture matching request headers as span attributes", () => {
+    vars.headersToCapture = [/x-test-header/];
+    instrumentXhr();
+
+    const xhr = new XMLHttpRequest() as unknown as FakeXMLHttpRequest;
+    xhr.open("GET", "/api/test");
+    xhr.setRequestHeader("x-test-header", "hello");
+    xhr.send();
+    xhr.respond(200);
+
+    const sendSpanMock = sendSpan as unknown as ReturnType<typeof vi.fn>;
+    const span = sendSpanMock.mock.calls[0]![0] as Span;
+    expect(span.attributes).toContainEqual({
+      key: "http.request.header.x-test-header",
+      value: { stringValue: "hello" },
+    });
+  });
+
+  // unskipped in the completion commit (Task 4)
+  it.skip("normalizes well-known methods to uppercase and records HTTP_METHOD_OTHER for unknown methods", () => {
+    instrumentXhr();
+
+    const xhr = new XMLHttpRequest() as unknown as FakeXMLHttpRequest;
+    xhr.open("get", "/api/test");
+    xhr.send();
+    xhr.respond(200);
+
+    const sendSpanMock = sendSpan as unknown as ReturnType<typeof vi.fn>;
+    const span = sendSpanMock.mock.calls[0]![0] as Span;
+    expect(span.name).toBe("HTTP GET");
+    expect(span.attributes).toContainEqual({ key: "http.request.method", value: { stringValue: "GET" } });
+  });
+
+  // unskipped in the completion commit (Task 4)
+  it.skip("is safe to call instrumentXhr() twice (double-instrumentation guard)", () => {
+    instrumentXhr();
+    instrumentXhr();
+
+    const xhr = new XMLHttpRequest() as unknown as FakeXMLHttpRequest;
+    xhr.open("GET", "/api/test");
+    xhr.send();
+    xhr.respond(200);
+
+    const sendSpanMock = sendSpan as unknown as ReturnType<typeof vi.fn>;
+    expect(sendSpanMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/instrumentations/http/xhr_test.ts
+++ b/src/instrumentations/http/xhr_test.ts
@@ -93,6 +93,9 @@ describe("xhr test", () => {
     NativeXHR = globalThis.XMLHttpRequest;
     vi.stubGlobal("XMLHttpRequest", FakeXMLHttpRequest);
     vi.stubGlobal("location", { origin: "http://localhost:3000", href: "http://localhost:3000/" });
+    // Let the async resource-timing wait resolve on the next tick. See the comment on the first
+    // success-path test below for why the success path is asynchronous.
+    vars.maxWaitForResourceTimingsMillis = 0;
   });
 
   afterEach(() => {
@@ -101,6 +104,7 @@ describe("xhr test", () => {
     vars.propagators = undefined;
     vars.headersToCapture = [];
     vars.ignoreUrls = [];
+    vars.maxWaitForResourceTimingsMillis = 10000;
   });
 
   it("should inject traceparent header for same-origin requests", () => {
@@ -163,8 +167,13 @@ describe("xhr test", () => {
     expect(sendSpan).not.toHaveBeenCalled();
   });
 
-  // unskipped in the completion commit (Task 4)
-  it.skip("should capture matching request headers as span attributes", () => {
+  // The tests below that drive a request to *successful* completion must await sendSpan
+  // asynchronously: the success path routes span completion through observeResourcePerformance,
+  // which resolves asynchronously. jsdom's PerformanceObserver never emits resource entries, so
+  // onEnd only fires after the maxWaitForResourceTimingsMillis timeout -- held at 0 in these tests
+  // (see beforeEach) to keep them fast. The error/timeout/abort paths bypass the observer and
+  // remain synchronous.
+  it("should capture matching request headers as span attributes", async () => {
     vars.headersToCapture = [/x-test-header/];
     instrumentXhr();
 
@@ -175,6 +184,7 @@ describe("xhr test", () => {
     xhr.respond(200);
 
     const sendSpanMock = sendSpan as unknown as ReturnType<typeof vi.fn>;
+    await vi.waitFor(() => expect(sendSpanMock).toHaveBeenCalledTimes(1));
     const span = sendSpanMock.mock.calls[0]![0] as Span;
     expect(span.attributes).toContainEqual({
       key: "http.request.header.x-test-header",
@@ -182,8 +192,7 @@ describe("xhr test", () => {
     });
   });
 
-  // unskipped in the completion commit (Task 4)
-  it.skip("normalizes well-known methods to uppercase and records HTTP_METHOD_OTHER for unknown methods", () => {
+  it("normalizes well-known methods to uppercase and records HTTP_METHOD_OTHER for unknown methods", async () => {
     instrumentXhr();
 
     const xhr = new XMLHttpRequest() as unknown as FakeXMLHttpRequest;
@@ -192,13 +201,13 @@ describe("xhr test", () => {
     xhr.respond(200);
 
     const sendSpanMock = sendSpan as unknown as ReturnType<typeof vi.fn>;
+    await vi.waitFor(() => expect(sendSpanMock).toHaveBeenCalledTimes(1));
     const span = sendSpanMock.mock.calls[0]![0] as Span;
     expect(span.name).toBe("HTTP GET");
     expect(span.attributes).toContainEqual({ key: "http.request.method", value: { stringValue: "GET" } });
   });
 
-  // unskipped in the completion commit (Task 4)
-  it.skip("is safe to call instrumentXhr() twice (double-instrumentation guard)", () => {
+  it("is safe to call instrumentXhr() twice (double-instrumentation guard)", async () => {
     instrumentXhr();
     instrumentXhr();
 
@@ -208,6 +217,139 @@ describe("xhr test", () => {
     xhr.respond(200);
 
     const sendSpanMock = sendSpan as unknown as ReturnType<typeof vi.fn>;
+    await vi.waitFor(() => expect(sendSpanMock).toHaveBeenCalledTimes(1));
     expect(sendSpanMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("ends the span with status UNSET and captures response headers on a successful response", async () => {
+    vars.headersToCapture = [/x-response-header/];
+    instrumentXhr();
+
+    const xhr = new XMLHttpRequest() as unknown as FakeXMLHttpRequest;
+    xhr.open("GET", "/api/test");
+    xhr.send();
+    xhr.respond(200, { "x-response-header": "yes", "content-type": "text/plain" });
+
+    const sendSpanMock = sendSpan as unknown as ReturnType<typeof vi.fn>;
+    await vi.waitFor(() => expect(sendSpanMock).toHaveBeenCalledTimes(1));
+    expect(sendSpanMock).toHaveBeenCalledTimes(1);
+    const span = sendSpanMock.mock.calls[0]![0] as Span;
+    expect(span.status?.code).toBe(0);
+    expect(span.attributes).toContainEqual({
+      key: "http.response.status_code",
+      value: { stringValue: "200" },
+    });
+    expect(span.attributes).toContainEqual({
+      key: "http.response.header.x-response-header",
+      value: { stringValue: "yes" },
+    });
+    expect(span.attributes).not.toContainEqual(expect.objectContaining({ key: "http.response.header.content-type" }));
+  });
+
+  it("marks the span as errored (status code ERROR) for a 4xx/5xx response", async () => {
+    instrumentXhr();
+
+    const xhr = new XMLHttpRequest() as unknown as FakeXMLHttpRequest;
+    xhr.open("GET", "/api/test");
+    xhr.send();
+    xhr.respond(500);
+
+    const sendSpanMock = sendSpan as unknown as ReturnType<typeof vi.fn>;
+    await vi.waitFor(() => expect(sendSpanMock).toHaveBeenCalledTimes(1));
+    const span = sendSpanMock.mock.calls[0]![0] as Span;
+    expect(span.status?.code).toBe(2);
+    expect(span.attributes).toContainEqual({
+      key: "http.response.status_code",
+      value: { stringValue: "500" },
+    });
+  });
+
+  it("records an exception and marks the span as errored on a network error", () => {
+    instrumentXhr();
+
+    const xhr = new XMLHttpRequest() as unknown as FakeXMLHttpRequest;
+    xhr.open("GET", "/api/test");
+    xhr.send();
+    xhr.triggerError();
+
+    const sendSpanMock = sendSpan as unknown as ReturnType<typeof vi.fn>;
+    expect(sendSpanMock).toHaveBeenCalledTimes(1);
+    const span = sendSpanMock.mock.calls[0]![0] as Span;
+    expect(span.status?.code).toBe(2);
+    expect(span.events.some((e) => e.name === "exception")).toBe(true);
+    expect(span.attributes).toContainEqual({ key: "error.type", value: { stringValue: "error" } });
+  });
+
+  it("records an exception and marks the span as errored on a timeout", () => {
+    instrumentXhr();
+
+    const xhr = new XMLHttpRequest() as unknown as FakeXMLHttpRequest;
+    xhr.open("GET", "/api/test");
+    xhr.send();
+    xhr.triggerTimeout();
+
+    const sendSpanMock = sendSpan as unknown as ReturnType<typeof vi.fn>;
+    const span = sendSpanMock.mock.calls[0]![0] as Span;
+    expect(span.status?.code).toBe(2);
+    expect(span.events.some((e) => e.name === "exception")).toBe(true);
+    expect(span.attributes).toContainEqual({ key: "error.type", value: { stringValue: "timeout" } });
+  });
+
+  it("marks the span as cancelled (not failed) on abort", () => {
+    instrumentXhr();
+
+    const xhr = new XMLHttpRequest() as unknown as FakeXMLHttpRequest;
+    xhr.open("GET", "/api/test");
+    xhr.send();
+    xhr.triggerAbort();
+
+    const sendSpanMock = sendSpan as unknown as ReturnType<typeof vi.fn>;
+    expect(sendSpanMock).toHaveBeenCalledTimes(1);
+    const span = sendSpanMock.mock.calls[0]![0] as Span;
+    expect(span.status?.code).toBe(0);
+    expect(span.attributes).toContainEqual({
+      key: "dash0.web.request.cancelled",
+      value: { boolValue: true },
+    });
+    expect(span.events.find((e) => e.name === "exception")).toBeUndefined();
+  });
+
+  it("only completes a span once even if multiple terminal events fire", async () => {
+    instrumentXhr();
+
+    const xhr = new XMLHttpRequest() as unknown as FakeXMLHttpRequest;
+    xhr.open("GET", "/api/test");
+    xhr.send();
+    xhr.respond(200);
+    // Simulate a spurious extra loadend (some browsers/polyfills have done this historically)
+    xhr.dispatchEvent(new Event("loadend"));
+
+    const sendSpanMock = sendSpan as unknown as ReturnType<typeof vi.fn>;
+    await vi.waitFor(() => expect(sendSpanMock).toHaveBeenCalledTimes(1));
+    expect(sendSpanMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("treats a reused XHR instance's second open() as a fresh request with its own span", async () => {
+    instrumentXhr();
+
+    const xhr = new XMLHttpRequest() as unknown as FakeXMLHttpRequest;
+    xhr.open("GET", "/api/first");
+    xhr.send();
+    xhr.respond(200);
+
+    xhr.open("GET", "/api/second");
+    xhr.send();
+    xhr.respond(201);
+
+    const sendSpanMock = sendSpan as unknown as ReturnType<typeof vi.fn>;
+    await vi.waitFor(() => expect(sendSpanMock).toHaveBeenCalledTimes(2));
+    expect(sendSpanMock).toHaveBeenCalledTimes(2);
+    const firstSpan = sendSpanMock.mock.calls[0]![0] as Span;
+    const secondSpan = sendSpanMock.mock.calls[1]![0] as Span;
+    expect(firstSpan.spanId).not.toBe(secondSpan.spanId);
+    expect(secondSpan.attributes).toContainEqual({
+      key: "http.response.status_code",
+      value: { stringValue: "201" },
+    });
   });
 });

--- a/src/instrumentations/http/xhr_test.ts
+++ b/src/instrumentations/http/xhr_test.ts
@@ -352,4 +352,31 @@ describe("xhr test", () => {
       value: { stringValue: "201" },
     });
   });
+
+  it("removes the per-request listeners once the request completes", async () => {
+    instrumentXhr();
+
+    const xhr = new XMLHttpRequest() as unknown as FakeXMLHttpRequest;
+    const removeListenerSpy = vi.spyOn(xhr, "removeEventListener");
+    xhr.open("GET", "/api/test");
+    xhr.send();
+    xhr.respond(200);
+
+    const sendSpanMock = sendSpan as unknown as ReturnType<typeof vi.fn>;
+    await vi.waitFor(() => expect(sendSpanMock).toHaveBeenCalledTimes(1));
+
+    expect(removeListenerSpy).toHaveBeenCalledTimes(4);
+    expect(removeListenerSpy.mock.calls.map((c) => c[0]).sort()).toEqual(["abort", "error", "loadend", "timeout"]);
+
+    // Spurious late events after completion must not affect the already-sent span...
+    xhr.dispatchEvent(new Event("error"));
+    xhr.dispatchEvent(new Event("loadend"));
+    expect(sendSpanMock).toHaveBeenCalledTimes(1);
+
+    // ...and a subsequent request cycle on the same instance still produces exactly one more span.
+    xhr.open("GET", "/api/test");
+    xhr.send();
+    xhr.respond(200);
+    await vi.waitFor(() => expect(sendSpanMock).toHaveBeenCalledTimes(2));
+  });
 });

--- a/src/instrumentations/interactions/action-name.ts
+++ b/src/instrumentations/interactions/action-name.ts
@@ -1,0 +1,181 @@
+export type ActionNameSource = "custom_attribute" | "standard_attribute" | "text_content" | "blank";
+
+export type ActionNameResult = {
+  name: string;
+  nameSource: ActionNameSource;
+};
+
+const MAX_ANCESTOR_WALK = 10;
+const MAX_NAME_LENGTH = 100;
+const TRUNCATION_MARKER = " [...]";
+const BOUNDARY_TAGS = new Set(["FORM", "BODY", "HTML", "HEAD"]);
+const VALUE_READABLE_INPUT_TYPES = new Set(["button", "submit", "reset"]);
+// Elements whose visible text is read during the text-content phase because their
+// text is an action label rather than page content.
+const CLICKABLE_TEXT_TAGS = new Set(["BUTTON", "LABEL", "A"]);
+// Never derive a name from the text content of these click targets: an OPTION's /
+// SELECT's visible text is the user's chosen value and a TEXTAREA's text IS its
+// value — all user data, not an action label. (They may still be named via
+// attribute sources such as aria-label or placeholder.)
+const TEXT_FALLBACK_EXCLUDED_TAGS = new Set(["INPUT", "TEXTAREA", "SELECT", "OPTION"]);
+
+function normalizeWhitespace(value: string): string {
+  return value.replace(/\s+/g, " ").trim();
+}
+
+function truncate(name: string): string {
+  if (name.length <= MAX_NAME_LENGTH) {
+    return name;
+  }
+  return name.substring(0, MAX_NAME_LENGTH) + TRUNCATION_MARKER;
+}
+
+function finalize(name: string, nameSource: ActionNameSource): ActionNameResult {
+  const normalized = normalizeWhitespace(name);
+  if (!normalized) {
+    return { name: "", nameSource: "blank" };
+  }
+  return { name: truncate(normalized), nameSource };
+}
+
+/**
+ * Collects the click target plus up to MAX_ANCESTOR_WALK ancestor elements,
+ * stopping (inclusively) at the first FORM/BODY/HTML/HEAD boundary.
+ */
+function collectWalkPath(target: Element): Element[] {
+  const path: Element[] = [target];
+  let current: Element | null = target;
+
+  if (BOUNDARY_TAGS.has(target.tagName)) {
+    return path;
+  }
+
+  for (let i = 0; i < MAX_ANCESTOR_WALK; i++) {
+    current = current.parentElement;
+    if (!current) break;
+    path.push(current);
+    if (BOUNDARY_TAGS.has(current.tagName)) break;
+  }
+
+  return path;
+}
+
+function findCustomAttributeName(path: Element[], actionNameAttribute: string): string | undefined {
+  for (const el of path) {
+    const value = el.getAttribute(actionNameAttribute);
+    if (value != null && normalizeWhitespace(value)) {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+function resolveAriaLabelledBy(el: Element): string | undefined {
+  const labelledBy = el.getAttribute("aria-labelledby");
+  if (!labelledBy) return undefined;
+
+  const doc = el.ownerDocument;
+  const parts = labelledBy
+    .split(/\s+/)
+    .map((id) => doc.getElementById(id)?.textContent ?? "")
+    .map((text) => normalizeWhitespace(text))
+    .filter((text) => text.length > 0);
+
+  return parts.length > 0 ? parts.join(" ") : undefined;
+}
+
+function readInputValueIfSafe(el: Element): string | undefined {
+  if (el.tagName !== "INPUT") return undefined;
+  const type = (el.getAttribute("type") || "text").toLowerCase();
+  if (!VALUE_READABLE_INPUT_TYPES.has(type)) return undefined;
+  const value = (el as HTMLInputElement).value;
+  return value ? value : undefined;
+}
+
+/**
+ * Attribute-only sources: the value of button/submit/reset inputs, aria-label,
+ * aria-labelledby resolution, alt, title, and placeholder. Visible text is
+ * deliberately NOT read here — it belongs to the text-content phase.
+ */
+function findStandardAttributeName(path: Element[]): string | undefined {
+  for (const el of path) {
+    const inputValue = readInputValueIfSafe(el);
+    if (inputValue) return inputValue;
+
+    const ariaLabel = el.getAttribute("aria-label");
+    if (ariaLabel && normalizeWhitespace(ariaLabel)) return ariaLabel;
+
+    const labelledByText = resolveAriaLabelledBy(el);
+    if (labelledByText) return labelledByText;
+
+    const alt = el.getAttribute("alt");
+    if (alt && normalizeWhitespace(alt)) return alt;
+
+    const title = el.getAttribute("title");
+    if (title && normalizeWhitespace(title)) return title;
+
+    const placeholder = el.getAttribute("placeholder");
+    if (placeholder && normalizeWhitespace(placeholder)) return placeholder;
+  }
+  return undefined;
+}
+
+/**
+ * Text-content sources: first the visible text of clickable-tag elements
+ * (BUTTON/[role=button]/LABEL/A) along the walk path, then the target's own
+ * textContent. Skipped entirely for INPUT/TEXTAREA/SELECT/OPTION targets —
+ * their text content is user data (see TEXT_FALLBACK_EXCLUDED_TAGS).
+ */
+function findTextContentName(target: Element, path: Element[]): string | undefined {
+  if (TEXT_FALLBACK_EXCLUDED_TAGS.has(target.tagName)) return undefined;
+
+  for (const el of path) {
+    if (CLICKABLE_TEXT_TAGS.has(el.tagName) || el.getAttribute("role") === "button") {
+      const text = el.textContent;
+      if (text && normalizeWhitespace(text)) return text;
+    }
+  }
+
+  const targetText = target.textContent;
+  if (targetText && normalizeWhitespace(targetText)) return targetText;
+
+  return undefined;
+}
+
+/**
+ * Derives a human-readable interaction name for a clicked element, following
+ * Datadog RUM's action-name priority order:
+ *   1. configured custom attribute (target or ancestor)
+ *   2. standard attribute-based sources (target or ancestor)
+ *   3. visible text (clickable-tag elements along the walk first, then the
+ *      target's own text content)
+ *   4. blank
+ *
+ * The ancestor walk is capped at 10 levels and stops (inclusively) at the
+ * first FORM/BODY/HTML/HEAD boundary.
+ *
+ * Privacy: never reads the value of password/text/textarea/select elements --
+ * only button/submit/reset inputs expose `.value` -- and never derives a name
+ * from the text content of INPUT/TEXTAREA/SELECT/OPTION targets. Whitespace is
+ * always normalized and the result is truncated to 100 characters.
+ */
+export function deriveActionName(target: Element, actionNameAttribute: string): ActionNameResult {
+  const path = collectWalkPath(target);
+
+  const customName = findCustomAttributeName(path, actionNameAttribute);
+  if (customName) {
+    return finalize(customName, "custom_attribute");
+  }
+
+  const standardName = findStandardAttributeName(path);
+  if (standardName) {
+    return finalize(standardName, "standard_attribute");
+  }
+
+  const textName = findTextContentName(target, path);
+  if (textName) {
+    return finalize(textName, "text_content");
+  }
+
+  return { name: "", nameSource: "blank" };
+}

--- a/src/instrumentations/interactions/action-name.ts
+++ b/src/instrumentations/interactions/action-name.ts
@@ -121,10 +121,14 @@ function findStandardAttributeName(path: Element[]): string | undefined {
 }
 
 /**
- * Text-content sources: first the visible text of clickable-tag elements
- * (BUTTON/[role=button]/LABEL/A) along the walk path, then the target's own
- * textContent. Skipped entirely for INPUT/TEXTAREA/SELECT/OPTION targets —
- * their text content is user data (see TEXT_FALLBACK_EXCLUDED_TAGS).
+ * Text-content source: the visible text of clickable-tag elements
+ * (BUTTON/[role=button]/LABEL/A) found along the walk path. A click that lands
+ * on a non-interactive container (e.g. a layout <div>/<footer>) with no such
+ * element in its path — and no naming attribute — deliberately yields no name,
+ * so deriveActionName falls through to "blank" + target metadata rather than
+ * dumping the container's entire textContent. Skipped entirely for
+ * INPUT/TEXTAREA/SELECT/OPTION targets — their text content is user data
+ * (see TEXT_FALLBACK_EXCLUDED_TAGS).
  */
 function findTextContentName(target: Element, path: Element[]): string | undefined {
   if (TEXT_FALLBACK_EXCLUDED_TAGS.has(target.tagName)) return undefined;
@@ -136,9 +140,6 @@ function findTextContentName(target: Element, path: Element[]): string | undefin
     }
   }
 
-  const targetText = target.textContent;
-  if (targetText && normalizeWhitespace(targetText)) return targetText;
-
   return undefined;
 }
 
@@ -147,8 +148,8 @@ function findTextContentName(target: Element, path: Element[]): string | undefin
  * Datadog RUM's action-name priority order:
  *   1. configured custom attribute (target or ancestor)
  *   2. standard attribute-based sources (target or ancestor)
- *   3. visible text (clickable-tag elements along the walk first, then the
- *      target's own text content)
+ *   3. visible text of clickable-tag elements (button/link/label/[role=button])
+ *      found along the walk path
  *   4. blank
  *
  * The ancestor walk is capped at 10 levels and stops (inclusively) at the

--- a/src/instrumentations/interactions/action-name_test.ts
+++ b/src/instrumentations/interactions/action-name_test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import {
   EVENT_NAMES,
   INTERACTION_TYPE,
@@ -8,6 +8,11 @@ import {
   INTERACTION_TARGET_TAG,
   INTERACTION_TARGET_ID,
 } from "../../semantic-conventions";
+import { doc } from "../../utils/globals";
+import { deriveActionName } from "./action-name";
+
+// Vitest runs these tests in jsdom, so the SSR-safe doc is always defined.
+const dom = doc!;
 
 describe("interaction semantic conventions", () => {
   it("defines the browser.interaction event name", () => {
@@ -21,5 +26,346 @@ describe("interaction semantic conventions", () => {
     expect(INTERACTION_TARGET_SELECTOR).toBe("target.selector");
     expect(INTERACTION_TARGET_TAG).toBe("target.tag");
     expect(INTERACTION_TARGET_ID).toBe("target.id");
+  });
+});
+
+describe("deriveActionName", () => {
+  const attributeName = "data-dash0-action-name";
+
+  beforeEach(() => {
+    dom.body.innerHTML = "";
+  });
+
+  describe("priority 1: custom attribute", () => {
+    it("uses the custom attribute on the target itself", () => {
+      dom.body.innerHTML = `<button id="btn" data-dash0-action-name="Save Settings">Save</button>`;
+      const target = dom.getElementById("btn")!;
+
+      expect(deriveActionName(target, attributeName)).toEqual({
+        name: "Save Settings",
+        nameSource: "custom_attribute",
+      });
+    });
+
+    it("uses the custom attribute on an ancestor", () => {
+      dom.body.innerHTML = `
+        <div data-dash0-action-name="Card Action">
+          <span id="inner">Click me</span>
+        </div>`;
+      const target = dom.getElementById("inner")!;
+
+      expect(deriveActionName(target, attributeName)).toEqual({
+        name: "Card Action",
+        nameSource: "custom_attribute",
+      });
+    });
+
+    it("prefers the custom attribute over standard attributes when both are present", () => {
+      dom.body.innerHTML = `<button id="btn" aria-label="Aria Label" data-dash0-action-name="Custom Name">Text</button>`;
+      const target = dom.getElementById("btn")!;
+
+      expect(deriveActionName(target, attributeName)).toEqual({
+        name: "Custom Name",
+        nameSource: "custom_attribute",
+      });
+    });
+
+    it("respects a custom actionNameAttribute name", () => {
+      dom.body.innerHTML = `<button id="btn" data-my-name="Custom">Text</button>`;
+      const target = dom.getElementById("btn")!;
+
+      expect(deriveActionName(target, "data-my-name")).toEqual({
+        name: "Custom",
+        nameSource: "custom_attribute",
+      });
+    });
+  });
+
+  describe("priority 2: standard attributes", () => {
+    it("uses .value for an input[type=button]", () => {
+      dom.body.innerHTML = `<input id="inp" type="button" value="Click Here" />`;
+      const target = dom.getElementById("inp")!;
+
+      expect(deriveActionName(target, attributeName)).toEqual({
+        name: "Click Here",
+        nameSource: "standard_attribute",
+      });
+    });
+
+    it("uses .value for an input[type=submit]", () => {
+      dom.body.innerHTML = `<input id="inp" type="submit" value="Submit Form" />`;
+      const target = dom.getElementById("inp")!;
+
+      expect(deriveActionName(target, attributeName)).toEqual({
+        name: "Submit Form",
+        nameSource: "standard_attribute",
+      });
+    });
+
+    it("uses .value for an input[type=reset]", () => {
+      dom.body.innerHTML = `<input id="inp" type="reset" value="Reset Form" />`;
+      const target = dom.getElementById("inp")!;
+
+      expect(deriveActionName(target, attributeName)).toEqual({
+        name: "Reset Form",
+        nameSource: "standard_attribute",
+      });
+    });
+
+    it("never reads .value for an input[type=text]", () => {
+      dom.body.innerHTML = `<input id="inp" type="text" value="secret-input-value" />`;
+      const target = dom.getElementById("inp")!;
+
+      expect(deriveActionName(target, attributeName)).toEqual({
+        name: "",
+        nameSource: "blank",
+      });
+    });
+
+    it("never reads .value for an input[type=password]", () => {
+      dom.body.innerHTML = `<input id="inp" type="password" value="hunter2" />`;
+      const target = dom.getElementById("inp")!;
+
+      expect(deriveActionName(target, attributeName)).toEqual({
+        name: "",
+        nameSource: "blank",
+      });
+    });
+
+    it("uses aria-label on a button before visible text", () => {
+      dom.body.innerHTML = `<button id="btn" aria-label="Close Dialog">X</button>`;
+      const target = dom.getElementById("btn")!;
+
+      expect(deriveActionName(target, attributeName)).toEqual({
+        name: "Close Dialog",
+        nameSource: "standard_attribute",
+      });
+    });
+
+    it("uses visible text on a button when aria-label is absent", () => {
+      dom.body.innerHTML = `<button id="btn">Save Settings</button>`;
+      const target = dom.getElementById("btn")!;
+
+      expect(deriveActionName(target, attributeName)).toEqual({
+        name: "Save Settings",
+        nameSource: "text_content",
+      });
+    });
+
+    it("uses aria-label on a role=button element", () => {
+      dom.body.innerHTML = `<div id="btn" role="button" aria-label="Icon Button"></div>`;
+      const target = dom.getElementById("btn")!;
+
+      expect(deriveActionName(target, attributeName)).toEqual({
+        name: "Icon Button",
+        nameSource: "standard_attribute",
+      });
+    });
+
+    it("uses aria-label on a label element", () => {
+      dom.body.innerHTML = `<label id="lbl" aria-label="Field Label">Text</label>`;
+      const target = dom.getElementById("lbl")!;
+
+      expect(deriveActionName(target, attributeName)).toEqual({
+        name: "Field Label",
+        nameSource: "standard_attribute",
+      });
+    });
+
+    it("uses aria-label on an anchor element", () => {
+      dom.body.innerHTML = `<a id="lnk" href="#" aria-label="Learn More">Read</a>`;
+      const target = dom.getElementById("lnk")!;
+
+      expect(deriveActionName(target, attributeName)).toEqual({
+        name: "Learn More",
+        nameSource: "standard_attribute",
+      });
+    });
+
+    it("resolves aria-labelledby to referenced element text, joined with a space", () => {
+      dom.body.innerHTML = `
+        <span id="label-a">Confirm</span>
+        <span id="label-b">Purchase</span>
+        <button id="btn" aria-labelledby="label-a label-b">X</button>`;
+      const target = dom.getElementById("btn")!;
+
+      expect(deriveActionName(target, attributeName)).toEqual({
+        name: "Confirm Purchase",
+        nameSource: "standard_attribute",
+      });
+    });
+
+    it("falls back to alt attribute", () => {
+      dom.body.innerHTML = `<img id="img" alt="Company Logo" />`;
+      const target = dom.getElementById("img")!;
+
+      expect(deriveActionName(target, attributeName)).toEqual({
+        name: "Company Logo",
+        nameSource: "standard_attribute",
+      });
+    });
+
+    it("falls back to title attribute", () => {
+      dom.body.innerHTML = `<span id="span" title="Tooltip Text"></span>`;
+      const target = dom.getElementById("span")!;
+
+      expect(deriveActionName(target, attributeName)).toEqual({
+        name: "Tooltip Text",
+        nameSource: "standard_attribute",
+      });
+    });
+
+    it("falls back to placeholder attribute", () => {
+      dom.body.innerHTML = `<input id="inp" type="text" placeholder="Search..." />`;
+      const target = dom.getElementById("inp")!;
+
+      expect(deriveActionName(target, attributeName)).toEqual({
+        name: "Search...",
+        nameSource: "standard_attribute",
+      });
+    });
+
+    it("finds standard attributes on an ancestor when the target has none", () => {
+      dom.body.innerHTML = `
+        <button id="btn" aria-label="Delete Item">
+          <span id="icon">🗑</span>
+        </button>`;
+      const target = dom.getElementById("icon")!;
+
+      expect(deriveActionName(target, attributeName)).toEqual({
+        name: "Delete Item",
+        nameSource: "standard_attribute",
+      });
+    });
+  });
+
+  describe("priority 3: text content fallback", () => {
+    it("uses whitespace-normalized textContent when no attributes match", () => {
+      dom.body.innerHTML = `<div id="div">  Some\n\n  Text   Here  </div>`;
+      const target = dom.getElementById("div")!;
+
+      expect(deriveActionName(target, attributeName)).toEqual({
+        name: "Some Text Here",
+        nameSource: "text_content",
+      });
+    });
+  });
+
+  describe("priority 4: blank fallback", () => {
+    it("returns blank when nothing matches", () => {
+      dom.body.innerHTML = `<div id="div"></div>`;
+      const target = dom.getElementById("div")!;
+
+      expect(deriveActionName(target, attributeName)).toEqual({
+        name: "",
+        nameSource: "blank",
+      });
+    });
+  });
+
+  describe("privacy: select and textarea values are never read", () => {
+    it("never reads a select's value or selected option text via .value", () => {
+      dom.body.innerHTML = `
+        <select id="sel">
+          <option value="secret-option" selected>Secret Option Label</option>
+        </select>`;
+      const target = dom.getElementById("sel")!;
+
+      expect(deriveActionName(target, attributeName)).toEqual({
+        name: "",
+        nameSource: "blank",
+      });
+    });
+
+    it("never reads a textarea's value", () => {
+      dom.body.innerHTML = `<textarea id="ta">secret multiline content</textarea>`;
+      const target = dom.getElementById("ta")!;
+
+      expect(deriveActionName(target, attributeName)).toEqual({
+        name: "",
+        nameSource: "blank",
+      });
+    });
+  });
+
+  describe("ancestor walk boundaries", () => {
+    it("stops walking at a FORM boundary and does not use attributes above it", () => {
+      dom.body.innerHTML = `
+        <form data-dash0-action-name="Form Name">
+          <span id="span">Inner</span>
+        </form>`;
+      const target = dom.getElementById("span")!;
+
+      // FORM itself is a valid boundary to check per Datadog prior art (closest() would match it),
+      // so the custom attribute on the FORM is still found -- the walk stops AT the boundary, not before it.
+      expect(deriveActionName(target, attributeName)).toEqual({
+        name: "Form Name",
+        nameSource: "custom_attribute",
+      });
+    });
+
+    it("does not walk past FORM to reach an ancestor's attribute", () => {
+      // The target is deliberately text-free so the blank assertion isolates
+      // the FORM walk boundary (the target's own text would otherwise
+      // legitimately resolve as text_content).
+      dom.body.innerHTML = `
+        <div data-dash0-action-name="Outer Name">
+          <form>
+            <span id="span"></span>
+          </form>
+        </div>`;
+      const target = dom.getElementById("span")!;
+
+      expect(deriveActionName(target, attributeName)).toEqual({
+        name: "",
+        nameSource: "blank",
+      });
+    });
+
+    it("caps the ancestor walk at 10 levels", () => {
+      // Build 12 nested divs; only the outermost (12 levels up) carries the attribute,
+      // which exceeds the 10-ancestor cap and must not be found.
+      // The target is deliberately text-free so the blank assertion isolates
+      // the 10-level walk cap (the target's own text would otherwise
+      // legitimately resolve as text_content).
+      let html = `<div data-dash0-action-name="Too Far">`;
+      for (let i = 0; i < 12; i++) {
+        html += `<div>`;
+      }
+      html += `<span id="span"></span>`;
+      for (let i = 0; i < 12; i++) {
+        html += `</div>`;
+      }
+      html += `</div>`;
+      dom.body.innerHTML = html;
+      const target = dom.getElementById("span")!;
+
+      expect(deriveActionName(target, attributeName)).toEqual({
+        name: "",
+        nameSource: "blank",
+      });
+    });
+  });
+
+  describe("truncation", () => {
+    it("truncates names longer than 100 characters and appends a marker", () => {
+      const longText = "A".repeat(150);
+      dom.body.innerHTML = `<button id="btn">${longText}</button>`;
+      const target = dom.getElementById("btn")!;
+
+      const result = deriveActionName(target, attributeName);
+      expect(result.nameSource).toBe("text_content");
+      expect(result.name).toBe("A".repeat(100) + " [...]");
+      expect(result.name.length).toBe(106);
+    });
+
+    it("does not truncate names at exactly 100 characters", () => {
+      const exactText = "B".repeat(100);
+      dom.body.innerHTML = `<button id="btn">${exactText}</button>`;
+      const target = dom.getElementById("btn")!;
+
+      const result = deriveActionName(target, attributeName);
+      expect(result.name).toBe(exactText);
+    });
   });
 });

--- a/src/instrumentations/interactions/action-name_test.ts
+++ b/src/instrumentations/interactions/action-name_test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import {
+  EVENT_NAMES,
+  INTERACTION_TYPE,
+  INTERACTION_NAME,
+  INTERACTION_NAME_SOURCE,
+  INTERACTION_TARGET_SELECTOR,
+  INTERACTION_TARGET_TAG,
+  INTERACTION_TARGET_ID,
+} from "../../semantic-conventions";
+
+describe("interaction semantic conventions", () => {
+  it("defines the browser.interaction event name", () => {
+    expect(EVENT_NAMES.INTERACTION).toBe("browser.interaction");
+  });
+
+  it("defines interaction attribute keys", () => {
+    expect(INTERACTION_TYPE).toBe("type");
+    expect(INTERACTION_NAME).toBe("name");
+    expect(INTERACTION_NAME_SOURCE).toBe("name_source");
+    expect(INTERACTION_TARGET_SELECTOR).toBe("target.selector");
+    expect(INTERACTION_TARGET_TAG).toBe("target.tag");
+    expect(INTERACTION_TARGET_ID).toBe("target.id");
+  });
+});

--- a/src/instrumentations/interactions/action-name_test.ts
+++ b/src/instrumentations/interactions/action-name_test.ts
@@ -19,13 +19,13 @@ describe("interaction semantic conventions", () => {
     expect(EVENT_NAMES.INTERACTION).toBe("browser.interaction");
   });
 
-  it("defines interaction attribute keys", () => {
-    expect(INTERACTION_TYPE).toBe("type");
-    expect(INTERACTION_NAME).toBe("name");
-    expect(INTERACTION_NAME_SOURCE).toBe("name_source");
-    expect(INTERACTION_TARGET_SELECTOR).toBe("target.selector");
-    expect(INTERACTION_TARGET_TAG).toBe("target.tag");
-    expect(INTERACTION_TARGET_ID).toBe("target.id");
+  it("defines namespaced interaction attribute keys (log attributes, not body keys)", () => {
+    expect(INTERACTION_TYPE).toBe("interaction.type");
+    expect(INTERACTION_NAME).toBe("interaction.name");
+    expect(INTERACTION_NAME_SOURCE).toBe("interaction.name_source");
+    expect(INTERACTION_TARGET_SELECTOR).toBe("interaction.target.selector");
+    expect(INTERACTION_TARGET_TAG).toBe("interaction.target.tag");
+    expect(INTERACTION_TARGET_ID).toBe("interaction.target.id");
   });
 });
 
@@ -240,13 +240,26 @@ describe("deriveActionName", () => {
   });
 
   describe("priority 3: text content fallback", () => {
-    it("uses whitespace-normalized textContent when no attributes match", () => {
+    it("uses whitespace-normalized textContent of a clickable-tag element", () => {
+      dom.body.innerHTML = `<button id="btn">  Save\n\n  Part   Now  </button>`;
+      const target = dom.getElementById("btn")!;
+
+      expect(deriveActionName(target, attributeName)).toEqual({
+        name: "Save Part Now",
+        nameSource: "text_content",
+      });
+    });
+
+    it("does NOT harvest textContent from a non-interactive container", () => {
+      // Regression guard: a click on a layout <div> with no clickable-tag
+      // ancestor and no naming attribute must fall through to blank, not dump
+      // the container's entire visible text as the action name.
       dom.body.innerHTML = `<div id="div">  Some\n\n  Text   Here  </div>`;
       const target = dom.getElementById("div")!;
 
       expect(deriveActionName(target, attributeName)).toEqual({
-        name: "Some Text Here",
-        nameSource: "text_content",
+        name: "",
+        nameSource: "blank",
       });
     });
   });

--- a/src/instrumentations/interactions/action-name_test.ts
+++ b/src/instrumentations/interactions/action-name_test.ts
@@ -286,6 +286,22 @@ describe("deriveActionName", () => {
         nameSource: "blank",
       });
     });
+
+    it("never derives a name from an OPTION click target's visible text", () => {
+      // Pins the OPTION entry of TEXT_FALLBACK_EXCLUDED_TAGS: an option's
+      // visible text is the user's chosen value, so a direct click on it
+      // (no attribute sources anywhere in the walk) must stay blank.
+      dom.body.innerHTML = `
+        <select id="sel">
+          <option id="opt" value="secret-option" selected>Secret Option Label</option>
+        </select>`;
+      const target = dom.getElementById("opt")!;
+
+      expect(deriveActionName(target, attributeName)).toEqual({
+        name: "",
+        nameSource: "blank",
+      });
+    });
   });
 
   describe("ancestor walk boundaries", () => {
@@ -334,6 +350,49 @@ describe("deriveActionName", () => {
       }
       html += `<span id="span"></span>`;
       for (let i = 0; i < 12; i++) {
+        html += `</div>`;
+      }
+      html += `</div>`;
+      dom.body.innerHTML = html;
+      const target = dom.getElementById("span")!;
+
+      expect(deriveActionName(target, attributeName)).toEqual({
+        name: "",
+        nameSource: "blank",
+      });
+    });
+
+    it("finds a custom attribute on exactly the 10th ancestor", () => {
+      // Pins the exact MAX_ANCESTOR_WALK boundary: the attribute div plus 9
+      // plain divs puts the attribute exactly 10 ancestors above the target.
+      let html = `<div data-dash0-action-name="At The Cap">`;
+      for (let i = 0; i < 9; i++) {
+        html += `<div>`;
+      }
+      html += `<span id="span"></span>`;
+      for (let i = 0; i < 9; i++) {
+        html += `</div>`;
+      }
+      html += `</div>`;
+      dom.body.innerHTML = html;
+      const target = dom.getElementById("span")!;
+
+      expect(deriveActionName(target, attributeName)).toEqual({
+        name: "At The Cap",
+        nameSource: "custom_attribute",
+      });
+    });
+
+    it("does not find a custom attribute on the 11th ancestor", () => {
+      // Pins the exact MAX_ANCESTOR_WALK boundary from the other side: 10
+      // plain divs push the attribute to ancestor 11, one past the cap. The
+      // target is deliberately text-free so blank isolates the cap itself.
+      let html = `<div data-dash0-action-name="One Past The Cap">`;
+      for (let i = 0; i < 10; i++) {
+        html += `<div>`;
+      }
+      html += `<span id="span"></span>`;
+      for (let i = 0; i < 10; i++) {
         html += `</div>`;
       }
       html += `</div>`;

--- a/src/instrumentations/interactions/active-interaction.ts
+++ b/src/instrumentations/interactions/active-interaction.ts
@@ -1,0 +1,53 @@
+import { generateUniqueId, WEB_EVENT_ID_BYTES } from "../../utils";
+
+/**
+ * The most recent user interaction, kept around briefly so that HTTP requests
+ * fired in reaction to it (event handlers, framework change detection,
+ * microtask-deferred XHR/fetch calls) can be attributed back to the click that
+ * caused them — the same causality RUM products expose as "user actions".
+ *
+ * The click instrumentation registers interactions from a window-level
+ * capture-phase listener, which is guaranteed to run before the application's
+ * own handlers. Any span started while the interaction is active gets stamped
+ * with `user_interaction.id` (and `.name` when one was derived), and the
+ * `browser.interaction` event carries the same id, so the two sides can be
+ * joined downstream.
+ */
+export type ActiveInteraction = {
+  id: string;
+  /** The derived action name; empty string when the click had no derivable name. */
+  name: string;
+  epochMillis: number;
+};
+
+/**
+ * How long after a click HTTP requests are still attributed to it. Requests
+ * triggered by a click are typically issued within the same task or a few
+ * microtasks; the window is deliberately small so long-lived polling or timers
+ * are not misattributed to a stale click.
+ */
+const ACTIVE_INTERACTION_WINDOW_MILLIS = 2000;
+
+let active: ActiveInteraction | undefined;
+
+export function registerActiveInteraction(name: string): ActiveInteraction {
+  active = {
+    id: generateUniqueId(WEB_EVENT_ID_BYTES),
+    name,
+    epochMillis: Date.now(),
+  };
+  return active;
+}
+
+export function getActiveInteraction(): ActiveInteraction | undefined {
+  if (!active) return undefined;
+  if (Date.now() - active.epochMillis > ACTIVE_INTERACTION_WINDOW_MILLIS) {
+    active = undefined;
+    return undefined;
+  }
+  return active;
+}
+
+export function clearActiveInteractionForTests(): void {
+  active = undefined;
+}

--- a/src/instrumentations/interactions/active-interaction_test.ts
+++ b/src/instrumentations/interactions/active-interaction_test.ts
@@ -1,0 +1,58 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { clearActiveInteractionForTests, getActiveInteraction, registerActiveInteraction } from "./active-interaction";
+
+describe("active interaction tracking", () => {
+  afterEach(() => {
+    clearActiveInteractionForTests();
+    vi.restoreAllMocks();
+  });
+
+  it("returns the registered interaction within the attribution window", () => {
+    const registered = registerActiveInteraction("Save Part");
+
+    const active = getActiveInteraction();
+    expect(active).toBeDefined();
+    expect(active!.id).toBe(registered.id);
+    expect(active!.name).toBe("Save Part");
+    expect(active!.id).toMatch(/^[0-9a-f]{16}$/);
+  });
+
+  it("expires the interaction after the attribution window", () => {
+    const now = vi.spyOn(Date, "now");
+
+    now.mockReturnValue(100_000);
+    registerActiveInteraction("Save Part");
+
+    now.mockReturnValue(101_999);
+    expect(getActiveInteraction()).toBeDefined();
+
+    now.mockReturnValue(102_001); // > 2000ms after registration
+    expect(getActiveInteraction()).toBeUndefined();
+
+    // and stays gone even if time goes on
+    now.mockReturnValue(103_000);
+    expect(getActiveInteraction()).toBeUndefined();
+  });
+
+  it("a new click replaces the previous interaction", () => {
+    const first = registerActiveInteraction("First");
+    const second = registerActiveInteraction("Second");
+
+    expect(second.id).not.toBe(first.id);
+    expect(getActiveInteraction()!.id).toBe(second.id);
+    expect(getActiveInteraction()!.name).toBe("Second");
+  });
+
+  it("keeps a blank name for unnamed interactions (id still joins the event to its requests)", () => {
+    registerActiveInteraction("");
+
+    const active = getActiveInteraction();
+    expect(active).toBeDefined();
+    expect(active!.name).toBe("");
+    expect(active!.id).toMatch(/^[0-9a-f]{16}$/);
+  });
+
+  it("returns undefined when no interaction was ever registered", () => {
+    expect(getActiveInteraction()).toBeUndefined();
+  });
+});

--- a/src/instrumentations/interactions/change.ts
+++ b/src/instrumentations/interactions/change.ts
@@ -1,0 +1,101 @@
+import { win } from "../../utils";
+import { debug } from "../../utils/debug";
+import { addAttribute } from "../../utils/otel";
+import { INTERACTION_SELECTED_COUNT, INTERACTION_VALUE_LENGTH } from "../../semantic-conventions";
+import { KeyValue } from "../../types/otlp";
+import { vars } from "../../vars";
+import { deriveActionName } from "./action-name";
+import { registerActiveInteraction } from "./active-interaction";
+import { emitInteractionEvent, pagePath } from "./emit";
+
+/**
+ * Form-change capture, privacy-first: the VALUE of a field is never read.
+ * What is emitted, per control kind:
+ *   - text-like inputs / textarea: the value's LENGTH only
+ *     ("Change "Email" to 17 characters")
+ *   - select: the number of selected options only
+ *     ("Change "Country" to 1 selected")
+ *   - checkbox / radio: the fact that it was toggled, nothing else
+ *   - password inputs: not even the length (length is itself a weak secret)
+ *   - file inputs: the fact that files were chosen; never a filename
+ * Field names come from deriveActionName, which for form controls only uses
+ * naming attributes (aria-label, placeholder, the custom attribute), never
+ * user-entered content.
+ */
+const CHANGE_TAGS = new Set(["INPUT", "SELECT", "TEXTAREA"]);
+const NO_LENGTH_INPUT_TYPES = new Set(["password", "hidden"]);
+const TOGGLE_INPUT_TYPES = new Set(["checkbox", "radio"]);
+
+let listenerAttached = false;
+
+function onWindowChange(event: Event) {
+  if (!event.isTrusted) return;
+  handleChange(event);
+}
+
+export function startChangeInstrumentation() {
+  if (listenerAttached) return;
+  if (!win) return;
+
+  win.addEventListener("change", onWindowChange, { capture: true });
+  listenerAttached = true;
+}
+
+export function stopChangeInstrumentationForTests() {
+  if (!listenerAttached || !win) return;
+  win.removeEventListener("change", onWindowChange, { capture: true } as EventListenerOptions);
+  listenerAttached = false;
+}
+
+/**
+ * Exported for tests (bypasses the isTrusted gate, same pattern as
+ * click.ts/handleClick).
+ */
+export function handleChange(event: Event): void {
+  try {
+    const target = event.target;
+    if (!target || (target as Node).nodeType !== 1) return;
+    const element = target as Element;
+    if (!CHANGE_TAGS.has(element.tagName)) return;
+
+    const { name, nameSource } = deriveActionName(element, vars.interactionInstrumentation.actionNameAttribute!);
+    const tag = element.tagName.toLowerCase();
+    const label = name ? `"${name}"` : tag;
+
+    // A change often triggers a request (dependent selects, autosave), so
+    // register it for HTTP span attribution just like a click.
+    const interaction = registerActiveInteraction(name);
+
+    const extraAttributes: KeyValue[] = [];
+    let title: string;
+
+    if (element.tagName === "SELECT") {
+      const selectedCount = (element as HTMLSelectElement).selectedOptions?.length ?? 0;
+      addAttribute(extraAttributes, INTERACTION_SELECTED_COUNT, selectedCount);
+      title = `Change ${label} to ${selectedCount} selected on ${pagePath()}`;
+    } else if (element.tagName === "INPUT" && TOGGLE_INPUT_TYPES.has((element as HTMLInputElement).type)) {
+      title = `Toggle ${label} on ${pagePath()}`;
+    } else if (element.tagName === "INPUT" && (element as HTMLInputElement).type === "file") {
+      title = `Change ${label} on ${pagePath()}`;
+    } else if (element.tagName === "INPUT" && NO_LENGTH_INPUT_TYPES.has((element as HTMLInputElement).type)) {
+      // password/hidden: even the length stays private
+      title = `Change ${label} on ${pagePath()}`;
+    } else {
+      const valueLength = (element as HTMLInputElement | HTMLTextAreaElement).value?.length ?? 0;
+      addAttribute(extraAttributes, INTERACTION_VALUE_LENGTH, valueLength);
+      title = `Change ${label} to ${valueLength} characters on ${pagePath()}`;
+    }
+
+    emitInteractionEvent({
+      type: "change",
+      title,
+      id: interaction.id,
+      name,
+      nameSource,
+      element,
+      extraAttributes,
+    });
+  } catch (err) {
+    debug("Dash0 interaction instrumentation failed to process a change event.", err);
+  }
+}

--- a/src/instrumentations/interactions/change_test.ts
+++ b/src/instrumentations/interactions/change_test.ts
@@ -1,0 +1,136 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { vars } from "../../vars";
+import { sendLog } from "../../transport";
+import { doc } from "../../utils/globals";
+import {
+  INTERACTION_NAME,
+  INTERACTION_NAME_SOURCE,
+  INTERACTION_SELECTED_COUNT,
+  INTERACTION_TYPE,
+  INTERACTION_VALUE_LENGTH,
+} from "../../semantic-conventions";
+import type { LogRecord } from "../../types/otlp";
+
+vi.mock("../../transport", () => ({
+  sendLog: vi.fn(),
+}));
+
+import { handleChange } from "./change";
+import { clearActiveInteractionForTests, getActiveInteraction } from "./active-interaction";
+
+const dom = doc!;
+
+function changeEventFor(el: Element): Event {
+  const event = new Event("change", { bubbles: true });
+  Object.defineProperty(event, "target", { value: el });
+  return event;
+}
+
+function lastLog(): LogRecord {
+  const calls = (sendLog as ReturnType<typeof vi.fn>).mock.calls;
+  expect(calls.length).toBeGreaterThan(0);
+  return calls[calls.length - 1]![0] as LogRecord;
+}
+
+function attr(log: LogRecord, key: string) {
+  return (log.attributes as { key: string; value: Record<string, unknown> }[]).find((kv) => kv.key === key)?.value;
+}
+
+describe("change instrumentation", () => {
+  beforeEach(() => {
+    dom.body.innerHTML = "";
+    vars.interactionInstrumentation = { enabled: true, actionNameAttribute: "data-dash0-action-name" };
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    clearActiveInteractionForTests();
+    vi.clearAllMocks();
+  });
+
+  it("reports only the value LENGTH for text inputs, never the value", () => {
+    dom.body.innerHTML = `<input id="email" type="text" aria-label="Email" />`;
+    const input = dom.getElementById("email") as HTMLInputElement;
+    input.value = "user@example.com"; // 16 characters of user data
+
+    handleChange(changeEventFor(input));
+
+    const log = lastLog();
+    expect(log.body).toEqual({ stringValue: 'Change "Email" to 16 characters on /' });
+    expect(attr(log, INTERACTION_VALUE_LENGTH)).toEqual({ doubleValue: 16 });
+    expect(attr(log, INTERACTION_TYPE)).toEqual({ stringValue: "change" });
+    // the raw value must not appear anywhere in the record
+    expect(JSON.stringify(log)).not.toContain("user@example.com");
+  });
+
+  it("reports neither value nor length for password inputs", () => {
+    dom.body.innerHTML = `<input id="pw" type="password" aria-label="Password" />`;
+    const input = dom.getElementById("pw") as HTMLInputElement;
+    input.value = "hunter2";
+
+    handleChange(changeEventFor(input));
+
+    const log = lastLog();
+    expect(log.body).toEqual({ stringValue: 'Change "Password" on /' });
+    expect(attr(log, INTERACTION_VALUE_LENGTH)).toBeUndefined();
+    expect(JSON.stringify(log)).not.toContain("hunter2");
+  });
+
+  it("reports the selected COUNT for selects, never the chosen option", () => {
+    dom.body.innerHTML = `
+      <select id="country" aria-label="Country">
+        <option value="secret-country" selected>Secret Country</option>
+        <option value="other">Other</option>
+      </select>`;
+    const select = dom.getElementById("country")!;
+
+    handleChange(changeEventFor(select));
+
+    const log = lastLog();
+    expect(log.body).toEqual({ stringValue: 'Change "Country" to 1 selected on /' });
+    expect(attr(log, INTERACTION_SELECTED_COUNT)).toEqual({ doubleValue: 1 });
+    expect(JSON.stringify(log)).not.toContain("Secret Country");
+    expect(JSON.stringify(log)).not.toContain("secret-country");
+  });
+
+  it("reports checkbox changes as a toggle with no value", () => {
+    dom.body.innerHTML = `<input id="sub" type="checkbox" aria-label="Subscribe" />`;
+    const box = dom.getElementById("sub") as HTMLInputElement;
+    box.checked = true;
+
+    handleChange(changeEventFor(box));
+
+    const log = lastLog();
+    expect(log.body).toEqual({ stringValue: 'Toggle "Subscribe" on /' });
+    expect(attr(log, INTERACTION_VALUE_LENGTH)).toBeUndefined();
+  });
+
+  it("ignores change events from non-form elements", () => {
+    dom.body.innerHTML = `<div id="d"></div>`;
+    handleChange(changeEventFor(dom.getElementById("d")!));
+
+    expect(sendLog).not.toHaveBeenCalled();
+  });
+
+  it("registers the change as the active interaction for span attribution", () => {
+    dom.body.innerHTML = `<select id="c" aria-label="Country"><option selected>A</option></select>`;
+    handleChange(changeEventFor(dom.getElementById("c")!));
+
+    const active = getActiveInteraction();
+    expect(active).toBeDefined();
+    expect(active!.name).toBe("Country");
+  });
+
+  it("names the field via naming attributes and records the source", () => {
+    dom.body.innerHTML = `<textarea id="notes" placeholder="Notes"></textarea>`;
+    const ta = dom.getElementById("notes") as HTMLTextAreaElement;
+    ta.value = "abc";
+
+    handleChange(changeEventFor(ta));
+
+    const log = lastLog();
+    expect(attr(log, INTERACTION_NAME)).toEqual({ stringValue: "Notes" });
+    expect(attr(log, INTERACTION_NAME_SOURCE)).toEqual({ stringValue: "standard_attribute" });
+    expect(attr(log, INTERACTION_VALUE_LENGTH)).toEqual({ doubleValue: 3 });
+  });
+});

--- a/src/instrumentations/interactions/click.ts
+++ b/src/instrumentations/interactions/click.ts
@@ -106,10 +106,14 @@ export function handleClick(event: Event): void {
  *   The walk never crosses a BODY/HTML boundary -- those document-structure
  *   elements are not meaningful click-target context.
  * Result is capped at MAX_SELECTOR_LENGTH characters.
+ *
+ * The selector is best-effort display telemetry, NOT guaranteed valid CSS for
+ * querySelector: ids/class names are not escaped and truncation may cut
+ * mid-token.
  */
 function buildSelector(element: Element): string {
   if (element.id) {
-    return describeElement(element);
+    return truncateSelector(describeElement(element));
   }
 
   const parts: string[] = [describeElement(element)];
@@ -121,7 +125,10 @@ function buildSelector(element: Element): string {
     if (current.id) break;
   }
 
-  const selector = parts.join(" > ");
+  return truncateSelector(parts.join(" > "));
+}
+
+function truncateSelector(selector: string): string {
   return selector.length > MAX_SELECTOR_LENGTH ? selector.substring(0, MAX_SELECTOR_LENGTH) : selector;
 }
 

--- a/src/instrumentations/interactions/click.ts
+++ b/src/instrumentations/interactions/click.ts
@@ -1,26 +1,9 @@
-import { nowNanos, win } from "../../utils";
+import { win } from "../../utils";
 import { debug } from "../../utils/debug";
-import { sendLog } from "../../transport";
-import {
-  EVENT_NAME,
-  EVENT_NAMES,
-  INTERACTION_NAME,
-  INTERACTION_NAME_SOURCE,
-  INTERACTION_TARGET_ID,
-  INTERACTION_TARGET_SELECTOR,
-  INTERACTION_TARGET_TAG,
-  INTERACTION_TYPE,
-  LOG_SEVERITIES,
-} from "../../semantic-conventions";
-import { addAttribute } from "../../utils/otel";
-import { addCommonAttributes } from "../../attributes";
-import { KeyValue, LogRecord } from "../../types/otlp";
 import { vars } from "../../vars";
 import { deriveActionName } from "./action-name";
-
-const MAX_SELECTOR_LENGTH = 128;
-const MAX_SELECTOR_ANCESTORS = 3;
-const SELECTOR_BOUNDARY_TAGS = new Set(["BODY", "HTML"]);
+import { registerActiveInteraction } from "./active-interaction";
+import { emitInteractionEvent, pagePath } from "./emit";
 
 let listenerAttached = false;
 
@@ -65,78 +48,24 @@ export function handleClick(event: Event): void {
 
     const element = target as Element;
     const { name, nameSource } = deriveActionName(element, vars.interactionInstrumentation.actionNameAttribute!);
-    const selector = buildSelector(element);
+    const tag = element.tagName.toLowerCase();
 
-    const attributes: KeyValue[] = [];
-    addCommonAttributes(attributes);
-    addAttribute(attributes, EVENT_NAME, EVENT_NAMES.INTERACTION);
+    // Register this click as the active interaction BEFORE the application's
+    // own handlers run (we are in the capture phase), so any HTTP request the
+    // click triggers gets stamped with this interaction's id/name.
+    const interaction = registerActiveInteraction(name);
 
-    const bodyValues: KeyValue[] = [];
-    addAttribute(bodyValues, INTERACTION_TYPE, "click");
-    addAttribute(bodyValues, INTERACTION_NAME, name);
-    addAttribute(bodyValues, INTERACTION_NAME_SOURCE, nameSource);
-    addAttribute(bodyValues, INTERACTION_TARGET_SELECTOR, selector);
-    addAttribute(bodyValues, INTERACTION_TARGET_TAG, element.tagName.toLowerCase());
-    if (element.id) {
-      addAttribute(bodyValues, INTERACTION_TARGET_ID, element.id);
-    }
-
-    const log: LogRecord = {
-      timeUnixNano: nowNanos(),
-      attributes,
-      severityNumber: LOG_SEVERITIES.INFO,
-      severityText: "INFO",
-      body: {
-        kvlistValue: { values: bodyValues },
-      },
-    };
-
-    sendLog(log);
+    emitInteractionEvent({
+      type: "click",
+      // Click "Save Part" on /inventory/parts
+      // Click button on /playground          (no derivable name)
+      title: name ? `Click "${name}" on ${pagePath()}` : `Click ${tag} on ${pagePath()}`,
+      id: interaction.id,
+      name,
+      nameSource,
+      element,
+    });
   } catch (err) {
     debug("Dash0 interaction instrumentation failed to process a click event.", err);
   }
-}
-
-/**
- * Builds a compact CSS-like selector describing the click target:
- * - `tag#id` when the target has an id.
- * - `tag.firstClass` when it has classes but no id.
- * - Otherwise, walks up to MAX_SELECTOR_ANCESTORS ancestors (each rendered the
- *   same way) joined with " > ", since there is no id anywhere to anchor on.
- *   The walk never crosses a BODY/HTML boundary -- those document-structure
- *   elements are not meaningful click-target context.
- * Result is capped at MAX_SELECTOR_LENGTH characters.
- *
- * The selector is best-effort display telemetry, NOT guaranteed valid CSS for
- * querySelector: ids/class names are not escaped and truncation may cut
- * mid-token.
- */
-function buildSelector(element: Element): string {
-  if (element.id) {
-    return truncateSelector(describeElement(element));
-  }
-
-  const parts: string[] = [describeElement(element)];
-  let current: Element | null = element;
-  for (let i = 0; i < MAX_SELECTOR_ANCESTORS; i++) {
-    current = current.parentElement;
-    if (!current || SELECTOR_BOUNDARY_TAGS.has(current.tagName)) break;
-    parts.unshift(describeElement(current));
-    if (current.id) break;
-  }
-
-  return truncateSelector(parts.join(" > "));
-}
-
-function truncateSelector(selector: string): string {
-  return selector.length > MAX_SELECTOR_LENGTH ? selector.substring(0, MAX_SELECTOR_LENGTH) : selector;
-}
-
-function describeElement(element: Element): string {
-  const tag = element.tagName.toLowerCase();
-  if (element.id) {
-    return `${tag}#${element.id}`;
-  }
-  const firstClass = element.classList.item(0);
-  return firstClass ? `${tag}.${firstClass}` : tag;
 }

--- a/src/instrumentations/interactions/click.ts
+++ b/src/instrumentations/interactions/click.ts
@@ -1,0 +1,135 @@
+import { nowNanos, win } from "../../utils";
+import { debug } from "../../utils/debug";
+import { sendLog } from "../../transport";
+import {
+  EVENT_NAME,
+  EVENT_NAMES,
+  INTERACTION_NAME,
+  INTERACTION_NAME_SOURCE,
+  INTERACTION_TARGET_ID,
+  INTERACTION_TARGET_SELECTOR,
+  INTERACTION_TARGET_TAG,
+  INTERACTION_TYPE,
+  LOG_SEVERITIES,
+} from "../../semantic-conventions";
+import { addAttribute } from "../../utils/otel";
+import { addCommonAttributes } from "../../attributes";
+import { KeyValue, LogRecord } from "../../types/otlp";
+import { vars } from "../../vars";
+import { deriveActionName } from "./action-name";
+
+const MAX_SELECTOR_LENGTH = 128;
+const MAX_SELECTOR_ANCESTORS = 3;
+const SELECTOR_BOUNDARY_TAGS = new Set(["BODY", "HTML"]);
+
+let listenerAttached = false;
+
+function onWindowClick(event: Event) {
+  if (!event.isTrusted) return;
+  handleClick(event);
+}
+
+export function startClickInstrumentation() {
+  if (listenerAttached) return;
+  if (!win) return;
+
+  win.addEventListener("click", onWindowClick, { capture: true });
+  listenerAttached = true;
+}
+
+/**
+ * Test-only teardown. Production code has no need to stop this listener --
+ * matching the errors/index.ts precedent of start-only lifecycle -- but unit
+ * tests need to avoid leaking a real window listener across test cases.
+ */
+export function stopClickInstrumentationForTests() {
+  if (!listenerAttached || !win) return;
+  win.removeEventListener("click", onWindowClick, { capture: true } as EventListenerOptions);
+  listenerAttached = false;
+}
+
+/**
+ * Handles a click event and, if the target is a valid Element, builds and
+ * transmits a `browser.interaction` log. Exported separately from the
+ * `isTrusted` gate in the real listener (see `onWindowClick`) so unit tests
+ * can exercise the full event-building path directly: jsdom's
+ * `dispatchEvent`, like real browsers, always produces `isTrusted: false`,
+ * so a trust-gated entry point cannot be driven by synthetic test events.
+ */
+export function handleClick(event: Event): void {
+  try {
+    const target = event.target;
+    if (!target || (target as Node).nodeType !== 1) {
+      return;
+    }
+
+    const element = target as Element;
+    const { name, nameSource } = deriveActionName(element, vars.interactionInstrumentation.actionNameAttribute!);
+    const selector = buildSelector(element);
+
+    const attributes: KeyValue[] = [];
+    addCommonAttributes(attributes);
+    addAttribute(attributes, EVENT_NAME, EVENT_NAMES.INTERACTION);
+
+    const bodyValues: KeyValue[] = [];
+    addAttribute(bodyValues, INTERACTION_TYPE, "click");
+    addAttribute(bodyValues, INTERACTION_NAME, name);
+    addAttribute(bodyValues, INTERACTION_NAME_SOURCE, nameSource);
+    addAttribute(bodyValues, INTERACTION_TARGET_SELECTOR, selector);
+    addAttribute(bodyValues, INTERACTION_TARGET_TAG, element.tagName.toLowerCase());
+    if (element.id) {
+      addAttribute(bodyValues, INTERACTION_TARGET_ID, element.id);
+    }
+
+    const log: LogRecord = {
+      timeUnixNano: nowNanos(),
+      attributes,
+      severityNumber: LOG_SEVERITIES.INFO,
+      severityText: "INFO",
+      body: {
+        kvlistValue: { values: bodyValues },
+      },
+    };
+
+    sendLog(log);
+  } catch (err) {
+    debug("Dash0 interaction instrumentation failed to process a click event.", err);
+  }
+}
+
+/**
+ * Builds a compact CSS-like selector describing the click target:
+ * - `tag#id` when the target has an id.
+ * - `tag.firstClass` when it has classes but no id.
+ * - Otherwise, walks up to MAX_SELECTOR_ANCESTORS ancestors (each rendered the
+ *   same way) joined with " > ", since there is no id anywhere to anchor on.
+ *   The walk never crosses a BODY/HTML boundary -- those document-structure
+ *   elements are not meaningful click-target context.
+ * Result is capped at MAX_SELECTOR_LENGTH characters.
+ */
+function buildSelector(element: Element): string {
+  if (element.id) {
+    return describeElement(element);
+  }
+
+  const parts: string[] = [describeElement(element)];
+  let current: Element | null = element;
+  for (let i = 0; i < MAX_SELECTOR_ANCESTORS; i++) {
+    current = current.parentElement;
+    if (!current || SELECTOR_BOUNDARY_TAGS.has(current.tagName)) break;
+    parts.unshift(describeElement(current));
+    if (current.id) break;
+  }
+
+  const selector = parts.join(" > ");
+  return selector.length > MAX_SELECTOR_LENGTH ? selector.substring(0, MAX_SELECTOR_LENGTH) : selector;
+}
+
+function describeElement(element: Element): string {
+  const tag = element.tagName.toLowerCase();
+  if (element.id) {
+    return `${tag}#${element.id}`;
+  }
+  const firstClass = element.classList.item(0);
+  return firstClass ? `${tag}.${firstClass}` : tag;
+}

--- a/src/instrumentations/interactions/click_test.ts
+++ b/src/instrumentations/interactions/click_test.ts
@@ -1,0 +1,230 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { vars } from "../../vars";
+import { sendLog } from "../../transport";
+import { doc, win } from "../../utils/globals";
+import {
+  EVENT_NAME,
+  EVENT_NAMES,
+  INTERACTION_NAME,
+  INTERACTION_NAME_SOURCE,
+  INTERACTION_TARGET_ID,
+  INTERACTION_TARGET_SELECTOR,
+  INTERACTION_TARGET_TAG,
+  INTERACTION_TYPE,
+  LOG_SEVERITIES,
+} from "../../semantic-conventions";
+import { WEB_EVENT_ID } from "../../semantic-conventions";
+import type { LogRecord } from "../../types/otlp";
+
+vi.mock("../../transport", () => ({
+  sendLog: vi.fn(),
+}));
+
+import { handleClick, startClickInstrumentation, stopClickInstrumentationForTests } from "./click";
+
+// Vitest runs these tests in jsdom, so the SSR-safe doc/win are always defined.
+const dom = doc!;
+const globalWindow = win!;
+
+function dispatchClick(target: Element) {
+  const event = new MouseEvent("click", { bubbles: true, cancelable: true });
+  target.dispatchEvent(event);
+  return event;
+}
+
+describe("click instrumentation", () => {
+  beforeEach(() => {
+    dom.body.innerHTML = "";
+    vars.interactionInstrumentation = { enabled: true, actionNameAttribute: "data-dash0-action-name" };
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    stopClickInstrumentationForTests();
+    vi.clearAllMocks();
+  });
+
+  function lastLog(): LogRecord {
+    const calls = (sendLog as ReturnType<typeof vi.fn>).mock.calls;
+    expect(calls.length).toBeGreaterThan(0);
+    return calls[calls.length - 1]![0] as LogRecord;
+  }
+
+  describe("handleClick (direct, bypasses isTrusted gate)", () => {
+    it("emits exactly one log per click with the full expected attribute set", () => {
+      dom.body.innerHTML = `<button id="btn" data-dash0-action-name="Save Settings">Save</button>`;
+      const target = dom.getElementById("btn")!;
+
+      handleClick(dispatchClick(target));
+
+      expect(sendLog).toHaveBeenCalledOnce();
+      const log = lastLog();
+
+      expect(log.severityNumber).toBe(LOG_SEVERITIES.INFO);
+      expect(log.severityText).toBe("INFO");
+      expect(typeof log.timeUnixNano).toBe("string");
+
+      expect(log.attributes).toEqual(
+        expect.arrayContaining([
+          { key: WEB_EVENT_ID, value: { stringValue: expect.any(String) } },
+          { key: EVENT_NAME, value: { stringValue: EVENT_NAMES.INTERACTION } },
+        ])
+      );
+
+      expect(log.body).toEqual({
+        kvlistValue: {
+          values: expect.arrayContaining([
+            { key: INTERACTION_TYPE, value: { stringValue: "click" } },
+            { key: INTERACTION_NAME, value: { stringValue: "Save Settings" } },
+            { key: INTERACTION_NAME_SOURCE, value: { stringValue: "custom_attribute" } },
+            { key: INTERACTION_TARGET_SELECTOR, value: { stringValue: "button#btn" } },
+            { key: INTERACTION_TARGET_TAG, value: { stringValue: "button" } },
+            { key: INTERACTION_TARGET_ID, value: { stringValue: "btn" } },
+          ]),
+        },
+      });
+    });
+
+    it("addCommonAttributes attributes come before EVENT_NAME, matching the errors/index.ts structural template", () => {
+      dom.body.innerHTML = `<button id="btn">Click</button>`;
+      handleClick(dispatchClick(dom.getElementById("btn")!));
+
+      const log = lastLog();
+      const eventNameIndex = log.attributes.findIndex((a) => a.key === EVENT_NAME);
+      const webEventIdIndex = log.attributes.findIndex((a) => a.key === WEB_EVENT_ID);
+
+      expect(webEventIdIndex).toBeGreaterThanOrEqual(0);
+      expect(eventNameIndex).toBeGreaterThan(webEventIdIndex);
+    });
+
+    it("omits target.id when the element has no id", () => {
+      dom.body.innerHTML = `<button class="cta">Click</button>`;
+      handleClick(dispatchClick(dom.querySelector(".cta")!));
+
+      const log = lastLog();
+      const values = (log.body!.kvlistValue!.values as { key: string }[]).map((kv) => kv.key);
+      expect(values).not.toContain(INTERACTION_TARGET_ID);
+    });
+
+    it("derives a compact selector: tag + #id when id is present", () => {
+      dom.body.innerHTML = `<div id="card" class="card highlighted"><span id="inner">x</span></div>`;
+      handleClick(dispatchClick(dom.getElementById("inner")!));
+
+      const log = lastLog();
+      const selector = (log.body!.kvlistValue!.values as { key: string; value: { stringValue: string } }[]).find(
+        (kv) => kv.key === INTERACTION_TARGET_SELECTOR
+      );
+      expect(selector?.value.stringValue).toBe("span#inner");
+    });
+
+    it("derives a compact selector: tag + first class when no id is present", () => {
+      dom.body.innerHTML = `<button class="btn-primary large">Click</button>`;
+      handleClick(dispatchClick(dom.querySelector(".btn-primary")!));
+
+      const log = lastLog();
+      const selector = (log.body!.kvlistValue!.values as { key: string; value: { stringValue: string } }[]).find(
+        (kv) => kv.key === INTERACTION_TARGET_SELECTOR
+      );
+      expect(selector?.value.stringValue).toBe("button.btn-primary");
+    });
+
+    it("walks up to 3 ancestors joined with ' > ' when no id is present anywhere in the path", () => {
+      dom.body.innerHTML = `
+        <div class="outer">
+          <div class="middle">
+            <span class="inner">x</span>
+          </div>
+        </div>`;
+      handleClick(dispatchClick(dom.querySelector(".inner")!));
+
+      const log = lastLog();
+      const selector = (log.body!.kvlistValue!.values as { key: string; value: { stringValue: string } }[]).find(
+        (kv) => kv.key === INTERACTION_TARGET_SELECTOR
+      );
+      expect(selector?.value.stringValue).toBe("div.outer > div.middle > span.inner");
+    });
+
+    it("does not emit a log when target is not an Element (e.g. a text node)", () => {
+      dom.body.innerHTML = `<div id="wrap">text</div>`;
+      const textNode = dom.getElementById("wrap")!.firstChild!;
+
+      const event = new MouseEvent("click", { bubbles: true });
+      Object.defineProperty(event, "target", { value: textNode });
+
+      handleClick(event);
+
+      expect(sendLog).not.toHaveBeenCalled();
+    });
+
+    it("swallows errors from a throwing scenario and does not propagate", () => {
+      dom.body.innerHTML = `<button id="btn">Click</button>`;
+      const target = dom.getElementById("btn")!;
+      // Force an internal error by making textContent throw.
+      Object.defineProperty(target, "textContent", {
+        get() {
+          throw new Error("boom");
+        },
+      });
+
+      expect(() => handleClick(dispatchClick(target))).not.toThrow();
+      expect(sendLog).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("startClickInstrumentation (real capture-phase listener + isTrusted gate)", () => {
+    it("registers exactly one window-level capture-phase click listener", () => {
+      const addSpy = vi.spyOn(globalWindow, "addEventListener");
+
+      startClickInstrumentation();
+
+      expect(addSpy).toHaveBeenCalledOnce();
+      expect(addSpy).toHaveBeenCalledWith("click", expect.any(Function), { capture: true });
+
+      addSpy.mockRestore();
+    });
+
+    it("ignores untrusted (synthetic) clicks -- jsdom's dispatchEvent always yields isTrusted: false", () => {
+      dom.body.innerHTML = `<button id="btn">Click</button>`;
+      startClickInstrumentation();
+
+      const target = dom.getElementById("btn")!;
+      const event = dispatchClick(target);
+
+      // jsdom, like real browsers, never sets isTrusted: true for dispatchEvent --
+      // this assertion documents and locks in that guard behavior.
+      expect(event.isTrusted).toBe(false);
+      expect(sendLog).not.toHaveBeenCalled();
+    });
+
+    it("processes a click when isTrusted is stubbed true, proving the gate is the only thing blocking synthetic clicks", () => {
+      // jsdom (v26, pinned in this repo) defines `isTrusted` as a non-configurable
+      // accessor on its Event prototype, so `Object.defineProperty` on a real
+      // dispatched event throws "Cannot redefine property: isTrusted" -- there is
+      // no public jsdom API to construct a pre-trusted event. Instead, capture the
+      // real capture-phase listener registered by `startClickInstrumentation` and
+      // invoke it directly with a minimal object shaped like a trusted click
+      // event. This still exercises the real production listener function (not a
+      // reimplementation of it), only substituting jsdom's event construction.
+      dom.body.innerHTML = `<button id="btn">Click</button>`;
+      const addSpy = vi.spyOn(globalWindow, "addEventListener");
+      startClickInstrumentation();
+
+      const target = dom.getElementById("btn")!;
+      const listener = addSpy.mock.calls.find((call) => call[0] === "click")![1] as EventListener;
+      listener({ isTrusted: true, target } as unknown as Event);
+
+      addSpy.mockRestore();
+      expect(sendLog).toHaveBeenCalledOnce();
+    });
+
+    it("does not register a second listener if called twice (idempotent start)", () => {
+      const addSpy = vi.spyOn(globalWindow, "addEventListener");
+
+      startClickInstrumentation();
+      startClickInstrumentation();
+
+      expect(addSpy).toHaveBeenCalledOnce();
+      addSpy.mockRestore();
+    });
+  });
+});

--- a/src/instrumentations/interactions/click_test.ts
+++ b/src/instrumentations/interactions/click_test.ts
@@ -128,6 +128,34 @@ describe("click instrumentation", () => {
       expect(selector?.value.stringValue).toBe("button.btn-primary");
     });
 
+    it("caps the selector length on the id-anchored path, same as the ancestor-walk path", () => {
+      // Regression: the tag#id fast path must go through the same
+      // MAX_SELECTOR_LENGTH (128) truncation as the ancestor-walk branch.
+      const longId = "x".repeat(200);
+      dom.body.innerHTML = `<button id="${longId}">Click</button>`;
+      handleClick(dispatchClick(dom.getElementById(longId)!));
+
+      const log = lastLog();
+      const selector = (log.body!.kvlistValue!.values as { key: string; value: { stringValue: string } }[]).find(
+        (kv) => kv.key === INTERACTION_TARGET_SELECTOR
+      );
+      expect(selector?.value.stringValue).toBe(`button#${longId}`.substring(0, 128));
+      expect(selector?.value.stringValue.length).toBe(128);
+    });
+
+    it("never includes body/html segments in the selector for a shallow element with no id", () => {
+      // Locks in SELECTOR_BOUNDARY_TAGS: the ancestor walk stops before
+      // crossing into document-structure elements.
+      dom.body.innerHTML = `<span class="lonely">x</span>`;
+      handleClick(dispatchClick(dom.querySelector(".lonely")!));
+
+      const log = lastLog();
+      const selector = (log.body!.kvlistValue!.values as { key: string; value: { stringValue: string } }[]).find(
+        (kv) => kv.key === INTERACTION_TARGET_SELECTOR
+      );
+      expect(selector?.value.stringValue).toBe("span.lonely");
+    });
+
     it("walks up to 3 ancestors joined with ' > ' when no id is present anywhere in the path", () => {
       dom.body.innerHTML = `
         <div class="outer">

--- a/src/instrumentations/interactions/click_test.ts
+++ b/src/instrumentations/interactions/click_test.ts
@@ -5,6 +5,7 @@ import { doc, win } from "../../utils/globals";
 import {
   EVENT_NAME,
   EVENT_NAMES,
+  INTERACTION_ID,
   INTERACTION_NAME,
   INTERACTION_NAME_SOURCE,
   INTERACTION_TARGET_ID,
@@ -21,6 +22,7 @@ vi.mock("../../transport", () => ({
 }));
 
 import { handleClick, startClickInstrumentation, stopClickInstrumentationForTests } from "./click";
+import { clearActiveInteractionForTests, getActiveInteraction } from "./active-interaction";
 
 // Vitest runs these tests in jsdom, so the SSR-safe doc/win are always defined.
 const dom = doc!;
@@ -41,6 +43,7 @@ describe("click instrumentation", () => {
 
   afterEach(() => {
     stopClickInstrumentationForTests();
+    clearActiveInteractionForTests();
     vi.clearAllMocks();
   });
 
@@ -68,21 +71,51 @@ describe("click instrumentation", () => {
         expect.arrayContaining([
           { key: WEB_EVENT_ID, value: { stringValue: expect.any(String) } },
           { key: EVENT_NAME, value: { stringValue: EVENT_NAMES.INTERACTION } },
+          { key: INTERACTION_ID, value: { stringValue: expect.stringMatching(/^[0-9a-f]{16}$/) } },
+          { key: INTERACTION_TYPE, value: { stringValue: "click" } },
+          { key: INTERACTION_NAME, value: { stringValue: "Save Settings" } },
+          { key: INTERACTION_NAME_SOURCE, value: { stringValue: "custom_attribute" } },
+          { key: INTERACTION_TARGET_SELECTOR, value: { stringValue: "button#btn" } },
+          { key: INTERACTION_TARGET_TAG, value: { stringValue: "button" } },
+          { key: INTERACTION_TARGET_ID, value: { stringValue: "btn" } },
         ])
       );
 
-      expect(log.body).toEqual({
-        kvlistValue: {
-          values: expect.arrayContaining([
-            { key: INTERACTION_TYPE, value: { stringValue: "click" } },
-            { key: INTERACTION_NAME, value: { stringValue: "Save Settings" } },
-            { key: INTERACTION_NAME_SOURCE, value: { stringValue: "custom_attribute" } },
-            { key: INTERACTION_TARGET_SELECTOR, value: { stringValue: "button#btn" } },
-            { key: INTERACTION_TARGET_TAG, value: { stringValue: "button" } },
-            { key: INTERACTION_TARGET_ID, value: { stringValue: "btn" } },
-          ]),
-        },
-      });
+      // The body is the plain human-readable summary -- UIs without a
+      // dedicated browser.interaction renderer display it as-is.
+      expect(log.body).toEqual({ stringValue: 'Click "Save Settings" on /' });
+    });
+
+    it("titles an unnamed click with the target tag instead of dumping its text content", () => {
+      dom.body.innerHTML = `<div id="page" class="page">Lots of page prose that must not become the title</div>`;
+      handleClick(dispatchClick(dom.getElementById("page")!));
+
+      const log = lastLog();
+      expect(log.body).toEqual({ stringValue: "Click div on /" });
+      expect(log.attributes).toEqual(
+        expect.arrayContaining([
+          { key: INTERACTION_NAME, value: { stringValue: "" } },
+          { key: INTERACTION_NAME_SOURCE, value: { stringValue: "blank" } },
+        ])
+      );
+    });
+
+    it("registers the click as the active interaction so HTTP spans can be attributed to it", () => {
+      dom.body.innerHTML = `<button id="btn" data-dash0-action-name="Fire Requests">Go</button>`;
+      handleClick(dispatchClick(dom.getElementById("btn")!));
+
+      const log = lastLog();
+      const eventId = (log.attributes as { key: string; value: { stringValue: string } }[]).find(
+        (kv) => kv.key === INTERACTION_ID
+      )!.value.stringValue;
+
+      const active = getActiveInteraction();
+      expect(active).toBeDefined();
+      expect(active!.name).toBe("Fire Requests");
+      // The event's interaction.id and the id stamped onto spans are the same
+      // value -- that shared id is what joins a click to the requests it
+      // triggered.
+      expect(active!.id).toBe(eventId);
     });
 
     it("addCommonAttributes attributes come before EVENT_NAME, matching the errors/index.ts structural template", () => {
@@ -102,8 +135,8 @@ describe("click instrumentation", () => {
       handleClick(dispatchClick(dom.querySelector(".cta")!));
 
       const log = lastLog();
-      const values = (log.body!.kvlistValue!.values as { key: string }[]).map((kv) => kv.key);
-      expect(values).not.toContain(INTERACTION_TARGET_ID);
+      const keys = (log.attributes as { key: string }[]).map((kv) => kv.key);
+      expect(keys).not.toContain(INTERACTION_TARGET_ID);
     });
 
     it("derives a compact selector: tag + #id when id is present", () => {
@@ -111,7 +144,7 @@ describe("click instrumentation", () => {
       handleClick(dispatchClick(dom.getElementById("inner")!));
 
       const log = lastLog();
-      const selector = (log.body!.kvlistValue!.values as { key: string; value: { stringValue: string } }[]).find(
+      const selector = (log.attributes as { key: string; value: { stringValue: string } }[]).find(
         (kv) => kv.key === INTERACTION_TARGET_SELECTOR
       );
       expect(selector?.value.stringValue).toBe("span#inner");
@@ -122,7 +155,7 @@ describe("click instrumentation", () => {
       handleClick(dispatchClick(dom.querySelector(".btn-primary")!));
 
       const log = lastLog();
-      const selector = (log.body!.kvlistValue!.values as { key: string; value: { stringValue: string } }[]).find(
+      const selector = (log.attributes as { key: string; value: { stringValue: string } }[]).find(
         (kv) => kv.key === INTERACTION_TARGET_SELECTOR
       );
       expect(selector?.value.stringValue).toBe("button.btn-primary");
@@ -136,7 +169,7 @@ describe("click instrumentation", () => {
       handleClick(dispatchClick(dom.getElementById(longId)!));
 
       const log = lastLog();
-      const selector = (log.body!.kvlistValue!.values as { key: string; value: { stringValue: string } }[]).find(
+      const selector = (log.attributes as { key: string; value: { stringValue: string } }[]).find(
         (kv) => kv.key === INTERACTION_TARGET_SELECTOR
       );
       expect(selector?.value.stringValue).toBe(`button#${longId}`.substring(0, 128));
@@ -150,7 +183,7 @@ describe("click instrumentation", () => {
       handleClick(dispatchClick(dom.querySelector(".lonely")!));
 
       const log = lastLog();
-      const selector = (log.body!.kvlistValue!.values as { key: string; value: { stringValue: string } }[]).find(
+      const selector = (log.attributes as { key: string; value: { stringValue: string } }[]).find(
         (kv) => kv.key === INTERACTION_TARGET_SELECTOR
       );
       expect(selector?.value.stringValue).toBe("span.lonely");
@@ -166,7 +199,7 @@ describe("click instrumentation", () => {
       handleClick(dispatchClick(dom.querySelector(".inner")!));
 
       const log = lastLog();
-      const selector = (log.body!.kvlistValue!.values as { key: string; value: { stringValue: string } }[]).find(
+      const selector = (log.attributes as { key: string; value: { stringValue: string } }[]).find(
         (kv) => kv.key === INTERACTION_TARGET_SELECTOR
       );
       expect(selector?.value.stringValue).toBe("div.outer > div.middle > span.inner");

--- a/src/instrumentations/interactions/emit.ts
+++ b/src/instrumentations/interactions/emit.ts
@@ -1,0 +1,125 @@
+import { loc, nowNanos } from "../../utils";
+import { sendLog } from "../../transport";
+import {
+  EVENT_NAME,
+  EVENT_NAMES,
+  INTERACTION_ID,
+  INTERACTION_NAME,
+  INTERACTION_NAME_SOURCE,
+  INTERACTION_TARGET_ID,
+  INTERACTION_TARGET_SELECTOR,
+  INTERACTION_TARGET_TAG,
+  INTERACTION_TYPE,
+  LOG_SEVERITIES,
+} from "../../semantic-conventions";
+import { addAttribute } from "../../utils/otel";
+import { addCommonAttributes } from "../../attributes";
+import { KeyValue, LogRecord } from "../../types/otlp";
+
+const MAX_SELECTOR_LENGTH = 128;
+const MAX_SELECTOR_ANCESTORS = 3;
+const SELECTOR_BOUNDARY_TAGS = new Set(["BODY", "HTML"]);
+
+export type InteractionType = "click" | "scroll" | "key_press" | "change";
+
+export type InteractionEvent = {
+  /** Discriminator emitted as `interaction.type`. */
+  type: InteractionType;
+  /** Human-readable one-line summary; becomes the log body. */
+  title: string;
+  /** Correlation id (shared with `user_interaction.id` on attributed spans). */
+  id: string;
+  /** Derived action name; may be blank. */
+  name: string;
+  /** How the name was derived. */
+  nameSource: string;
+  /** The DOM element the interaction targeted. */
+  element: Element;
+  /** Type-specific extra attributes (e.g. key, direction, value_length). */
+  extraAttributes?: KeyValue[];
+};
+
+/** The current page path, used in every interaction title. */
+export function pagePath(): string {
+  return loc?.pathname || "/";
+}
+
+/**
+ * Shared emit path for every interaction type: identical envelope
+ * (browser.interaction event, INFO severity), a plain-string human-readable
+ * body, and the structured fields as namespaced `interaction.*` log
+ * attributes.
+ */
+export function emitInteractionEvent(evt: InteractionEvent): void {
+  const attributes: KeyValue[] = [];
+  addCommonAttributes(attributes);
+  addAttribute(attributes, EVENT_NAME, EVENT_NAMES.INTERACTION);
+  addAttribute(attributes, INTERACTION_ID, evt.id);
+  addAttribute(attributes, INTERACTION_TYPE, evt.type);
+  addAttribute(attributes, INTERACTION_NAME, evt.name);
+  addAttribute(attributes, INTERACTION_NAME_SOURCE, evt.nameSource);
+  addAttribute(attributes, INTERACTION_TARGET_SELECTOR, buildSelector(evt.element));
+  addAttribute(attributes, INTERACTION_TARGET_TAG, evt.element.tagName.toLowerCase());
+  if (evt.element.id) {
+    addAttribute(attributes, INTERACTION_TARGET_ID, evt.element.id);
+  }
+  for (const extra of evt.extraAttributes ?? []) {
+    attributes.push(extra);
+  }
+
+  const log: LogRecord = {
+    timeUnixNano: nowNanos(),
+    attributes,
+    severityNumber: LOG_SEVERITIES.INFO,
+    severityText: "INFO",
+    body: {
+      stringValue: evt.title,
+    },
+  };
+
+  sendLog(log);
+}
+
+/**
+ * Builds a compact CSS-like selector describing the interaction target:
+ * - `tag#id` when the target has an id.
+ * - `tag.firstClass` when it has classes but no id.
+ * - Otherwise, walks up to MAX_SELECTOR_ANCESTORS ancestors (each rendered the
+ *   same way) joined with " > ", since there is no id anywhere to anchor on.
+ *   The walk never crosses a BODY/HTML boundary -- those document-structure
+ *   elements are not meaningful target context.
+ * Result is capped at MAX_SELECTOR_LENGTH characters.
+ *
+ * The selector is best-effort display telemetry, NOT guaranteed valid CSS for
+ * querySelector: ids/class names are not escaped and truncation may cut
+ * mid-token.
+ */
+export function buildSelector(element: Element): string {
+  if (element.id) {
+    return truncateSelector(describeElement(element));
+  }
+
+  const parts: string[] = [describeElement(element)];
+  let current: Element | null = element;
+  for (let i = 0; i < MAX_SELECTOR_ANCESTORS; i++) {
+    current = current.parentElement;
+    if (!current || SELECTOR_BOUNDARY_TAGS.has(current.tagName)) break;
+    parts.unshift(describeElement(current));
+    if (current.id) break;
+  }
+
+  return truncateSelector(parts.join(" > "));
+}
+
+function truncateSelector(selector: string): string {
+  return selector.length > MAX_SELECTOR_LENGTH ? selector.substring(0, MAX_SELECTOR_LENGTH) : selector;
+}
+
+function describeElement(element: Element): string {
+  const tag = element.tagName.toLowerCase();
+  if (element.id) {
+    return `${tag}#${element.id}`;
+  }
+  const firstClass = element.classList.item(0);
+  return firstClass ? `${tag}.${firstClass}` : tag;
+}

--- a/src/instrumentations/interactions/index.ts
+++ b/src/instrumentations/interactions/index.ts
@@ -6,13 +6,15 @@ import { startChangeInstrumentation } from "./change";
 
 export function startInteractionInstrumentation() {
   startClickInstrumentation();
-  if (vars.interactionInstrumentation.captureScrolls !== false) {
+  // Scroll/key-press/change capture are individually opt-in: enabling
+  // interaction instrumentation alone only captures clicks.
+  if (vars.interactionInstrumentation.captureScrolls === true) {
     startScrollInstrumentation();
   }
-  if (vars.interactionInstrumentation.captureKeyPresses !== false) {
+  if (vars.interactionInstrumentation.captureKeyPresses === true) {
     startKeyPressInstrumentation();
   }
-  if (vars.interactionInstrumentation.captureChanges !== false) {
+  if (vars.interactionInstrumentation.captureChanges === true) {
     startChangeInstrumentation();
   }
 }

--- a/src/instrumentations/interactions/index.ts
+++ b/src/instrumentations/interactions/index.ts
@@ -1,0 +1,3 @@
+export function startInteractionInstrumentation() {
+  // Implemented in Task 5 (click.ts composition).
+}

--- a/src/instrumentations/interactions/index.ts
+++ b/src/instrumentations/interactions/index.ts
@@ -1,3 +1,5 @@
+import { startClickInstrumentation } from "./click";
+
 export function startInteractionInstrumentation() {
-  // Implemented in Task 5 (click.ts composition).
+  startClickInstrumentation();
 }

--- a/src/instrumentations/interactions/index.ts
+++ b/src/instrumentations/interactions/index.ts
@@ -1,5 +1,18 @@
+import { vars } from "../../vars";
 import { startClickInstrumentation } from "./click";
+import { startScrollInstrumentation } from "./scroll";
+import { startKeyPressInstrumentation } from "./keypress";
+import { startChangeInstrumentation } from "./change";
 
 export function startInteractionInstrumentation() {
   startClickInstrumentation();
+  if (vars.interactionInstrumentation.captureScrolls !== false) {
+    startScrollInstrumentation();
+  }
+  if (vars.interactionInstrumentation.captureKeyPresses !== false) {
+    startKeyPressInstrumentation();
+  }
+  if (vars.interactionInstrumentation.captureChanges !== false) {
+    startChangeInstrumentation();
+  }
 }

--- a/src/instrumentations/interactions/index_test.ts
+++ b/src/instrumentations/interactions/index_test.ts
@@ -1,16 +1,56 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { vars } from "../../vars";
 
 vi.mock("./click", () => ({
   startClickInstrumentation: vi.fn(),
 }));
+vi.mock("./scroll", () => ({
+  startScrollInstrumentation: vi.fn(),
+}));
+vi.mock("./keypress", () => ({
+  startKeyPressInstrumentation: vi.fn(),
+}));
+vi.mock("./change", () => ({
+  startChangeInstrumentation: vi.fn(),
+}));
 
 import { startInteractionInstrumentation } from "./index";
 import { startClickInstrumentation } from "./click";
+import { startScrollInstrumentation } from "./scroll";
+import { startKeyPressInstrumentation } from "./keypress";
+import { startChangeInstrumentation } from "./change";
 
 describe("startInteractionInstrumentation", () => {
-  it("starts click instrumentation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vars.interactionInstrumentation = {
+      enabled: true,
+      actionNameAttribute: "data-dash0-action-name",
+      captureScrolls: true,
+      captureKeyPresses: true,
+      captureChanges: true,
+    };
+  });
+
+  it("starts all four interaction instrumentations by default", () => {
     startInteractionInstrumentation();
 
     expect(startClickInstrumentation).toHaveBeenCalledOnce();
+    expect(startScrollInstrumentation).toHaveBeenCalledOnce();
+    expect(startKeyPressInstrumentation).toHaveBeenCalledOnce();
+    expect(startChangeInstrumentation).toHaveBeenCalledOnce();
+  });
+
+  it("honors the capture* opt-outs while clicks stay on", () => {
+    vars.interactionInstrumentation.captureScrolls = false;
+    vars.interactionInstrumentation.captureKeyPresses = false;
+    vars.interactionInstrumentation.captureChanges = false;
+
+    startInteractionInstrumentation();
+
+    expect(startClickInstrumentation).toHaveBeenCalledOnce();
+    expect(startScrollInstrumentation).not.toHaveBeenCalled();
+    expect(startKeyPressInstrumentation).not.toHaveBeenCalled();
+    expect(startChangeInstrumentation).not.toHaveBeenCalled();
   });
 });

--- a/src/instrumentations/interactions/index_test.ts
+++ b/src/instrumentations/interactions/index_test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("./click", () => ({
+  startClickInstrumentation: vi.fn(),
+}));
+
+import { startInteractionInstrumentation } from "./index";
+import { startClickInstrumentation } from "./click";
+
+describe("startInteractionInstrumentation", () => {
+  it("starts click instrumentation", () => {
+    startInteractionInstrumentation();
+
+    expect(startClickInstrumentation).toHaveBeenCalledOnce();
+  });
+});

--- a/src/instrumentations/interactions/index_test.ts
+++ b/src/instrumentations/interactions/index_test.ts
@@ -26,13 +26,26 @@ describe("startInteractionInstrumentation", () => {
     vars.interactionInstrumentation = {
       enabled: true,
       actionNameAttribute: "data-dash0-action-name",
-      captureScrolls: true,
-      captureKeyPresses: true,
-      captureChanges: true,
+      captureScrolls: false,
+      captureKeyPresses: false,
+      captureChanges: false,
     };
   });
 
-  it("starts all four interaction instrumentations by default", () => {
+  it("starts only click instrumentation by default", () => {
+    startInteractionInstrumentation();
+
+    expect(startClickInstrumentation).toHaveBeenCalledOnce();
+    expect(startScrollInstrumentation).not.toHaveBeenCalled();
+    expect(startKeyPressInstrumentation).not.toHaveBeenCalled();
+    expect(startChangeInstrumentation).not.toHaveBeenCalled();
+  });
+
+  it("starts scroll/key-press/change capture when opted in", () => {
+    vars.interactionInstrumentation.captureScrolls = true;
+    vars.interactionInstrumentation.captureKeyPresses = true;
+    vars.interactionInstrumentation.captureChanges = true;
+
     startInteractionInstrumentation();
 
     expect(startClickInstrumentation).toHaveBeenCalledOnce();
@@ -41,10 +54,11 @@ describe("startInteractionInstrumentation", () => {
     expect(startChangeInstrumentation).toHaveBeenCalledOnce();
   });
 
-  it("honors the capture* opt-outs while clicks stay on", () => {
-    vars.interactionInstrumentation.captureScrolls = false;
-    vars.interactionInstrumentation.captureKeyPresses = false;
-    vars.interactionInstrumentation.captureChanges = false;
+  it("does not start the extra capture types when the flags are absent", () => {
+    vars.interactionInstrumentation = {
+      enabled: true,
+      actionNameAttribute: "data-dash0-action-name",
+    };
 
     startInteractionInstrumentation();
 

--- a/src/instrumentations/interactions/keypress.ts
+++ b/src/instrumentations/interactions/keypress.ts
@@ -1,4 +1,4 @@
-import { win } from "../../utils";
+import { generateUniqueId, win, WEB_EVENT_ID_BYTES } from "../../utils";
 import { debug } from "../../utils/debug";
 import { addAttribute } from "../../utils/otel";
 import { INTERACTION_KEY } from "../../semantic-conventions";
@@ -30,6 +30,16 @@ const CAPTURED_KEYS = new Set([
   "Home",
   "End",
 ]);
+
+/**
+ * Only these keys register for HTTP span attribution: Enter and Space are the
+ * keys that activate a control or submit a form, so a request that follows is
+ * plausibly caused by them. Navigation keys (arrows, Tab, PageUp/Down, ...)
+ * still emit an interaction event but must not claim the active-interaction
+ * slot -- arrowing through a list would steal attribution from a real click
+ * or stamp unrelated background requests.
+ */
+const ACTIVATION_KEYS = new Set(["Enter", " "]);
 
 let listenerAttached = false;
 
@@ -68,9 +78,12 @@ export function handleKeydown(event: KeyboardEvent): void {
     const key = event.key === " " ? "Space" : event.key;
     const { name, nameSource } = deriveActionName(element, vars.interactionInstrumentation.actionNameAttribute!);
 
-    // Enter/Space frequently activate a control or submit a form, so register
-    // the interaction for HTTP span attribution just like a click.
-    const interaction = registerActiveInteraction(name);
+    // Enter/Space activate a control or submit a form, so they register for
+    // HTTP span attribution just like a click; navigation keys only get an
+    // event id of their own (see ACTIVATION_KEYS).
+    const id = ACTIVATION_KEYS.has(event.key)
+      ? registerActiveInteraction(name).id
+      : generateUniqueId(WEB_EVENT_ID_BYTES);
 
     const extraAttributes: KeyValue[] = [];
     addAttribute(extraAttributes, INTERACTION_KEY, key);
@@ -80,7 +93,7 @@ export function handleKeydown(event: KeyboardEvent): void {
       // Press Enter in "Search parts" on /inventory/parts
       // Press Escape on /playground              (no derivable target name)
       title: name ? `Press ${key} in "${name}" on ${pagePath()}` : `Press ${key} on ${pagePath()}`,
-      id: interaction.id,
+      id,
       name,
       nameSource,
       element,

--- a/src/instrumentations/interactions/keypress.ts
+++ b/src/instrumentations/interactions/keypress.ts
@@ -1,0 +1,92 @@
+import { win } from "../../utils";
+import { debug } from "../../utils/debug";
+import { addAttribute } from "../../utils/otel";
+import { INTERACTION_KEY } from "../../semantic-conventions";
+import { KeyValue } from "../../types/otlp";
+import { vars } from "../../vars";
+import { deriveActionName } from "./action-name";
+import { registerActiveInteraction } from "./active-interaction";
+import { emitInteractionEvent, pagePath } from "./emit";
+
+/**
+ * Only these navigation/activation keys are ever captured. Printable
+ * characters (letters, digits, punctuation) are deliberately excluded --
+ * capturing them would amount to keylogging. This is an allow-list, not a
+ * block-list, so anything unknown is dropped by default.
+ */
+const CAPTURED_KEYS = new Set([
+  "Enter",
+  "Tab",
+  "Escape",
+  " ", // reported as "Space"
+  "ArrowUp",
+  "ArrowDown",
+  "ArrowLeft",
+  "ArrowRight",
+  "Backspace",
+  "Delete",
+  "PageUp",
+  "PageDown",
+  "Home",
+  "End",
+]);
+
+let listenerAttached = false;
+
+function onWindowKeydown(event: KeyboardEvent) {
+  if (!event.isTrusted) return;
+  handleKeydown(event);
+}
+
+export function startKeyPressInstrumentation() {
+  if (listenerAttached) return;
+  if (!win) return;
+
+  win.addEventListener("keydown", onWindowKeydown as EventListener, { capture: true });
+  listenerAttached = true;
+}
+
+export function stopKeyPressInstrumentationForTests() {
+  if (!listenerAttached || !win) return;
+  win.removeEventListener("keydown", onWindowKeydown as EventListener, { capture: true } as EventListenerOptions);
+  listenerAttached = false;
+}
+
+/**
+ * Exported for tests (bypasses the isTrusted gate, same pattern as
+ * click.ts/handleClick).
+ */
+export function handleKeydown(event: KeyboardEvent): void {
+  try {
+    if (event.repeat) return; // holding a key down is one interaction, not many
+    if (!CAPTURED_KEYS.has(event.key)) return;
+
+    const target = event.target;
+    if (!target || (target as Node).nodeType !== 1) return;
+    const element = target as Element;
+
+    const key = event.key === " " ? "Space" : event.key;
+    const { name, nameSource } = deriveActionName(element, vars.interactionInstrumentation.actionNameAttribute!);
+
+    // Enter/Space frequently activate a control or submit a form, so register
+    // the interaction for HTTP span attribution just like a click.
+    const interaction = registerActiveInteraction(name);
+
+    const extraAttributes: KeyValue[] = [];
+    addAttribute(extraAttributes, INTERACTION_KEY, key);
+
+    emitInteractionEvent({
+      type: "key_press",
+      // Press Enter in "Search parts" on /inventory/parts
+      // Press Escape on /playground              (no derivable target name)
+      title: name ? `Press ${key} in "${name}" on ${pagePath()}` : `Press ${key} on ${pagePath()}`,
+      id: interaction.id,
+      name,
+      nameSource,
+      element,
+      extraAttributes,
+    });
+  } catch (err) {
+    debug("Dash0 interaction instrumentation failed to process a keydown event.", err);
+  }
+}

--- a/src/instrumentations/interactions/keypress_test.ts
+++ b/src/instrumentations/interactions/keypress_test.ts
@@ -85,13 +85,50 @@ describe("key press instrumentation", () => {
     expect(sendLog).toHaveBeenCalledOnce();
   });
 
-  it("registers the key press as the active interaction for span attribution", () => {
+  it("registers Enter as the active interaction for span attribution", () => {
     dom.body.innerHTML = `<input id="q" aria-label="Search parts" />`;
 
     handleKeydown(keydownOn(dom.getElementById("q")!, "Enter"));
 
     const active = getActiveInteraction();
     expect(active).toBeDefined();
+    expect(active!.name).toBe("Search parts");
+  });
+
+  it("registers Space as the active interaction for span attribution", () => {
+    dom.body.innerHTML = `<button id="b" aria-label="Play"></button>`;
+
+    handleKeydown(keydownOn(dom.getElementById("b")!, " "));
+
+    const active = getActiveInteraction();
+    expect(active).toBeDefined();
+    expect(active!.name).toBe("Play");
+  });
+
+  it("does NOT register navigation keys for span attribution (but still emits their events)", () => {
+    dom.body.innerHTML = `<div id="list" tabindex="0" aria-label="Results"></div>`;
+    const list = dom.getElementById("list")!;
+
+    for (const key of ["ArrowDown", "Tab", "Escape", "PageDown", "Home", "Backspace"]) {
+      handleKeydown(keydownOn(list, key));
+      expect(getActiveInteraction()).toBeUndefined();
+    }
+
+    expect(sendLog).toHaveBeenCalledTimes(6);
+  });
+
+  it("a navigation key does not steal attribution from a preceding activation", () => {
+    dom.body.innerHTML = `<input id="q" aria-label="Search parts" />`;
+    const input = dom.getElementById("q")!;
+
+    handleKeydown(keydownOn(input, "Enter"));
+    const registered = getActiveInteraction()!;
+
+    handleKeydown(keydownOn(input, "ArrowDown"));
+
+    const active = getActiveInteraction();
+    expect(active).toBeDefined();
+    expect(active!.id).toBe(registered.id);
     expect(active!.name).toBe("Search parts");
   });
 });

--- a/src/instrumentations/interactions/keypress_test.ts
+++ b/src/instrumentations/interactions/keypress_test.ts
@@ -1,0 +1,97 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { vars } from "../../vars";
+import { sendLog } from "../../transport";
+import { doc } from "../../utils/globals";
+import { INTERACTION_KEY, INTERACTION_TYPE } from "../../semantic-conventions";
+import type { LogRecord } from "../../types/otlp";
+
+vi.mock("../../transport", () => ({
+  sendLog: vi.fn(),
+}));
+
+import { handleKeydown } from "./keypress";
+import { clearActiveInteractionForTests, getActiveInteraction } from "./active-interaction";
+
+const dom = doc!;
+
+function keydownOn(el: Element, key: string, repeat = false): KeyboardEvent {
+  const event = new KeyboardEvent("keydown", { key, repeat, bubbles: true });
+  Object.defineProperty(event, "target", { value: el });
+  return event;
+}
+
+function lastLog(): LogRecord {
+  const calls = (sendLog as ReturnType<typeof vi.fn>).mock.calls;
+  expect(calls.length).toBeGreaterThan(0);
+  return calls[calls.length - 1]![0] as LogRecord;
+}
+
+function attr(log: LogRecord, key: string) {
+  return (log.attributes as { key: string; value: Record<string, unknown> }[]).find((kv) => kv.key === key)?.value;
+}
+
+describe("key press instrumentation", () => {
+  beforeEach(() => {
+    dom.body.innerHTML = "";
+    vars.interactionInstrumentation = { enabled: true, actionNameAttribute: "data-dash0-action-name" };
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    clearActiveInteractionForTests();
+    vi.clearAllMocks();
+  });
+
+  it("captures Enter with the target's derived name", () => {
+    dom.body.innerHTML = `<input id="search" type="text" aria-label="Search parts" />`;
+
+    handleKeydown(keydownOn(dom.getElementById("search")!, "Enter"));
+
+    const log = lastLog();
+    expect(log.body).toEqual({ stringValue: 'Press Enter in "Search parts" on /' });
+    expect(attr(log, INTERACTION_KEY)).toEqual({ stringValue: "Enter" });
+    expect(attr(log, INTERACTION_TYPE)).toEqual({ stringValue: "key_press" });
+  });
+
+  it("normalizes the space key to a readable name", () => {
+    dom.body.innerHTML = `<button id="b">Play</button>`;
+
+    handleKeydown(keydownOn(dom.getElementById("b")!, " "));
+
+    const log = lastLog();
+    expect(attr(log, INTERACTION_KEY)).toEqual({ stringValue: "Space" });
+    expect(log.body).toEqual({ stringValue: 'Press Space in "Play" on /' });
+  });
+
+  it("NEVER captures printable characters (no keylogging)", () => {
+    dom.body.innerHTML = `<input id="pw" type="password" aria-label="Password" />`;
+    const input = dom.getElementById("pw")!;
+
+    for (const key of ["a", "Z", "1", "!", "ü", "€"]) {
+      handleKeydown(keydownOn(input, key));
+    }
+
+    expect(sendLog).not.toHaveBeenCalled();
+  });
+
+  it("ignores auto-repeat from a held-down key", () => {
+    dom.body.innerHTML = `<div id="list" tabindex="0"></div>`;
+    const list = dom.getElementById("list")!;
+
+    handleKeydown(keydownOn(list, "ArrowDown", false));
+    handleKeydown(keydownOn(list, "ArrowDown", true));
+    handleKeydown(keydownOn(list, "ArrowDown", true));
+
+    expect(sendLog).toHaveBeenCalledOnce();
+  });
+
+  it("registers the key press as the active interaction for span attribution", () => {
+    dom.body.innerHTML = `<input id="q" aria-label="Search parts" />`;
+
+    handleKeydown(keydownOn(dom.getElementById("q")!, "Enter"));
+
+    const active = getActiveInteraction();
+    expect(active).toBeDefined();
+    expect(active!.name).toBe("Search parts");
+  });
+});

--- a/src/instrumentations/interactions/scroll.ts
+++ b/src/instrumentations/interactions/scroll.ts
@@ -1,0 +1,151 @@
+import { doc, generateUniqueId, win, WEB_EVENT_ID_BYTES } from "../../utils";
+import { debug } from "../../utils/debug";
+import { setTimeout, clearTimeout } from "../../utils/timers";
+import { addAttribute } from "../../utils/otel";
+import { INTERACTION_DIRECTION } from "../../semantic-conventions";
+import { KeyValue } from "../../types/otlp";
+import { emitInteractionEvent, pagePath } from "./emit";
+
+/**
+ * Scroll events fire per frame, so emitting one telemetry event per DOM event
+ * would be pure noise. Instead a contiguous burst of scrolling is collapsed
+ * into ONE `browser.interaction` (type "scroll"): the burst starts on the
+ * first scroll event, and finalizes after SCROLL_SETTLE_MILLIS without
+ * further scrolling. The emitted direction is derived from the net position
+ * delta over the whole burst.
+ */
+const SCROLL_SETTLE_MILLIS = 300;
+
+/**
+ * Net movement (px) below which a burst is dropped entirely -- sub-pixel and
+ * micro-scrolls (trackpad jitter, momentum tails) are not meaningful user
+ * interactions.
+ */
+const MIN_SCROLL_DELTA_PX = 8;
+
+type ScrollBurst = {
+  element: Element;
+  startX: number;
+  startY: number;
+  settleTimeout: ReturnType<typeof setTimeout> | null;
+};
+
+let listenerAttached = false;
+let burst: ScrollBurst | undefined;
+
+function onWindowScroll(event: Event) {
+  if (!event.isTrusted) return;
+  handleScroll(event);
+}
+
+export function startScrollInstrumentation() {
+  if (listenerAttached) return;
+  if (!win) return;
+
+  // Capture phase on window sees both document scrolling and scrolling of
+  // nested overflow containers (scroll does not bubble, but capture works).
+  win.addEventListener("scroll", onWindowScroll, { capture: true, passive: true } as AddEventListenerOptions);
+  listenerAttached = true;
+}
+
+export function stopScrollInstrumentationForTests() {
+  if (!listenerAttached || !win) return;
+  win.removeEventListener("scroll", onWindowScroll, { capture: true } as EventListenerOptions);
+  if (burst?.settleTimeout != null) clearTimeout(burst.settleTimeout);
+  burst = undefined;
+  listenerAttached = false;
+}
+
+/** Resolves the scrolled element plus its current scroll position. */
+function scrollStateFor(event: Event): { element: Element; x: number; y: number } | undefined {
+  const target = event.target;
+
+  // Scrolling the page itself reports the document (or window) as target.
+  if (!target || target === doc || target === win) {
+    const root = doc?.scrollingElement ?? doc?.documentElement;
+    if (!root) return undefined;
+    return { element: root, x: win?.scrollX ?? root.scrollLeft, y: win?.scrollY ?? root.scrollTop };
+  }
+
+  if ((target as Node).nodeType !== 1) return undefined;
+  const element = target as Element;
+  return { element, x: element.scrollLeft, y: element.scrollTop };
+}
+
+/**
+ * Exported for tests (bypasses the isTrusted gate, same pattern as
+ * click.ts/handleClick).
+ */
+export function handleScroll(event: Event): void {
+  try {
+    const state = scrollStateFor(event);
+    if (!state) return;
+
+    if (!burst) {
+      burst = {
+        element: state.element,
+        startX: state.x,
+        startY: state.y,
+        settleTimeout: null,
+      };
+    } else if (burst.settleTimeout != null) {
+      clearTimeout(burst.settleTimeout);
+    }
+
+    // The burst tracks the element it started on; scrolls of other elements
+    // during the settle window just keep the burst alive.
+    burst.settleTimeout = setTimeout(() => finalizeBurst(), SCROLL_SETTLE_MILLIS);
+  } catch (err) {
+    debug("Dash0 interaction instrumentation failed to process a scroll event.", err);
+  }
+}
+
+function finalizeBurst(): void {
+  const finished = burst;
+  burst = undefined;
+  if (!finished) return;
+
+  try {
+    const element = finished.element;
+    const endX =
+      element === (doc?.scrollingElement ?? doc?.documentElement)
+        ? (win?.scrollX ?? element.scrollLeft)
+        : element.scrollLeft;
+    const endY =
+      element === (doc?.scrollingElement ?? doc?.documentElement)
+        ? (win?.scrollY ?? element.scrollTop)
+        : element.scrollTop;
+
+    const deltaX = endX - finished.startX;
+    const deltaY = endY - finished.startY;
+
+    if (Math.abs(deltaX) < MIN_SCROLL_DELTA_PX && Math.abs(deltaY) < MIN_SCROLL_DELTA_PX) {
+      return; // micro-scroll, not a meaningful interaction
+    }
+
+    const direction =
+      Math.abs(deltaY) >= Math.abs(deltaX) ? (deltaY > 0 ? "down" : "up") : deltaX > 0 ? "right" : "left";
+
+    const extraAttributes: KeyValue[] = [];
+    addAttribute(extraAttributes, INTERACTION_DIRECTION, direction);
+
+    emitInteractionEvent({
+      type: "scroll",
+      // Scroll down on /inventory/parts
+      title: `Scroll ${direction} on ${pagePath()}`,
+      id: generateUniqueId(WEB_EVENT_ID_BYTES),
+      name: "",
+      nameSource: "blank",
+      element,
+      extraAttributes,
+    });
+  } catch (err) {
+    debug("Dash0 interaction instrumentation failed to finalize a scroll burst.", err);
+  }
+}
+
+/** Test-only: force-finalize the in-flight burst without waiting for the settle timer. */
+export function flushScrollBurstForTests(): void {
+  if (burst?.settleTimeout != null) clearTimeout(burst.settleTimeout);
+  finalizeBurst();
+}

--- a/src/instrumentations/interactions/scroll_test.ts
+++ b/src/instrumentations/interactions/scroll_test.ts
@@ -1,0 +1,108 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { vars } from "../../vars";
+import { sendLog } from "../../transport";
+import { doc } from "../../utils/globals";
+import { INTERACTION_DIRECTION, INTERACTION_TYPE } from "../../semantic-conventions";
+import type { LogRecord } from "../../types/otlp";
+
+vi.mock("../../transport", () => ({
+  sendLog: vi.fn(),
+}));
+
+import { handleScroll, flushScrollBurstForTests, stopScrollInstrumentationForTests } from "./scroll";
+
+const dom = doc!;
+
+function scrollEventFor(el: Element): Event {
+  const event = new Event("scroll", { bubbles: false });
+  Object.defineProperty(event, "target", { value: el });
+  return event;
+}
+
+function lastLog(): LogRecord {
+  const calls = (sendLog as ReturnType<typeof vi.fn>).mock.calls;
+  expect(calls.length).toBeGreaterThan(0);
+  return calls[calls.length - 1]![0] as LogRecord;
+}
+
+function attr(log: LogRecord, key: string) {
+  return (log.attributes as { key: string; value: Record<string, unknown> }[]).find((kv) => kv.key === key)?.value;
+}
+
+/** jsdom elements have scrollTop/scrollLeft as plain settable properties. */
+function scrollable(): HTMLElement {
+  dom.body.innerHTML = `<div id="pane" class="pane" style="overflow:auto;height:100px"></div>`;
+  return dom.getElementById("pane")!;
+}
+
+describe("scroll instrumentation", () => {
+  beforeEach(() => {
+    vars.interactionInstrumentation = { enabled: true, actionNameAttribute: "data-dash0-action-name" };
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    stopScrollInstrumentationForTests();
+    vi.clearAllMocks();
+  });
+
+  it("collapses a burst of scroll events into a single event with the net direction", () => {
+    const pane = scrollable();
+
+    pane.scrollTop = 0;
+    handleScroll(scrollEventFor(pane));
+    pane.scrollTop = 40;
+    handleScroll(scrollEventFor(pane));
+    pane.scrollTop = 120;
+    handleScroll(scrollEventFor(pane));
+
+    flushScrollBurstForTests();
+
+    expect(sendLog).toHaveBeenCalledOnce();
+    const log = lastLog();
+    expect(log.body).toEqual({ stringValue: "Scroll down on /" });
+    expect(attr(log, INTERACTION_DIRECTION)).toEqual({ stringValue: "down" });
+    expect(attr(log, INTERACTION_TYPE)).toEqual({ stringValue: "scroll" });
+  });
+
+  it("reports upward scrolling", () => {
+    const pane = scrollable();
+
+    pane.scrollTop = 200;
+    handleScroll(scrollEventFor(pane));
+    pane.scrollTop = 20;
+    handleScroll(scrollEventFor(pane));
+
+    flushScrollBurstForTests();
+
+    const log = lastLog();
+    expect(log.body).toEqual({ stringValue: "Scroll up on /" });
+    expect(attr(log, INTERACTION_DIRECTION)).toEqual({ stringValue: "up" });
+  });
+
+  it("drops micro-scrolls below the noise threshold", () => {
+    const pane = scrollable();
+
+    pane.scrollTop = 100;
+    handleScroll(scrollEventFor(pane));
+    pane.scrollTop = 103; // 3px net movement
+    handleScroll(scrollEventFor(pane));
+
+    flushScrollBurstForTests();
+
+    expect(sendLog).not.toHaveBeenCalled();
+  });
+
+  it("emits nothing while a burst is still in flight", () => {
+    const pane = scrollable();
+
+    pane.scrollTop = 0;
+    handleScroll(scrollEventFor(pane));
+    pane.scrollTop = 500;
+    handleScroll(scrollEventFor(pane));
+
+    expect(sendLog).not.toHaveBeenCalled(); // settle timer still pending
+    flushScrollBurstForTests();
+    expect(sendLog).toHaveBeenCalledOnce();
+  });
+});

--- a/src/instrumentations/navigation/event.ts
+++ b/src/instrumentations/navigation/event.ts
@@ -11,6 +11,8 @@ import {
 import { doc, NO_VALUE_FALLBACK } from "../../utils";
 import { addCommonAttributes } from "../../attributes";
 import { sendLog } from "../../transport";
+import { AttributeValueType } from "../../utils/otel";
+import { AnyValue } from "../../types/otlp";
 import { PageViewMeta, vars } from "../../vars";
 import { KeyValue, LogRecord } from "../../types/otlp";
 
@@ -20,32 +22,37 @@ function getPageViewMeta(url?: URL): PageViewMeta {
   return vars.pageViewInstrumentation.generateMetadata?.(url) ?? {};
 }
 
-export function transmitPageViewEvent(timeUnixNano: string, url?: URL, virtual?: boolean, replaced?: boolean) {
-  const meta = getPageViewMeta(url);
+type BuildPageViewLogOptions = {
+  timeUnixNano: string;
+  url?: URL;
+  title?: string;
+  metaAttributes?: Record<string, AttributeValueType | AnyValue>;
+  pageViewType: number;
+  changeState?: string;
+};
 
+function buildAndSendPageViewLog(opts: BuildPageViewLogOptions) {
   const attributes: KeyValue[] = [];
   addAttribute(attributes, EVENT_NAME, EVENT_NAMES.PAGE_VIEW);
 
-  if (meta.attributes) {
-    Object.entries(meta.attributes).forEach(([key, value]) => addAttribute(attributes, key, value));
+  if (opts.metaAttributes) {
+    Object.entries(opts.metaAttributes).forEach(([key, value]) => addAttribute(attributes, key, value));
   }
-  addCommonAttributes(attributes, { url });
+  addCommonAttributes(attributes, { url: opts.url });
 
   const bodyAttributes: KeyValue[] = [];
-  addAttribute(bodyAttributes, "title", meta.title ?? doc?.title ?? NO_VALUE_FALLBACK);
+  addAttribute(bodyAttributes, "title", opts.title ?? doc?.title ?? NO_VALUE_FALLBACK);
   if (doc?.referrer) {
     addAttribute(bodyAttributes, "referrer", doc.referrer);
   }
 
-  addAttribute(bodyAttributes, PAGE_VIEW_TYPE, virtual ? PAGE_VIEW_TYPE_VALUES.VIRTUAL : PAGE_VIEW_TYPE_VALUES.INITIAL);
-  addAttribute(
-    bodyAttributes,
-    PAGE_VIEW_CHANGE_STATE,
-    replaced ? PAGE_VIEW_CHANGE_STATE_VALUES.REPLACE : PAGE_VIEW_CHANGE_STATE_VALUES.PUSH
-  );
+  addAttribute(bodyAttributes, PAGE_VIEW_TYPE, opts.pageViewType);
+  if (opts.changeState) {
+    addAttribute(bodyAttributes, PAGE_VIEW_CHANGE_STATE, opts.changeState);
+  }
 
   const log: LogRecord = {
-    timeUnixNano: timeUnixNano,
+    timeUnixNano: opts.timeUnixNano,
     attributes: attributes,
     severityNumber: LOG_SEVERITIES.INFO,
     severityText: "INFO",
@@ -63,4 +70,41 @@ export function transmitPageViewEvent(timeUnixNano: string, url?: URL, virtual?:
   }
 
   sendLog(log);
+}
+
+export function transmitPageViewEvent(timeUnixNano: string, url?: URL, virtual?: boolean, replaced?: boolean) {
+  const meta = getPageViewMeta(url);
+
+  buildAndSendPageViewLog({
+    timeUnixNano,
+    url,
+    title: meta.title,
+    metaAttributes: meta.attributes,
+    pageViewType: virtual ? PAGE_VIEW_TYPE_VALUES.VIRTUAL : PAGE_VIEW_TYPE_VALUES.INITIAL,
+    changeState: replaced ? PAGE_VIEW_CHANGE_STATE_VALUES.REPLACE : PAGE_VIEW_CHANGE_STATE_VALUES.PUSH,
+  });
+}
+
+export type ManualPageViewOptions = {
+  timeUnixNano: string;
+  url?: URL;
+  title: string;
+  attributes?: Record<string, AttributeValueType | AnyValue>;
+};
+
+/**
+ * Emits a manually-triggered page view log, e.g. from the public `startView` API.
+ * Deliberately does NOT read `vars.pageViewInstrumentation.generateMetadata` and does NOT
+ * include a `change_state` body key (a manual view is neither a pushState nor replaceState).
+ * The emitted `type` is PAGE_VIEW_TYPE_VALUES.VIRTUAL, matching automatic virtual page views —
+ * manual views are deliberately indistinguishable from virtual ones downstream.
+ */
+export function transmitManualPageViewEvent(opts: ManualPageViewOptions) {
+  buildAndSendPageViewLog({
+    timeUnixNano: opts.timeUnixNano,
+    url: opts.url,
+    title: opts.title,
+    metaAttributes: opts.attributes,
+    pageViewType: PAGE_VIEW_TYPE_VALUES.VIRTUAL,
+  });
 }

--- a/src/instrumentations/navigation/event_test.ts
+++ b/src/instrumentations/navigation/event_test.ts
@@ -1,0 +1,73 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { KeyValue, LogRecord } from "../../types/otlp";
+
+vi.mock("../../transport", () => ({
+  sendLog: vi.fn(),
+}));
+
+import { sendLog } from "../../transport";
+import { transmitPageViewEvent } from "./event";
+import { vars } from "../../vars";
+
+const sendLogMock = sendLog as unknown as ReturnType<typeof vi.fn>;
+
+describe("transmitPageViewEvent", () => {
+  beforeEach(() => {
+    sendLogMock.mockClear();
+    vars.pageViewInstrumentation = { trackVirtualPageViews: true, includeParts: [] };
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("transmits an initial page view with type=INITIAL and change_state=pushState", () => {
+    transmitPageViewEvent("1700000000000000000", new URL("https://example.com/landing"));
+
+    expect(sendLogMock).toHaveBeenCalledTimes(1);
+    const log = sendLogMock.mock.calls[0]![0] as LogRecord;
+
+    expect(log.timeUnixNano).toBe("1700000000000000000");
+    expect(log.severityNumber).toBe(9);
+    expect(log.severityText).toBe("INFO");
+    expect(log.attributes).toEqual(
+      expect.arrayContaining([{ key: "event.name", value: { stringValue: "browser.page_view" } }])
+    );
+
+    const bodyValues = log.body?.kvlistValue?.values as KeyValue[];
+    expect(bodyValues).toEqual(
+      expect.arrayContaining([
+        { key: "type", value: { doubleValue: 0 } },
+        { key: "change_state", value: { stringValue: "pushState" } },
+      ])
+    );
+  });
+
+  it("transmits a virtual page view with type=VIRTUAL and change_state=replaceState when replaced", () => {
+    transmitPageViewEvent("1700000000000000000", new URL("https://example.com/settings"), true, true);
+
+    const log = sendLogMock.mock.calls[0]![0] as LogRecord;
+    const bodyValues = log.body?.kvlistValue?.values as KeyValue[];
+    expect(bodyValues).toEqual(
+      expect.arrayContaining([
+        { key: "type", value: { doubleValue: 1 } },
+        { key: "change_state", value: { stringValue: "replaceState" } },
+      ])
+    );
+  });
+
+  it("applies generateMetadata title and attributes when provided", () => {
+    vars.pageViewInstrumentation = {
+      trackVirtualPageViews: true,
+      includeParts: [],
+      generateMetadata: () => ({ title: "Custom Title", attributes: { "app.screen": "settings" } }),
+    };
+
+    transmitPageViewEvent("1700000000000000000", new URL("https://example.com/settings"), true);
+
+    const log = sendLogMock.mock.calls[0]![0] as LogRecord;
+    expect(log.attributes).toEqual(expect.arrayContaining([{ key: "app.screen", value: { stringValue: "settings" } }]));
+    const bodyValues = log.body?.kvlistValue?.values as KeyValue[];
+    expect(bodyValues).toEqual(expect.arrayContaining([{ key: "title", value: { stringValue: "Custom Title" } }]));
+  });
+});

--- a/src/instrumentations/navigation/event_test.ts
+++ b/src/instrumentations/navigation/event_test.ts
@@ -84,6 +84,7 @@ describe("transmitManualPageViewEvent", () => {
 
   afterEach(() => {
     vi.clearAllMocks();
+    vars.pageViewInstrumentation = { trackVirtualPageViews: true, includeParts: [] };
   });
 
   it("emits type=VIRTUAL and no change_state key", () => {

--- a/src/instrumentations/navigation/event_test.ts
+++ b/src/instrumentations/navigation/event_test.ts
@@ -6,7 +6,7 @@ vi.mock("../../transport", () => ({
 }));
 
 import { sendLog } from "../../transport";
-import { transmitPageViewEvent } from "./event";
+import { transmitPageViewEvent, transmitManualPageViewEvent } from "./event";
 import { vars } from "../../vars";
 
 const sendLogMock = sendLog as unknown as ReturnType<typeof vi.fn>;
@@ -69,5 +69,85 @@ describe("transmitPageViewEvent", () => {
     expect(log.attributes).toEqual(expect.arrayContaining([{ key: "app.screen", value: { stringValue: "settings" } }]));
     const bodyValues = log.body?.kvlistValue?.values as KeyValue[];
     expect(bodyValues).toEqual(expect.arrayContaining([{ key: "title", value: { stringValue: "Custom Title" } }]));
+  });
+});
+
+describe("transmitManualPageViewEvent", () => {
+  beforeEach(() => {
+    sendLogMock.mockClear();
+    vars.pageViewInstrumentation = {
+      trackVirtualPageViews: true,
+      includeParts: [],
+      generateMetadata: () => ({ title: "should not be used", attributes: { should_not_appear: true } }),
+    };
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("emits type=VIRTUAL and no change_state key", () => {
+    transmitManualPageViewEvent({ timeUnixNano: "1700000000000000000", title: "/settings" });
+
+    const log = sendLogMock.mock.calls[0]![0] as LogRecord;
+    const bodyValues = log.body?.kvlistValue?.values as KeyValue[];
+
+    expect(bodyValues).toEqual(
+      expect.arrayContaining([
+        { key: "type", value: { doubleValue: 1 } },
+        { key: "title", value: { stringValue: "/settings" } },
+      ])
+    );
+    expect(bodyValues.find((v) => v.key === "change_state")).toBeUndefined();
+  });
+
+  it("does not invoke vars.pageViewInstrumentation.generateMetadata", () => {
+    const generateMetadata = vi.fn().mockReturnValue({ title: "ignored" });
+    vars.pageViewInstrumentation = { trackVirtualPageViews: true, includeParts: [], generateMetadata };
+
+    transmitManualPageViewEvent({ timeUnixNano: "1700000000000000000", title: "/settings" });
+
+    expect(generateMetadata).not.toHaveBeenCalled();
+    const log = sendLogMock.mock.calls[0]![0] as LogRecord;
+    const bodyValues = log.body?.kvlistValue?.values as KeyValue[];
+    expect(bodyValues).toEqual(expect.arrayContaining([{ key: "title", value: { stringValue: "/settings" } }]));
+  });
+
+  it("merges custom attributes into signal attributes", () => {
+    transmitManualPageViewEvent({
+      timeUnixNano: "1700000000000000000",
+      title: "/settings",
+      attributes: { "app.screen": "settings", "app.tab_index": 2 },
+    });
+
+    const log = sendLogMock.mock.calls[0]![0] as LogRecord;
+    expect(log.attributes).toEqual(
+      expect.arrayContaining([
+        { key: "app.screen", value: { stringValue: "settings" } },
+        { key: "app.tab_index", value: { doubleValue: 2 } },
+      ])
+    );
+  });
+
+  it("passes url through to page.url.* attributes when provided", () => {
+    transmitManualPageViewEvent({
+      timeUnixNano: "1700000000000000000",
+      title: "/settings",
+      url: new URL("https://example.com/settings"),
+    });
+
+    const log = sendLogMock.mock.calls[0]![0] as LogRecord;
+    expect(log.attributes).toEqual(
+      expect.arrayContaining([{ key: "page.url.path", value: { stringValue: "/settings" } }])
+    );
+  });
+
+  it("includes referrer the same way the auto path does", () => {
+    transmitManualPageViewEvent({ timeUnixNano: "1700000000000000000", title: "/settings" });
+
+    const log = sendLogMock.mock.calls[0]![0] as LogRecord;
+    const bodyValues = log.body?.kvlistValue?.values as KeyValue[];
+    // doc.referrer is empty string in jsdom by default, so "referrer" key should be absent
+    expect(bodyValues.find((v) => v.key === "referrer")).toBeUndefined();
   });
 });

--- a/src/semantic-conventions.ts
+++ b/src/semantic-conventions.ts
@@ -42,13 +42,32 @@ export const EXCEPTION_MESSAGE = "exception.message";
 export const EXCEPTION_TYPE = "exception.type";
 export const EXCEPTION_STACKTRACE = "exception.stacktrace";
 
-// Interaction Attribute Keys
-export const INTERACTION_TYPE = "type";
-export const INTERACTION_NAME = "name";
-export const INTERACTION_NAME_SOURCE = "name_source";
-export const INTERACTION_TARGET_SELECTOR = "target.selector";
-export const INTERACTION_TARGET_TAG = "target.tag";
-export const INTERACTION_TARGET_ID = "target.id";
+// Interaction Attribute Keys. These are LOG RECORD attributes (namespaced like
+// page.* / user_agent.*), NOT body keys: the browser.interaction body is a
+// plain human-readable string ("Click \"Save Part\" on /inventory/parts") so
+// UIs without a dedicated renderer for this event type display something
+// readable, while the structured fields stay individually filterable.
+export const INTERACTION_ID = "interaction.id";
+export const INTERACTION_TYPE = "interaction.type";
+export const INTERACTION_NAME = "interaction.name";
+export const INTERACTION_NAME_SOURCE = "interaction.name_source";
+export const INTERACTION_TARGET_SELECTOR = "interaction.target.selector";
+export const INTERACTION_TARGET_TAG = "interaction.target.tag";
+export const INTERACTION_TARGET_ID = "interaction.target.id";
+/** key_press events: the captured key (allow-listed control keys only). */
+export const INTERACTION_KEY = "interaction.key";
+/** scroll events: net direction of the scroll burst (up/down/left/right). */
+export const INTERACTION_DIRECTION = "interaction.direction";
+/** change events: length of the new value; the value itself is never read. */
+export const INTERACTION_VALUE_LENGTH = "interaction.value_length";
+/** change events on selects: number of selected options. */
+export const INTERACTION_SELECTED_COUNT = "interaction.selected_count";
+
+// Span attribute keys linking an HTTP request span to the user interaction
+// (click) that triggered it. Stamped on XHR/fetch spans started while an
+// interaction is active, mirroring the "user action" concept of RUM products.
+export const USER_INTERACTION_ID = "user_interaction.id";
+export const USER_INTERACTION_NAME = "user_interaction.name";
 
 // Error Attribute Keys
 export const ERROR_TYPE = "error.type";

--- a/src/semantic-conventions.ts
+++ b/src/semantic-conventions.ts
@@ -42,6 +42,14 @@ export const EXCEPTION_MESSAGE = "exception.message";
 export const EXCEPTION_TYPE = "exception.type";
 export const EXCEPTION_STACKTRACE = "exception.stacktrace";
 
+// Interaction Attribute Keys
+export const INTERACTION_TYPE = "type";
+export const INTERACTION_NAME = "name";
+export const INTERACTION_NAME_SOURCE = "name_source";
+export const INTERACTION_TARGET_SELECTOR = "target.selector";
+export const INTERACTION_TARGET_TAG = "target.tag";
+export const INTERACTION_TARGET_ID = "target.id";
+
 // Error Attribute Keys
 export const ERROR_TYPE = "error.type";
 
@@ -68,6 +76,7 @@ export const EVENT_NAMES = {
   NAVIGATION_TIMING: "browser.navigation_timing",
   WEB_VITAL: "browser.web_vital",
   ERROR: "browser.error",
+  INTERACTION: "browser.interaction",
 };
 export const SPAN_EVENT_NAME_EXCEPTION = "exception";
 

--- a/src/types/options.ts
+++ b/src/types/options.ts
@@ -2,7 +2,12 @@ import { AttributeValueType } from "../utils/otel";
 import { AnyValue } from "./otlp";
 import { Endpoint, Vars, PropagatorConfig } from "../vars";
 
-export type InstrumentationName = "@dash0/navigation" | "@dash0/web-vitals" | "@dash0/error" | "@dash0/fetch";
+export type InstrumentationName =
+  | "@dash0/navigation"
+  | "@dash0/web-vitals"
+  | "@dash0/error"
+  | "@dash0/fetch"
+  | "@dash0/xhr";
 
 /**
  * VCS (version control) context describing the build the SDK is running

--- a/src/types/options.ts
+++ b/src/types/options.ts
@@ -2,7 +2,12 @@ import { AttributeValueType } from "../utils/otel";
 import { AnyValue } from "./otlp";
 import { Endpoint, Vars, PropagatorConfig } from "../vars";
 
-export type InstrumentationName = "@dash0/navigation" | "@dash0/web-vitals" | "@dash0/error" | "@dash0/fetch";
+export type InstrumentationName =
+  | "@dash0/navigation"
+  | "@dash0/web-vitals"
+  | "@dash0/error"
+  | "@dash0/fetch"
+  | "@dash0/interactions";
 
 /**
  * VCS (version control) context describing the build the SDK is running
@@ -136,6 +141,7 @@ export type InitOptions = {
     | "headersToCapture"
     | "urlAttributeScrubber"
     | "pageViewInstrumentation"
+    | "interactionInstrumentation"
     | "enableTransportCompression"
   >
 >;

--- a/src/vars.ts
+++ b/src/vars.ts
@@ -62,6 +62,8 @@ export type InteractionInstrumentationSettings = {
   /**
    * Whether the SDK should automatically capture click interactions.
    * Opt-in: disabled by default.
+   * Also requires "@dash0/interactions" to be present in enabledInstrumentations
+   * (or enabledInstrumentations left undefined).
    *
    * @default false
    */

--- a/src/vars.ts
+++ b/src/vars.ts
@@ -78,6 +78,33 @@ export type InteractionInstrumentationSettings = {
    * @default "data-dash0-action-name"
    */
   actionNameAttribute?: string;
+
+  /**
+   * Whether scroll interactions are captured (one event per scroll burst,
+   * with the net direction). Only applies when `enabled` is true.
+   *
+   * @default true
+   */
+  captureScrolls?: boolean;
+
+  /**
+   * Whether key presses are captured. Only navigation/activation keys
+   * (Enter, Tab, Escape, Space, arrows, ...) are ever recorded; printable
+   * characters never are. Only applies when `enabled` is true.
+   *
+   * @default true
+   */
+  captureKeyPresses?: boolean;
+
+  /**
+   * Whether form-field changes are captured. The field value is never read:
+   * text fields report only the value length, selects only the selected
+   * count, and password fields report neither. Only applies when `enabled`
+   * is true.
+   *
+   * @default true
+   */
+  captureChanges?: boolean;
 };
 
 export type Vars = {
@@ -234,6 +261,9 @@ export const vars: Vars = {
   interactionInstrumentation: {
     enabled: false,
     actionNameAttribute: "data-dash0-action-name",
+    captureScrolls: true,
+    captureKeyPresses: true,
+    captureChanges: true,
   },
   enableTransportCompression: false,
   isSessionSampled: true,

--- a/src/vars.ts
+++ b/src/vars.ts
@@ -58,6 +58,26 @@ export type PageViewInstrumentationSettings = {
   includeParts?: Array<"HASH" | "SEARCH">;
 };
 
+export type InteractionInstrumentationSettings = {
+  /**
+   * Whether the SDK should automatically capture click interactions.
+   * Opt-in: disabled by default.
+   *
+   * @default false
+   */
+  enabled?: boolean;
+
+  /**
+   * The element attribute the SDK checks first (on the clicked element or any
+   * ancestor) when deriving a human-readable interaction name. Set this
+   * attribute on interactive elements to fully control the captured name,
+   * e.g. `<button data-dash0-action-name="Save Settings">`.
+   *
+   * @default "data-dash0-action-name"
+   */
+  actionNameAttribute?: string;
+};
+
 export type Vars = {
   /**
    * Telemetry endpoints to which the generated telemetry should be sent
@@ -167,6 +187,12 @@ export type Vars = {
   pageViewInstrumentation: PageViewInstrumentationSettings;
 
   /**
+   * Configures automatic user-interaction (click) instrumentation. Opt-in --
+   * disabled by default. See {@link InteractionInstrumentationSettings}.
+   */
+  interactionInstrumentation: InteractionInstrumentationSettings;
+
+  /**
    * Enables telemetry transport compression using gzip.
    * experimental - in rare cases causes Chrome to crash to use at your own risk.
    */
@@ -202,6 +228,10 @@ export const vars: Vars = {
   pageViewInstrumentation: {
     trackVirtualPageViews: true,
     includeParts: [],
+  },
+  interactionInstrumentation: {
+    enabled: false,
+    actionNameAttribute: "data-dash0-action-name",
   },
   enableTransportCompression: false,
   isSessionSampled: true,

--- a/src/vars.ts
+++ b/src/vars.ts
@@ -80,29 +80,29 @@ export type InteractionInstrumentationSettings = {
   actionNameAttribute?: string;
 
   /**
-   * Whether scroll interactions are captured (one event per scroll burst,
+   * Opt in to capturing scroll interactions (one event per scroll burst,
    * with the net direction). Only applies when `enabled` is true.
    *
-   * @default true
+   * @default false
    */
   captureScrolls?: boolean;
 
   /**
-   * Whether key presses are captured. Only navigation/activation keys
+   * Opt in to capturing key presses. Only navigation/activation keys
    * (Enter, Tab, Escape, Space, arrows, ...) are ever recorded; printable
    * characters never are. Only applies when `enabled` is true.
    *
-   * @default true
+   * @default false
    */
   captureKeyPresses?: boolean;
 
   /**
-   * Whether form-field changes are captured. The field value is never read:
+   * Opt in to capturing form-field changes. The field value is never read:
    * text fields report only the value length, selects only the selected
    * count, and password fields report neither. Only applies when `enabled`
    * is true.
    *
-   * @default true
+   * @default false
    */
   captureChanges?: boolean;
 };
@@ -261,9 +261,9 @@ export const vars: Vars = {
   interactionInstrumentation: {
     enabled: false,
     actionNameAttribute: "data-dash0-action-name",
-    captureScrolls: true,
-    captureKeyPresses: true,
-    captureChanges: true,
+    captureScrolls: false,
+    captureKeyPresses: false,
+    captureChanges: false,
   },
   enableTransportCompression: false,
   isSessionSampled: true,

--- a/src/vars_test.ts
+++ b/src/vars_test.ts
@@ -6,6 +6,9 @@ describe("vars defaults", () => {
     expect(vars.interactionInstrumentation).toEqual({
       enabled: false,
       actionNameAttribute: "data-dash0-action-name",
+      captureScrolls: true,
+      captureKeyPresses: true,
+      captureChanges: true,
     });
   });
 });

--- a/src/vars_test.ts
+++ b/src/vars_test.ts
@@ -6,9 +6,9 @@ describe("vars defaults", () => {
     expect(vars.interactionInstrumentation).toEqual({
       enabled: false,
       actionNameAttribute: "data-dash0-action-name",
-      captureScrolls: true,
-      captureKeyPresses: true,
-      captureChanges: true,
+      captureScrolls: false,
+      captureKeyPresses: false,
+      captureChanges: false,
     });
   });
 });

--- a/src/vars_test.ts
+++ b/src/vars_test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "vitest";
+import { vars } from "./vars";
+
+describe("vars defaults", () => {
+  it("defaults interactionInstrumentation to disabled with the standard action-name attribute", () => {
+    expect(vars.interactionInstrumentation).toEqual({
+      enabled: false,
+      actionNameAttribute: "data-dash0-action-name",
+    });
+  });
+});

--- a/test/e2e/server/index.mjs
+++ b/test/e2e/server/index.mjs
@@ -78,6 +78,13 @@ app.use((req, res, next) => {
   )
 );
 
+// Serves axios's browser UMD bundle for the XHR instrumentation e2e tests (test/e2e/spec/09-xhr-instrumentation),
+// which need a real XHR-based HTTP client (axios defaults to its XHR adapter in browsers) to prove the
+// instrumentation works transparently under a popular library, not just hand-rolled XHR calls.
+app.get("/vendor/axios.min.js", (_req, res) => {
+  res.sendFile(path.join(import.meta.dirname, "..", "..", "..", "node_modules", "axios", "dist", "axios.min.js"));
+});
+
 app.use(bodyParser.urlencoded({ extended: true }));
 app.use(bodyParser.json());
 app.use(bodyParser.raw({ type: "text/plain" }));

--- a/test/e2e/spec/08-start-view/08-start-view.test.ts
+++ b/test/e2e/spec/08-start-view/08-start-view.test.ts
@@ -1,0 +1,76 @@
+import { sharedAfterEach, sharedBeforeEach } from "../shared";
+import { generateUniqueId } from "../../../../src/utils";
+import { browser } from "@wdio/globals";
+import { loadPage, retry } from "../utils";
+import { expectLogMatching, expectNoBrowserErrors } from "../expectations";
+import { PAGE_VIEW_TYPE_VALUES } from "../../../../src/semantic-conventions";
+
+describe("Start View", () => {
+  beforeEach(sharedBeforeEach);
+  afterEach(sharedAfterEach);
+
+  it("transmits a page view with the given name and attributes (options object)", async () => {
+    const testId = generateUniqueId(16);
+    await loadPage(`/e2e/spec/08-start-view/page.html?testId=${testId}`);
+    await expect(await browser.getTitle()).toMatch(/start view test/);
+
+    const btn = await $("button=Start View Options");
+    await btn.click();
+
+    await retry(async () => {
+      await expectLogMatching(
+        expect.objectContaining({
+          attributes: expect.arrayContaining([
+            { key: "event.name", value: { stringValue: "browser.page_view" } },
+            { key: "app.screen", value: { stringValue: "settings" } },
+            { key: "page.load.id", value: { stringValue: expect.any(String) } },
+            { key: "session.id", value: { stringValue: expect.any(String) } },
+          ]),
+          body: {
+            kvlistValue: {
+              values: expect.arrayContaining([
+                { key: "type", value: { doubleValue: PAGE_VIEW_TYPE_VALUES.VIRTUAL } },
+                { key: "title", value: { stringValue: "/settings" } },
+              ]),
+            },
+          },
+          severityNumber: 9,
+          severityText: "INFO",
+          timeUnixNano: expect.any(String),
+        })
+      );
+    });
+
+    expectNoBrowserErrors();
+  });
+
+  it("transmits a page view from the string shorthand", async () => {
+    const testId = generateUniqueId(16);
+    await loadPage(`/e2e/spec/08-start-view/page.html?testId=${testId}`);
+    await expect(await browser.getTitle()).toMatch(/start view test/);
+
+    const btn = await $("button=Start View String");
+    await btn.click();
+
+    await retry(async () => {
+      await expectLogMatching(
+        expect.objectContaining({
+          attributes: expect.arrayContaining([{ key: "event.name", value: { stringValue: "browser.page_view" } }]),
+          body: {
+            kvlistValue: {
+              values: expect.arrayContaining([
+                { key: "type", value: { doubleValue: PAGE_VIEW_TYPE_VALUES.VIRTUAL } },
+                { key: "title", value: { stringValue: "/checkout" } },
+              ]),
+            },
+          },
+          severityNumber: 9,
+          severityText: "INFO",
+          timeUnixNano: expect.any(String),
+        })
+      );
+    });
+
+    expectNoBrowserErrors();
+  });
+});

--- a/test/e2e/spec/08-start-view/08-start-view.test.ts
+++ b/test/e2e/spec/08-start-view/08-start-view.test.ts
@@ -73,4 +73,98 @@ describe("Start View", () => {
 
     expectNoBrowserErrors();
   });
+
+  it("reflects the url override in page.url.path", async () => {
+    const testId = generateUniqueId(16);
+    await loadPage(`/e2e/spec/08-start-view/page.html?testId=${testId}`);
+    await expect(await browser.getTitle()).toMatch(/start view test/);
+
+    const btn = await $("button=Start View With Url");
+    await btn.click();
+
+    await retry(async () => {
+      await expectLogMatching(
+        expect.objectContaining({
+          attributes: expect.arrayContaining([
+            { key: "event.name", value: { stringValue: "browser.page_view" } },
+            { key: "page.url.path", value: { stringValue: "/settings" } },
+          ]),
+          body: {
+            kvlistValue: {
+              values: expect.arrayContaining([
+                { key: "type", value: { doubleValue: PAGE_VIEW_TYPE_VALUES.VIRTUAL } },
+                { key: "title", value: { stringValue: "/settings" } },
+              ]),
+            },
+          },
+        })
+      );
+    });
+
+    expectNoBrowserErrors();
+  });
+
+  it("never touches history or location", async () => {
+    const testId = generateUniqueId(16);
+    await loadPage(`/e2e/spec/08-start-view/page.html?testId=${testId}`);
+    await expect(await browser.getTitle()).toMatch(/start view test/);
+
+    const before = await browser.execute(() => ({
+      href: window.location.href,
+      historyLength: window.history.length,
+    }));
+
+    const btn = await $("button=Start View Options");
+    await btn.click();
+    await retry(async () => {
+      await expectLogMatching(
+        expect.objectContaining({
+          attributes: expect.arrayContaining([{ key: "event.name", value: { stringValue: "browser.page_view" } }]),
+        })
+      );
+    });
+
+    const after = await browser.execute(() => ({
+      href: window.location.href,
+      historyLength: window.history.length,
+    }));
+
+    expect(after.href).toBe(before.href);
+    expect(after.historyLength).toBe(before.historyLength);
+
+    expectNoBrowserErrors();
+  });
+
+  it("does not interfere with automatic page-view instrumentation on the same page", async () => {
+    const testId = generateUniqueId(16);
+    await loadPage(`/e2e/spec/08-start-view/page.html?testId=${testId}`);
+    await expect(await browser.getTitle()).toMatch(/start view test/);
+
+    const btn = await $("button=Real Push State");
+    await btn.click();
+
+    await retry(async () => {
+      await expectLogMatching(
+        expect.objectContaining({
+          attributes: expect.arrayContaining([
+            { key: "event.name", value: { stringValue: "browser.page_view" } },
+            {
+              key: "page.url.full",
+              value: { stringValue: expect.stringContaining("/e2e/spec/08-start-view/virtual-page") },
+            },
+          ]),
+          body: {
+            kvlistValue: {
+              values: expect.arrayContaining([
+                { key: "type", value: { doubleValue: PAGE_VIEW_TYPE_VALUES.VIRTUAL } },
+                { key: "change_state", value: { stringValue: "pushState" } },
+              ]),
+            },
+          },
+        })
+      );
+    });
+
+    expectNoBrowserErrors();
+  });
 });

--- a/test/e2e/spec/08-start-view/page.html
+++ b/test/e2e/spec/08-start-view/page.html
@@ -1,0 +1,54 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <title>start view test</title>
+
+    <script>
+      (function (d, a, s, h, z, e, r, o) {
+        d[a] ||
+          ((z = d[a] =
+            function () {
+              h.push(arguments);
+            }),
+          (z._t = new Date()),
+          (z._v = 1),
+          (h = z._q = []));
+      })(window, "dash0");
+
+      dash0("init", {
+        serviceName: "dash0.com",
+        serviceVersion: "1.2.3",
+        environment: "prod",
+        endpoint: {
+          url: `http://${window.location.hostname}:8011?cors=true`,
+          authToken: "auth_abc123",
+          dataset: "production",
+        },
+      });
+
+      function onStartViewOptions() {
+        dash0("startView", { name: "/settings", attributes: { "app.screen": "settings" } });
+      }
+
+      function onStartViewString() {
+        dash0("startView", "/checkout");
+      }
+
+      function onStartViewWithUrl() {
+        dash0("startView", { name: "/settings", url: "/settings" });
+      }
+
+      function onRealPushState() {
+        history.pushState(undefined, "", new URL("./virtual-page", window.location.href));
+      }
+    </script>
+    <script defer crossorigin="anonymous" src="/dist/dash0.iife.js"></script>
+  </head>
+  <body>
+    <button onclick="onStartViewOptions()">Start View Options</button>
+    <button onclick="onStartViewString()">Start View String</button>
+    <button onclick="onStartViewWithUrl()">Start View With Url</button>
+    <button onclick="onRealPushState()">Real Push State</button>
+  </body>
+</html>

--- a/test/e2e/spec/09-xhr-instrumentation/09-xhr-instrumentation.test.ts
+++ b/test/e2e/spec/09-xhr-instrumentation/09-xhr-instrumentation.test.ts
@@ -1,0 +1,144 @@
+import { SPAN_KIND_CLIENT } from "../../../../src/semantic-conventions";
+import { sharedAfterEach, sharedBeforeEach } from "../shared";
+import { loadPage, retry } from "../utils";
+import { expectNoBrowserErrors, expectSpanCount, expectSpanMatching } from "../expectations";
+
+function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+describe("XHR Instrumentation", () => {
+  beforeEach(sharedBeforeEach);
+  afterEach(sharedAfterEach);
+
+  it("must send spans for same-origin XHR requests with the same shape as fetch spans", async () => {
+    await loadPage("/e2e/spec/09-xhr-instrumentation/page.html");
+    await expect(browser).toHaveTitle("xhr instrumentation test");
+
+    const btn = await $("button=Same Origin XHR");
+    await btn.click();
+
+    await retry(async () => {
+      await expectSpanMatching(
+        expect.objectContaining({
+          traceId: expect.any(String),
+          spanId: expect.any(String),
+          name: "HTTP GET",
+          kind: SPAN_KIND_CLIENT,
+          attributes: expect.arrayContaining([
+            { key: "http.request.method", value: { stringValue: "GET" } },
+            { key: "url.path", value: { stringValue: "/ajax" } },
+            { key: "http.response.status_code", value: { stringValue: "200" } },
+            { key: "http.request.header.x-test-header", value: { stringValue: "this is a green test" } },
+          ]),
+          status: { code: 0 },
+        })
+      );
+    });
+    expectNoBrowserErrors();
+  });
+
+  it("must inject traceparent for matching cross-origin XHR requests", async () => {
+    await loadPage("/e2e/spec/09-xhr-instrumentation/page.html");
+    await expect(browser).toHaveTitle("xhr instrumentation test");
+
+    await browser.execute(async () => {
+      await fetch("http://localhost.lambdatest.com:8012/ajax-requests", { method: "DELETE" }).catch(() => {});
+    });
+
+    const btn = await $("button=Cross Origin XHR");
+    await btn.click();
+    await sleep(500);
+
+    const ajaxResponse = await fetch("http://localhost.lambdatest.com:8012/ajax-requests");
+    const ajaxRequests = await ajaxResponse.json();
+    const postRequest = ajaxRequests.find((req: any) => req.method == "POST");
+
+    expect(postRequest).toBeDefined();
+    expect(postRequest.headers).toHaveProperty("traceparent");
+    expect(postRequest.headers["traceparent"]).toMatch(/^00-[0-9a-f]{32}-[0-9a-f]{16}-01$/);
+
+    expectNoBrowserErrors();
+  });
+
+  it("must send X-Ray headers for the same-origin XHR X-Ray case", async () => {
+    await loadPage("/e2e/spec/09-xhr-instrumentation/page.html");
+    await expect(browser).toHaveTitle("xhr instrumentation test");
+
+    const btn = await $("#xray-xhr-btn");
+    await btn.click();
+
+    await retry(async () => {
+      await expectSpanMatching(
+        expect.objectContaining({
+          attributes: expect.arrayContaining([
+            { key: "url.path", value: { stringValue: "/aws" } },
+            { key: "http.response.status_code", value: { stringValue: "200" } },
+          ]),
+        })
+      );
+    });
+    expectNoBrowserErrors();
+  });
+
+  it("must ignore urls matching the ignoredUrls config for XHR", async () => {
+    await loadPage("/e2e/spec/09-xhr-instrumentation/page.html");
+    await expect(browser).toHaveTitle("xhr instrumentation test");
+
+    const ignoredBtn = await $("button=XHR With Ignored URL");
+    await ignoredBtn.click();
+
+    const okBtn = await $("button=Same Origin XHR");
+    await okBtn.click();
+
+    await retry(async () => {
+      await expectSpanCount(1);
+    });
+    expectNoBrowserErrors();
+  });
+
+  it("must instrument synchronous XHR requests the same as asynchronous ones", async () => {
+    await loadPage("/e2e/spec/09-xhr-instrumentation/page.html");
+    await expect(browser).toHaveTitle("xhr instrumentation test");
+
+    const btn = await $("button=Sync XHR");
+    await btn.click();
+
+    await retry(async () => {
+      await expectSpanMatching(
+        expect.objectContaining({
+          name: "HTTP GET",
+          attributes: expect.arrayContaining([
+            { key: "url.query", value: { stringValue: "sync=test" } },
+            { key: "http.response.status_code", value: { stringValue: "200" } },
+          ]),
+        })
+      );
+    });
+    expectNoBrowserErrors();
+  });
+
+  it("must send spans for axios requests (axios defaults to the XHR adapter in browsers)", async () => {
+    await loadPage("/e2e/spec/09-xhr-instrumentation/page.html");
+    await expect(browser).toHaveTitle("xhr instrumentation test");
+
+    const btn = await $("button=Axios GET");
+    await btn.click();
+
+    await retry(async () => {
+      await expectSpanMatching(
+        expect.objectContaining({
+          name: "HTTP GET",
+          kind: SPAN_KIND_CLIENT,
+          attributes: expect.arrayContaining([
+            { key: "http.request.method", value: { stringValue: "GET" } },
+            { key: "url.query", value: { stringValue: "thisIsAxios=test" } },
+            { key: "http.response.status_code", value: { stringValue: "200" } },
+          ]),
+          status: { code: 0 },
+        })
+      );
+    });
+    expectNoBrowserErrors();
+  });
+});

--- a/test/e2e/spec/09-xhr-instrumentation/09-xhr-instrumentation.test.ts
+++ b/test/e2e/spec/09-xhr-instrumentation/09-xhr-instrumentation.test.ts
@@ -65,6 +65,10 @@ describe("XHR Instrumentation", () => {
     await loadPage("/e2e/spec/09-xhr-instrumentation/page.html");
     await expect(browser).toHaveTitle("xhr instrumentation test");
 
+    await browser.execute(async () => {
+      await fetch("http://localhost.lambdatest.com:8012/ajax-requests", { method: "DELETE" }).catch(() => {});
+    });
+
     const btn = await $("#xray-xhr-btn");
     await btn.click();
 
@@ -78,6 +82,20 @@ describe("XHR Instrumentation", () => {
         })
       );
     });
+
+    const ajaxResponse = await fetch("http://localhost.lambdatest.com:8012/ajax-requests");
+    const ajaxRequests = await ajaxResponse.json();
+    const awsRequest = ajaxRequests.find((req: any) => req.url.startsWith("/aws"));
+
+    expect(awsRequest).toBeDefined();
+    expect(awsRequest.headers).toHaveProperty("x-amzn-trace-id");
+    expect(awsRequest.headers["x-amzn-trace-id"]).toMatch(
+      /^Root=1-[0-9a-f]{8}-[0-9a-f]{24};Parent=[0-9a-f]{16};Sampled=1$/
+    );
+    // Same-origin requests receive ALL configured propagator types, so traceparent must be present too.
+    expect(awsRequest.headers).toHaveProperty("traceparent");
+    expect(awsRequest.headers["traceparent"]).toMatch(/^00-[0-9a-f]{32}-[0-9a-f]{16}-01$/);
+
     expectNoBrowserErrors();
   });
 

--- a/test/e2e/spec/09-xhr-instrumentation/page.html
+++ b/test/e2e/spec/09-xhr-instrumentation/page.html
@@ -1,0 +1,100 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <title>xhr instrumentation test</title>
+    <script>
+      (function (d, a, s, h, z, e, r, o) {
+        d[a] ||
+          ((z = d[a] =
+            function () {
+              h.push(arguments);
+            }),
+          (z._t = new Date()),
+          (z._v = 1),
+          (h = z._q = []));
+      })(window, "dash0");
+      dash0("init", {
+        serviceName: "dash0.com",
+        serviceVersion: "1.2.3",
+        environment: "prod",
+        endpoint: [
+          {
+            url: `http://${window.location.hostname}:8011?cors=true`,
+            authToken: "auth_abc123",
+            dataset: "production",
+          },
+        ],
+        propagators: [
+          {
+            type: "traceparent",
+            match: [new RegExp(`http://${window.location.hostname}:8012`)],
+          },
+          {
+            type: "xray",
+            match: [],
+          },
+        ],
+        headersToCapture: [/x-test-header/],
+        ignoreUrls: [/you-cant-see-this/],
+      });
+    </script>
+    <script defer crossorigin="anonymous" src="/dist/dash0.iife.js"></script>
+    <script defer src="/vendor/axios.min.js"></script>
+  </head>
+  <body>
+    <button
+      onclick="(function(){
+        const xhr = new XMLHttpRequest();
+        xhr.open('GET', '/ajax?thisIsA=test');
+        xhr.setRequestHeader('x-test-header', 'this is a green test');
+        xhr.send();
+      })()"
+    >
+      Same Origin XHR
+    </button>
+
+    <button
+      onclick="(function(){
+        const xhr = new XMLHttpRequest();
+        xhr.open('POST', `http://${window.location.hostname}:8012/ajax?cors=true`);
+        xhr.send();
+      })()"
+    >
+      Cross Origin XHR
+    </button>
+
+    <button
+      onclick="(function(){
+        const xhr = new XMLHttpRequest();
+        xhr.open('GET', '/ajax?sync=test', false);
+        xhr.send();
+      })()"
+    >
+      Sync XHR
+    </button>
+
+    <button
+      onclick="(function(){
+        const xhr = new XMLHttpRequest();
+        xhr.open('GET', '/you-cant-see-this');
+        xhr.send();
+      })()"
+    >
+      XHR With Ignored URL
+    </button>
+
+    <button
+      onclick="(function(){
+        const xhr = new XMLHttpRequest();
+        xhr.open('GET', '/aws?test=xray&cors=true');
+        xhr.send();
+      })()"
+      id="xray-xhr-btn"
+    >
+      XHR with X-Ray
+    </button>
+
+    <button onclick="axios.get('/ajax?thisIsAxios=test')">Axios GET</button>
+  </body>
+</html>

--- a/test/e2e/spec/10-interactions/10-interactions.test.ts
+++ b/test/e2e/spec/10-interactions/10-interactions.test.ts
@@ -1,14 +1,16 @@
-import { sharedAfterEach, sharedBeforeEach } from "../shared";
+import { getOTLPRequests, sharedAfterEach, sharedBeforeEach } from "../shared";
+import { generateUniqueId } from "../../../../src/utils";
 import { browser } from "@wdio/globals";
 import { loadPage, retry } from "../utils";
-import { expectLogMatching, expectNoLogMatching } from "../expectations";
+import { expectLogMatching, expectNoBrowserErrors, expectNoLogMatching } from "../expectations";
 
 describe("Interaction Instrumentation", () => {
   beforeEach(sharedBeforeEach);
   afterEach(sharedAfterEach);
 
   it("emits a browser.interaction log with the custom action name when a data-dash0-action-name button is clicked", async () => {
-    await loadPage("/e2e/spec/10-interactions/page.html");
+    const testId = generateUniqueId(16);
+    await loadPage(`/e2e/spec/10-interactions/page.html?testId=${testId}`);
     await expect(await browser.getTitle()).toMatch(/interactions test/);
 
     const btn = await $("#save-button");
@@ -41,10 +43,13 @@ describe("Interaction Instrumentation", () => {
         })
       );
     });
+
+    expectNoBrowserErrors();
   });
 
   it("derives the name from visible text when no custom attribute or aria-label is present", async () => {
-    await loadPage("/e2e/spec/10-interactions/page.html");
+    const testId = generateUniqueId(16);
+    await loadPage(`/e2e/spec/10-interactions/page.html?testId=${testId}`);
 
     const btn = await $("#plain-button");
     await btn.click();
@@ -65,10 +70,13 @@ describe("Interaction Instrumentation", () => {
         })
       );
     });
+
+    expectNoBrowserErrors();
   });
 
   it("derives the name from aria-label for an icon-only button with no visible text", async () => {
-    await loadPage("/e2e/spec/10-interactions/page.html");
+    const testId = generateUniqueId(16);
+    await loadPage(`/e2e/spec/10-interactions/page.html?testId=${testId}`);
 
     const btn = await $("#icon-button");
     await btn.click();
@@ -89,10 +97,13 @@ describe("Interaction Instrumentation", () => {
         })
       );
     });
+
+    expectNoBrowserErrors();
   });
 
   it("never derives a name from a text input's value, even though it has a pre-filled value", async () => {
-    await loadPage("/e2e/spec/10-interactions/page.html");
+    const testId = generateUniqueId(16);
+    await loadPage(`/e2e/spec/10-interactions/page.html?testId=${testId}`);
 
     const input = await $("#text-input");
     await input.click();
@@ -118,7 +129,7 @@ describe("Interaction Instrumentation", () => {
         })
       );
 
-      const requests = await (await import("../shared")).getOTLPRequests();
+      const requests = await getOTLPRequests();
       const logRequests = requests.filter((r) => r.path === "/v1/logs");
       const bodies = logRequests.flatMap((r) =>
         "resourceLogs" in r.body
@@ -136,10 +147,13 @@ describe("Interaction Instrumentation", () => {
         "pre-filled secret"
       );
     });
+
+    expectNoBrowserErrors();
   });
 
   it("emits no browser.interaction logs when interactionInstrumentation is left at its default (disabled)", async () => {
-    await loadPage("/e2e/spec/10-interactions/page-disabled.html");
+    const testId = generateUniqueId(16);
+    await loadPage(`/e2e/spec/10-interactions/page-disabled.html?testId=${testId}`);
 
     const btn = await $("#save-button");
     await btn.click();
@@ -153,5 +167,7 @@ describe("Interaction Instrumentation", () => {
         })
       );
     });
+
+    expectNoBrowserErrors();
   });
 });

--- a/test/e2e/spec/10-interactions/10-interactions.test.ts
+++ b/test/e2e/spec/10-interactions/10-interactions.test.ts
@@ -1,0 +1,157 @@
+import { sharedAfterEach, sharedBeforeEach } from "../shared";
+import { browser } from "@wdio/globals";
+import { loadPage, retry } from "../utils";
+import { expectLogMatching, expectNoLogMatching } from "../expectations";
+
+describe("Interaction Instrumentation", () => {
+  beforeEach(sharedBeforeEach);
+  afterEach(sharedAfterEach);
+
+  it("emits a browser.interaction log with the custom action name when a data-dash0-action-name button is clicked", async () => {
+    await loadPage("/e2e/spec/10-interactions/page.html");
+    await expect(await browser.getTitle()).toMatch(/interactions test/);
+
+    const btn = await $("#save-button");
+    await btn.click();
+
+    await retry(async () => {
+      await expectLogMatching(
+        expect.objectContaining({
+          attributes: expect.arrayContaining([
+            { key: "event.name", value: { stringValue: "browser.interaction" } },
+            { key: "page.load.id", value: { stringValue: expect.any(String) } },
+            { key: "session.id", value: { stringValue: expect.any(String) } },
+            { key: "the_answer", value: { doubleValue: 42 } },
+          ]),
+          body: {
+            kvlistValue: {
+              values: expect.arrayContaining([
+                { key: "type", value: { stringValue: "click" } },
+                { key: "name", value: { stringValue: "Save Settings" } },
+                { key: "name_source", value: { stringValue: "custom_attribute" } },
+                { key: "target.tag", value: { stringValue: "button" } },
+                { key: "target.id", value: { stringValue: "save-button" } },
+                { key: "target.selector", value: { stringValue: "button#save-button" } },
+              ]),
+            },
+          },
+          severityNumber: 9,
+          severityText: "INFO",
+          timeUnixNano: expect.any(String),
+        })
+      );
+    });
+  });
+
+  it("derives the name from visible text when no custom attribute or aria-label is present", async () => {
+    await loadPage("/e2e/spec/10-interactions/page.html");
+
+    const btn = await $("#plain-button");
+    await btn.click();
+
+    await retry(async () => {
+      await expectLogMatching(
+        expect.objectContaining({
+          body: {
+            kvlistValue: {
+              values: expect.arrayContaining([
+                { key: "name", value: { stringValue: "Continue" } },
+                { key: "name_source", value: { stringValue: "text_content" } },
+                { key: "target.id", value: { stringValue: "plain-button" } },
+                { key: "target.selector", value: { stringValue: "button#plain-button" } },
+              ]),
+            },
+          },
+        })
+      );
+    });
+  });
+
+  it("derives the name from aria-label for an icon-only button with no visible text", async () => {
+    await loadPage("/e2e/spec/10-interactions/page.html");
+
+    const btn = await $("#icon-button");
+    await btn.click();
+
+    await retry(async () => {
+      await expectLogMatching(
+        expect.objectContaining({
+          body: {
+            kvlistValue: {
+              values: expect.arrayContaining([
+                { key: "name", value: { stringValue: "Close Dialog" } },
+                { key: "name_source", value: { stringValue: "standard_attribute" } },
+                { key: "target.id", value: { stringValue: "icon-button" } },
+                { key: "target.selector", value: { stringValue: "button#icon-button" } },
+              ]),
+            },
+          },
+        })
+      );
+    });
+  });
+
+  it("never derives a name from a text input's value, even though it has a pre-filled value", async () => {
+    await loadPage("/e2e/spec/10-interactions/page.html");
+
+    const input = await $("#text-input");
+    await input.click();
+
+    await retry(async () => {
+      await expectLogMatching(
+        expect.objectContaining({
+          body: {
+            kvlistValue: {
+              values: expect.arrayContaining([
+                { key: "target.id", value: { stringValue: "text-input" } },
+                { key: "target.tag", value: { stringValue: "input" } },
+                // The input's only available name source is its `placeholder` attribute
+                // (INPUT targets never fall back to reading their own value or text
+                // content -- see TEXT_FALLBACK_EXCLUDED_TAGS / VALUE_READABLE_INPUT_TYPES
+                // in src/instrumentations/interactions/action-name.ts). The pre-filled
+                // `value="pre-filled secret"` must never leak into the emitted log.
+                { key: "name", value: { stringValue: "Type here" } },
+                { key: "name_source", value: { stringValue: "standard_attribute" } },
+              ]),
+            },
+          },
+        })
+      );
+
+      const requests = await (await import("../shared")).getOTLPRequests();
+      const logRequests = requests.filter((r) => r.path === "/v1/logs");
+      const bodies = logRequests.flatMap((r) =>
+        "resourceLogs" in r.body
+          ? r.body.resourceLogs.flatMap((rl) => rl.scopeLogs.flatMap((sl) => sl.logRecords.map((lr) => lr.body)))
+          : []
+      );
+      const interactionBody = bodies.find((b: any) =>
+        b?.kvlistValue?.values?.some((kv: any) => kv.key === "target.id" && kv.value.stringValue === "text-input")
+      ) as any;
+
+      expect(interactionBody.kvlistValue.values.map((kv: any) => kv.value?.stringValue)).not.toContain(
+        "pre-filled secret"
+      );
+      expect(interactionBody.kvlistValue.values.find((kv: any) => kv.key === "name")?.value.stringValue).not.toBe(
+        "pre-filled secret"
+      );
+    });
+  });
+
+  it("emits no browser.interaction logs when interactionInstrumentation is left at its default (disabled)", async () => {
+    await loadPage("/e2e/spec/10-interactions/page-disabled.html");
+
+    const btn = await $("#save-button");
+    await btn.click();
+    const otherBtn = await $("#plain-button");
+    await otherBtn.click();
+
+    await retry(async () => {
+      await expectNoLogMatching(
+        expect.objectContaining({
+          attributes: expect.arrayContaining([{ key: "event.name", value: { stringValue: "browser.interaction" } }]),
+        })
+      );
+    });
+  });
+});

--- a/test/e2e/spec/10-interactions/10-interactions.test.ts
+++ b/test/e2e/spec/10-interactions/10-interactions.test.ts
@@ -4,13 +4,15 @@ import { browser } from "@wdio/globals";
 import { loadPage, retry } from "../utils";
 import { expectLogMatching, expectNoBrowserErrors, expectNoLogMatching } from "../expectations";
 
+const PAGE_PATH = "/e2e/spec/10-interactions/page.html";
+
 describe("Interaction Instrumentation", () => {
   beforeEach(sharedBeforeEach);
   afterEach(sharedAfterEach);
 
   it("emits a browser.interaction log with the custom action name when a data-dash0-action-name button is clicked", async () => {
     const testId = generateUniqueId(16);
-    await loadPage(`/e2e/spec/10-interactions/page.html?testId=${testId}`);
+    await loadPage(`${PAGE_PATH}?testId=${testId}`);
     await expect(await browser.getTitle()).toMatch(/interactions test/);
 
     const btn = await $("#save-button");
@@ -24,19 +26,15 @@ describe("Interaction Instrumentation", () => {
             { key: "page.load.id", value: { stringValue: expect.any(String) } },
             { key: "session.id", value: { stringValue: expect.any(String) } },
             { key: "the_answer", value: { doubleValue: 42 } },
+            { key: "interaction.id", value: { stringValue: expect.any(String) } },
+            { key: "interaction.type", value: { stringValue: "click" } },
+            { key: "interaction.name", value: { stringValue: "Save Settings" } },
+            { key: "interaction.name_source", value: { stringValue: "custom_attribute" } },
+            { key: "interaction.target.tag", value: { stringValue: "button" } },
+            { key: "interaction.target.id", value: { stringValue: "save-button" } },
+            { key: "interaction.target.selector", value: { stringValue: "button#save-button" } },
           ]),
-          body: {
-            kvlistValue: {
-              values: expect.arrayContaining([
-                { key: "type", value: { stringValue: "click" } },
-                { key: "name", value: { stringValue: "Save Settings" } },
-                { key: "name_source", value: { stringValue: "custom_attribute" } },
-                { key: "target.tag", value: { stringValue: "button" } },
-                { key: "target.id", value: { stringValue: "save-button" } },
-                { key: "target.selector", value: { stringValue: "button#save-button" } },
-              ]),
-            },
-          },
+          body: { stringValue: `Click "Save Settings" on ${PAGE_PATH}` },
           severityNumber: 9,
           severityText: "INFO",
           timeUnixNano: expect.any(String),
@@ -49,7 +47,7 @@ describe("Interaction Instrumentation", () => {
 
   it("derives the name from visible text when no custom attribute or aria-label is present", async () => {
     const testId = generateUniqueId(16);
-    await loadPage(`/e2e/spec/10-interactions/page.html?testId=${testId}`);
+    await loadPage(`${PAGE_PATH}?testId=${testId}`);
 
     const btn = await $("#plain-button");
     await btn.click();
@@ -57,16 +55,13 @@ describe("Interaction Instrumentation", () => {
     await retry(async () => {
       await expectLogMatching(
         expect.objectContaining({
-          body: {
-            kvlistValue: {
-              values: expect.arrayContaining([
-                { key: "name", value: { stringValue: "Continue" } },
-                { key: "name_source", value: { stringValue: "text_content" } },
-                { key: "target.id", value: { stringValue: "plain-button" } },
-                { key: "target.selector", value: { stringValue: "button#plain-button" } },
-              ]),
-            },
-          },
+          attributes: expect.arrayContaining([
+            { key: "interaction.name", value: { stringValue: "Continue" } },
+            { key: "interaction.name_source", value: { stringValue: "text_content" } },
+            { key: "interaction.target.id", value: { stringValue: "plain-button" } },
+            { key: "interaction.target.selector", value: { stringValue: "button#plain-button" } },
+          ]),
+          body: { stringValue: `Click "Continue" on ${PAGE_PATH}` },
         })
       );
     });
@@ -76,7 +71,7 @@ describe("Interaction Instrumentation", () => {
 
   it("derives the name from aria-label for an icon-only button with no visible text", async () => {
     const testId = generateUniqueId(16);
-    await loadPage(`/e2e/spec/10-interactions/page.html?testId=${testId}`);
+    await loadPage(`${PAGE_PATH}?testId=${testId}`);
 
     const btn = await $("#icon-button");
     await btn.click();
@@ -84,16 +79,13 @@ describe("Interaction Instrumentation", () => {
     await retry(async () => {
       await expectLogMatching(
         expect.objectContaining({
-          body: {
-            kvlistValue: {
-              values: expect.arrayContaining([
-                { key: "name", value: { stringValue: "Close Dialog" } },
-                { key: "name_source", value: { stringValue: "standard_attribute" } },
-                { key: "target.id", value: { stringValue: "icon-button" } },
-                { key: "target.selector", value: { stringValue: "button#icon-button" } },
-              ]),
-            },
-          },
+          attributes: expect.arrayContaining([
+            { key: "interaction.name", value: { stringValue: "Close Dialog" } },
+            { key: "interaction.name_source", value: { stringValue: "standard_attribute" } },
+            { key: "interaction.target.id", value: { stringValue: "icon-button" } },
+            { key: "interaction.target.selector", value: { stringValue: "button#icon-button" } },
+          ]),
+          body: { stringValue: `Click "Close Dialog" on ${PAGE_PATH}` },
         })
       );
     });
@@ -103,7 +95,7 @@ describe("Interaction Instrumentation", () => {
 
   it("never derives a name from a text input's value, even though it has a pre-filled value", async () => {
     const testId = generateUniqueId(16);
-    await loadPage(`/e2e/spec/10-interactions/page.html?testId=${testId}`);
+    await loadPage(`${PAGE_PATH}?testId=${testId}`);
 
     const input = await $("#text-input");
     await input.click();
@@ -111,41 +103,31 @@ describe("Interaction Instrumentation", () => {
     await retry(async () => {
       await expectLogMatching(
         expect.objectContaining({
-          body: {
-            kvlistValue: {
-              values: expect.arrayContaining([
-                { key: "target.id", value: { stringValue: "text-input" } },
-                { key: "target.tag", value: { stringValue: "input" } },
-                // The input's only available name source is its `placeholder` attribute
-                // (INPUT targets never fall back to reading their own value or text
-                // content -- see TEXT_FALLBACK_EXCLUDED_TAGS / VALUE_READABLE_INPUT_TYPES
-                // in src/instrumentations/interactions/action-name.ts). The pre-filled
-                // `value="pre-filled secret"` must never leak into the emitted log.
-                { key: "name", value: { stringValue: "Type here" } },
-                { key: "name_source", value: { stringValue: "standard_attribute" } },
-              ]),
-            },
-          },
+          attributes: expect.arrayContaining([
+            { key: "interaction.target.id", value: { stringValue: "text-input" } },
+            { key: "interaction.target.tag", value: { stringValue: "input" } },
+            // The input's only available name source is its `placeholder` attribute
+            // (INPUT targets never fall back to reading their own value or text
+            // content -- see TEXT_FALLBACK_EXCLUDED_TAGS / VALUE_READABLE_INPUT_TYPES
+            // in src/instrumentations/interactions/action-name.ts). The pre-filled
+            // `value="pre-filled secret"` must never leak into the emitted log.
+            { key: "interaction.name", value: { stringValue: "Type here" } },
+            { key: "interaction.name_source", value: { stringValue: "standard_attribute" } },
+          ]),
         })
       );
 
       const requests = await getOTLPRequests();
       const logRequests = requests.filter((r) => r.path === "/v1/logs");
-      const bodies = logRequests.flatMap((r) =>
-        "resourceLogs" in r.body
-          ? r.body.resourceLogs.flatMap((rl) => rl.scopeLogs.flatMap((sl) => sl.logRecords.map((lr) => lr.body)))
-          : []
+      const logRecords = logRequests.flatMap((r) =>
+        "resourceLogs" in r.body ? r.body.resourceLogs.flatMap((rl) => rl.scopeLogs.flatMap((sl) => sl.logRecords)) : []
       );
-      const interactionBody = bodies.find((b: any) =>
-        b?.kvlistValue?.values?.some((kv: any) => kv.key === "target.id" && kv.value.stringValue === "text-input")
+      const interactionRecord = logRecords.find((lr: any) =>
+        lr.attributes?.some((kv: any) => kv.key === "interaction.target.id" && kv.value.stringValue === "text-input")
       ) as any;
 
-      expect(interactionBody.kvlistValue.values.map((kv: any) => kv.value?.stringValue)).not.toContain(
-        "pre-filled secret"
-      );
-      expect(interactionBody.kvlistValue.values.find((kv: any) => kv.key === "name")?.value.stringValue).not.toBe(
-        "pre-filled secret"
-      );
+      expect(interactionRecord.attributes.map((kv: any) => kv.value?.stringValue)).not.toContain("pre-filled secret");
+      expect(interactionRecord.body?.stringValue).not.toContain("pre-filled secret");
     });
 
     expectNoBrowserErrors();

--- a/test/e2e/spec/10-interactions/page-disabled.html
+++ b/test/e2e/spec/10-interactions/page-disabled.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <title>interactions disabled test</title>
+
+    <script>
+      (function (d, a, s, h, z, e, r, o) {
+        d[a] ||
+          ((z = d[a] =
+            function () {
+              h.push(arguments);
+            }),
+          (z._t = new Date()),
+          (z._v = 1),
+          (h = z._q = []));
+      })(window, "dash0");
+      dash0("init", {
+        serviceName: "dash0.com",
+        serviceVersion: "1.2.3",
+        environment: "prod",
+        endpoint: {
+          url: `http://${window.location.hostname}:8011?cors=true`,
+          authToken: "auth_abc123",
+          dataset: "production",
+        },
+      });
+      dash0("addSignalAttribute", "the_answer", 42);
+    </script>
+    <script defer crossorigin="anonymous" src="/dist/dash0.iife.js"></script>
+  </head>
+  <body>
+    <button id="save-button" data-dash0-action-name="Save Settings">Save</button>
+    <button id="plain-button">Continue</button>
+  </body>
+</html>

--- a/test/e2e/spec/10-interactions/page.html
+++ b/test/e2e/spec/10-interactions/page.html
@@ -1,0 +1,41 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <title>interactions test</title>
+
+    <script>
+      (function (d, a, s, h, z, e, r, o) {
+        d[a] ||
+          ((z = d[a] =
+            function () {
+              h.push(arguments);
+            }),
+          (z._t = new Date()),
+          (z._v = 1),
+          (h = z._q = []));
+      })(window, "dash0");
+      dash0("init", {
+        serviceName: "dash0.com",
+        serviceVersion: "1.2.3",
+        environment: "prod",
+        endpoint: {
+          url: `http://${window.location.hostname}:8011?cors=true`,
+          authToken: "auth_abc123",
+          dataset: "production",
+        },
+        interactionInstrumentation: {
+          enabled: true,
+        },
+      });
+      dash0("addSignalAttribute", "the_answer", 42);
+    </script>
+    <script defer crossorigin="anonymous" src="/dist/dash0.iife.js"></script>
+  </head>
+  <body>
+    <button id="save-button" data-dash0-action-name="Save Settings">Save</button>
+    <button id="plain-button">Continue</button>
+    <button id="icon-button" aria-label="Close Dialog">&times;</button>
+    <input id="text-input" type="text" value="pre-filled secret" placeholder="Type here" />
+  </body>
+</html>


### PR DESCRIPTION
## What

This PR contributes three features I built on a fork of the Web SDK, aimed at closing common gaps teams hit when migrating to Dash0 from other RUM products:

1. **`startView(nameOrOptions)` — side-effect-free manual page views**
2. **`XMLHttpRequest` instrumentation (`@dash0/xhr`)** — spans + trace-context propagation for XHR, matching the existing fetch instrumentation
3. **Opt-in interaction instrumentation (`@dash0/interactions`)** — automatic `browser.interaction` events for clicks (plus opt-in scroll / key-press / change capture) with click-to-request correlation

All three are documented in `INSTALL.md`, unit-tested, and covered by new e2e specs (`08-start-view`, `09-xhr-instrumentation`, `10-interactions`).

## Why

I work with single-page applications that the current SDK cannot fully cover:

- **Electron-style SPAs served from one root URL**: automatic page-view tracking reports every screen as `/`, and the app owns its router, so the SDK must not touch `history`/`location`. `startView` gives these apps manual page views that are indistinguishable downstream from automatic virtual page views (same `browser.page_view` event) without any navigation side effects.
- **axios/XHR-based consumers**: axios's default browser adapter uses `XMLHttpRequest`, so today those requests get no spans and no `traceparent` — frontend telemetry never joins backend traces. The new `@dash0/xhr` instrumentation closes that.
- **Interaction visibility**: teams migrating from other RUM tools expect click analytics with human-readable action names.

## Feature details

### `startView` (`src/api/start-view.ts`)

- Exported from both the npm-package and script entrypoints; accepts a string shorthand or an options object (`name`, optional `url` override).
- Never calls `history.pushState`/`replaceState` and never mutates `location`. The emitted page view carries no `change_state` value (no history mutation occurred) but is otherwise identical to an automatic virtual page view.
- Extracted a shared page-view log builder in `instrumentations/navigation/event.ts` so manual and automatic page views cannot drift.

### XHR instrumentation (`src/instrumentations/http/xhr.ts`)

- New `@dash0/xhr` instrumentation name, enabled by default alongside `@dash0/fetch`.
- Creates HTTP client spans for XHR requests (success/error/timeout/abort all end the span; per-request listeners are removed on completion to avoid leaks).
- Reuses the propagator/error helpers extracted from `fetch.ts` into `http/utils.ts`, so fetch and XHR share one propagation code path (`traceparent`, X-Ray, `propagators` config, CORS URL allow-lists).
- e2e coverage includes raw XHR, cross-origin propagation, X-Ray header delivery, and axios.
- Known limitation (candidate follow-up): environments that polyfill `fetch` on top of XHR will produce two spans for one logical request. A polyfill guard is a natural follow-up if you want it; I kept it out of scope here.

### Interaction instrumentation (`src/instrumentations/interactions/`)

- **Opt-in**: `interactionInstrumentation.enabled` defaults to `false`; scroll (`captureScrolls`), key-press (`captureKeyPresses`), and change (`captureChanges`) capture are each additionally opt-in.
- A single capture-phase `window` listener (no per-element wiring) emits one `browser.interaction` log per interaction: a plain-string human-readable body (e.g. `Click "Save Settings" on /settings`) plus namespaced `interaction.*` attributes (`type`, `name`, `name_source`, `target.tag`, `target.id`, `target.selector`, `id`).
- **Action-name derivation** walks the ancestor chain with a strict priority — configured attribute (`data-dash0-action-name` by default) → standard attributes (`aria-label`, `aria-labelledby`, `alt`, `title`, `placeholder`, button-ish `value`) → visible text → blank — with hard privacy rules: values of text/password/select fields are never read, text-content fallback never applies to form controls, names are whitespace-normalized and truncated.
- **Click-to-request correlation**: the click registers an active interaction before application handlers run, so HTTP spans triggered by the click are stamped with `user_interaction.id`/`user_interaction.name` (key presses attribute only for activation keys, Enter/Space).
- Change capture never reads field values: text fields report value length only, selects report selected count only, password fields report neither.

## Testing

- `pnpm run ci` (lint, prettier, unit tests, build): green — 380 unit tests across 29 files.
- `pnpm run test:e2e:local`: green — 11/11 spec files, including the three new specs (startView options/shorthand/url-override/side-effect coexistence; XHR raw/cross-origin/X-Ray/axios; interactions naming/privacy/default-disabled).
- `axios` was added as a devDependency only, for the XHR e2e spec.

## Notes for reviewers

- This is my own initiative rather than a scheduled roadmap item — I'm happy to adjust naming, semantics, or scope to fit your conventions.
- The three features are logically independent; if you'd rather review them separately, I can split this into three PRs (startView → XHR → interactions is the dependency-free order).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
