### PR TITLE
SUP-1284: docs: call out propagators requirement more prominently

### DIFF
--- a/.github/workflows/sync-docs/transformations.yaml
+++ b/.github/workflows/sync-docs/transformations.yaml
@@ -42,6 +42,10 @@ files:
         type: replace-regex
         find: '\]\(\./INSTALL\.md\)'
         replace: "](installation)"
+      - description: rewrite the propagators link into the sibling Configuration page
+        type: replace-regex
+        find: '\]\(\./docs/sdk/configuration\.md#propagators-configuration-recommended\)'
+        replace: "](configuration#propagators-configuration-recommended)"
       - description: rewrite the relative DEVELOPMENT.md link to the source repo (page is not synced)
         type: replace-regex
         find: '\]\(\./DEVELOPMENT\.md\)'

--- a/README.md
+++ b/README.md
@@ -60,6 +60,11 @@ init({
 });
 ```
 
+> [!IMPORTANT]
+> To correlate frontend requests with a backend on a **different origin**, you must configure **propagators** — see
+> [Propagators Configuration](./docs/sdk/configuration.md#propagators-configuration-recommended) (recommended over the
+> deprecated legacy `propagateTraceHeadersCorsURLs` option). Same-origin requests are propagated automatically.
+
 #### Session Sampling
 
 You can control the percentage of user sessions that produce telemetry by setting `sessionSamplingRate` (0–100, default 100):

--- a/docs/sdk/configuration.md
+++ b/docs/sdk/configuration.md
@@ -9,8 +9,11 @@ The SDK supports trace context propagation to correlate frontend requests with b
 and `XMLHttpRequest` (including libraries built on XHR, such as axios's default browser adapter). You can configure
 different header types (`traceparent`, `X-Amzn-Trace-Id`) for different endpoints using the `propagators` configuration.
 
-> Misconfiguration of cross origin trace correlation can lead to request failures. Please make sure to carefully
-> validate the configuration provided in the next steps
+> [!IMPORTANT]
+> To correlate frontend requests with a backend on a **different origin**, you must configure **propagators** below
+> (recommended over the deprecated legacy `propagateTraceHeadersCorsURLs` option). Same-origin requests are propagated
+> automatically. Misconfiguration of cross origin trace correlation can lead to request failures — please make sure to
+> carefully validate the configuration provided in the next steps.
 
 #### Propagators Configuration (Recommended)
 


### PR DESCRIPTION
Although we already have a coding sample under install section, teaching how to configure propagators, this wasn't clear why this was required and also nothing calling users attention.