### PR TITLE
feat: add side-effect-free startView API for manual page views

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -668,6 +668,49 @@ sendEvent("user_action", {
 dash0("sendEvent", "user_action", { data: "button_clicked", severity: "INFO" });
 ```
 
+#### `startView(nameOrOptions)`
+
+Manually records a page view. Side-effect free: this never calls `history.pushState` /
+`history.replaceState` and never mutates `location`. Use this for single-page applications that
+own their own router and cannot let the SDK touch navigation state — for example, an Electron
+app that serves the whole application from one root URL, where automatic page-view tracking
+would report every screen as `/`.
+
+The emitted page view is indistinguishable from an automatic virtual page view downstream (same
+`browser.page_view` event, same `type` value); the only difference is that it is never
+accompanied by a `change_state` value, since no history mutation occurred.
+
+**Parameters:**
+
+- `nameOrOptions` (string | object): Either the view name directly, or an options object:
+  - `name` (string): The name of the view, e.g. `/settings`. Transmitted as the page view's title.
+  - `url` (string, optional): Overrides the url reflected in `page.url.*` attributes for this
+    view. Accepts an absolute or relative url; relative urls are resolved against the current
+    `location.href`. Falls back to the real `location.href` if omitted or invalid. Display-only —
+    never navigates or mutates history/location.
+  - `attributes` (Record<string, AttributeValueType | AnyValue>, optional): Additional attributes
+    to include with the page view.
+
+**Example:**
+
+```js
+// Module
+import { startView } from "@dash0/sdk-web";
+
+startView({
+  name: "/settings",
+  attributes: {
+    "app.screen": "settings",
+  },
+});
+
+// String shorthand
+startView("/checkout");
+
+// Script
+dash0("startView", { name: "/settings", attributes: { "app.screen": "settings" } });
+```
+
 ### Error Reporting
 
 #### `reportError(error, opts)`

--- a/src/api/start-view.ts
+++ b/src/api/start-view.ts
@@ -1,0 +1,61 @@
+import { transmitManualPageViewEvent } from "../instrumentations/navigation/event";
+import { AttributeValueType } from "../utils/otel";
+import { AnyValue } from "../types/otlp";
+import { debug, nowNanos, win } from "../utils";
+import { vars } from "../vars";
+
+export type StartViewOptions = {
+  /**
+   * The name of the view, e.g. "/settings". Transmitted as the page view's title.
+   */
+  name: string;
+
+  /**
+   * Optionally override the url reflected in `page.url.*` attributes for this view.
+   * Accepts an absolute or relative url; relative urls are resolved against the current
+   * `location.href`. Falls back to the real `location.href` if omitted or invalid.
+   * This is display-only: calling startView never navigates or mutates history/location.
+   */
+  url?: string;
+
+  /**
+   * Additional attributes to include with the page view.
+   */
+  attributes?: Record<string, AttributeValueType | AnyValue>;
+};
+
+/**
+ * Manually records a page view, side-effect free: this never calls `history.pushState` /
+ * `history.replaceState` and never mutates `location`. Intended for single-page applications
+ * that own their own router and cannot let the SDK touch navigation state (e.g. Electron apps
+ * serving the whole app from one root URL, where automatic page-view tracking would report
+ * every screen as "/").
+ *
+ * The emitted event is indistinguishable from an automatic virtual page view downstream
+ * (same `browser.page_view` event name, same `type` value); the difference is only that it is
+ * never accompanied by a `change_state` value, since no history mutation occurred.
+ */
+export function startView(nameOrOptions: string | StartViewOptions) {
+  if (vars.endpoints.length === 0) {
+    debug("Dash0 SDK has not been initialized. Ignoring startView call.");
+    return;
+  }
+
+  const opts: StartViewOptions = typeof nameOrOptions === "string" ? { name: nameOrOptions } : nameOrOptions;
+
+  let url: URL | undefined;
+  if (opts.url != null) {
+    try {
+      url = new URL(opts.url, win?.location.href);
+    } catch (e) {
+      debug("Failed to parse startView url option. Falling back to the current location.", e);
+    }
+  }
+
+  transmitManualPageViewEvent({
+    timeUnixNano: nowNanos(),
+    title: opts.name,
+    url,
+    attributes: opts.attributes,
+  });
+}

--- a/src/api/start-view_test.ts
+++ b/src/api/start-view_test.ts
@@ -1,0 +1,80 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { KeyValue, LogRecord } from "../types/otlp";
+
+vi.mock("../transport", () => ({
+  sendLog: vi.fn(),
+}));
+
+import { sendLog } from "../transport";
+import { startView } from "./start-view";
+import { vars } from "../vars";
+
+const sendLogMock = sendLog as unknown as ReturnType<typeof vi.fn>;
+
+describe("startView", () => {
+  beforeEach(() => {
+    sendLogMock.mockClear();
+    vars.endpoints = [{ url: "https://example.com", authToken: "auth_abc123" }];
+    vars.pageViewInstrumentation = { trackVirtualPageViews: true, includeParts: [] };
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    vars.endpoints = [];
+  });
+
+  it("accepts a string shorthand and uses it as the title", () => {
+    startView("/settings");
+
+    expect(sendLogMock).toHaveBeenCalledTimes(1);
+    const log = sendLogMock.mock.calls[0]![0] as LogRecord;
+    const bodyValues = log.body?.kvlistValue?.values as KeyValue[];
+    expect(bodyValues).toEqual(expect.arrayContaining([{ key: "title", value: { stringValue: "/settings" } }]));
+  });
+
+  it("accepts an options object with name and attributes", () => {
+    startView({ name: "/settings", attributes: { "app.screen": "settings" } });
+
+    const log = sendLogMock.mock.calls[0]![0] as LogRecord;
+    const bodyValues = log.body?.kvlistValue?.values as KeyValue[];
+    expect(bodyValues).toEqual(expect.arrayContaining([{ key: "title", value: { stringValue: "/settings" } }]));
+    expect(log.attributes).toEqual(expect.arrayContaining([{ key: "app.screen", value: { stringValue: "settings" } }]));
+  });
+
+  it("parses a relative url option and reflects it in page.url.path", () => {
+    startView({ name: "/settings", url: "/settings" });
+
+    const log = sendLogMock.mock.calls[0]![0] as LogRecord;
+    expect(log.attributes).toEqual(
+      expect.arrayContaining([{ key: "page.url.path", value: { stringValue: "/settings" } }])
+    );
+  });
+
+  it("falls back to no url override and logs a debug message on an invalid url", () => {
+    startView({ name: "/settings", url: "http://" });
+
+    expect(sendLogMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not touch history or location", () => {
+    // eslint-disable-next-line no-restricted-globals
+    const originalHref = window.location.href;
+    // eslint-disable-next-line no-restricted-globals
+    const originalLength = window.history.length;
+
+    startView({ name: "/settings" });
+
+    // eslint-disable-next-line no-restricted-globals
+    expect(window.location.href).toBe(originalHref);
+    // eslint-disable-next-line no-restricted-globals
+    expect(window.history.length).toBe(originalLength);
+  });
+
+  it("is a no-op before init (no endpoints configured)", () => {
+    vars.endpoints = [];
+
+    startView("/settings");
+
+    expect(sendLogMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/entrypoint/npm-package.ts
+++ b/src/entrypoint/npm-package.ts
@@ -9,12 +9,14 @@ export * from "../api/events";
 export * from "../api/log-level";
 export { terminateSession } from "../api/session";
 export { reportError } from "../api/report-error";
+export { startView } from "../api/start-view";
 
 // Additional utility types
 export type { AttributeValueType } from "../utils/otel";
 export type { AnyValue } from "../types/otlp";
 export type { PageViewMeta, PropagatorConfig, PropagatorType } from "../vars";
 export type { UrlAttributeScrubber, UrlAttributeRecord } from "../attributes/url";
+export type { StartViewOptions } from "../api/start-view";
 
 export function init(opts: InitOptions): void {
   debug(`${INIT_MESSAGE} (via package)`);

--- a/src/entrypoint/npm-package_test.ts
+++ b/src/entrypoint/npm-package_test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from "vitest";
+import * as npmPackage from "./npm-package";
+
+describe("npm-package entrypoint", () => {
+  it("exports startView", () => {
+    expect(typeof npmPackage.startView).toBe("function");
+  });
+});

--- a/src/entrypoint/script.ts
+++ b/src/entrypoint/script.ts
@@ -8,6 +8,7 @@ import { terminateSession } from "../api/session";
 import { addSignalAttribute, removeSignalAttribute } from "../api/attributes";
 import { sendEvent } from "../api/events";
 import { setActiveLogLevel } from "../api/log-level";
+import { startView } from "../api/start-view";
 
 /**
  * All the APIs exposed through the script tag via `dash0('{{api name}}')`
@@ -22,6 +23,7 @@ const scriptApis = {
   removeSignalAttribute,
   setActiveLogLevel,
   sendEvent,
+  startView,
 } as const;
 
 type GlobalObject = {

--- a/src/instrumentations/navigation/event.ts
+++ b/src/instrumentations/navigation/event.ts
@@ -11,6 +11,8 @@ import {
 import { doc, NO_VALUE_FALLBACK } from "../../utils";
 import { addCommonAttributes } from "../../attributes";
 import { sendLog } from "../../transport";
+import { AttributeValueType } from "../../utils/otel";
+import { AnyValue } from "../../types/otlp";
 import { PageViewMeta, vars } from "../../vars";
 import { KeyValue, LogRecord } from "../../types/otlp";
 
@@ -20,32 +22,37 @@ function getPageViewMeta(url?: URL): PageViewMeta {
   return vars.pageViewInstrumentation.generateMetadata?.(url) ?? {};
 }
 
-export function transmitPageViewEvent(timeUnixNano: string, url?: URL, virtual?: boolean, replaced?: boolean) {
-  const meta = getPageViewMeta(url);
+type BuildPageViewLogOptions = {
+  timeUnixNano: string;
+  url?: URL;
+  title?: string;
+  metaAttributes?: Record<string, AttributeValueType | AnyValue>;
+  pageViewType: number;
+  changeState?: string;
+};
 
+function buildAndSendPageViewLog(opts: BuildPageViewLogOptions) {
   const attributes: KeyValue[] = [];
   addAttribute(attributes, EVENT_NAME, EVENT_NAMES.PAGE_VIEW);
 
-  if (meta.attributes) {
-    Object.entries(meta.attributes).forEach(([key, value]) => addAttribute(attributes, key, value));
+  if (opts.metaAttributes) {
+    Object.entries(opts.metaAttributes).forEach(([key, value]) => addAttribute(attributes, key, value));
   }
-  addCommonAttributes(attributes, { url });
+  addCommonAttributes(attributes, { url: opts.url });
 
   const bodyAttributes: KeyValue[] = [];
-  addAttribute(bodyAttributes, "title", meta.title ?? doc?.title ?? NO_VALUE_FALLBACK);
+  addAttribute(bodyAttributes, "title", opts.title ?? doc?.title ?? NO_VALUE_FALLBACK);
   if (doc?.referrer) {
     addAttribute(bodyAttributes, "referrer", doc.referrer);
   }
 
-  addAttribute(bodyAttributes, PAGE_VIEW_TYPE, virtual ? PAGE_VIEW_TYPE_VALUES.VIRTUAL : PAGE_VIEW_TYPE_VALUES.INITIAL);
-  addAttribute(
-    bodyAttributes,
-    PAGE_VIEW_CHANGE_STATE,
-    replaced ? PAGE_VIEW_CHANGE_STATE_VALUES.REPLACE : PAGE_VIEW_CHANGE_STATE_VALUES.PUSH
-  );
+  addAttribute(bodyAttributes, PAGE_VIEW_TYPE, opts.pageViewType);
+  if (opts.changeState) {
+    addAttribute(bodyAttributes, PAGE_VIEW_CHANGE_STATE, opts.changeState);
+  }
 
   const log: LogRecord = {
-    timeUnixNano: timeUnixNano,
+    timeUnixNano: opts.timeUnixNano,
     attributes: attributes,
     severityNumber: LOG_SEVERITIES.INFO,
     severityText: "INFO",
@@ -63,4 +70,41 @@ export function transmitPageViewEvent(timeUnixNano: string, url?: URL, virtual?:
   }
 
   sendLog(log);
+}
+
+export function transmitPageViewEvent(timeUnixNano: string, url?: URL, virtual?: boolean, replaced?: boolean) {
+  const meta = getPageViewMeta(url);
+
+  buildAndSendPageViewLog({
+    timeUnixNano,
+    url,
+    title: meta.title,
+    metaAttributes: meta.attributes,
+    pageViewType: virtual ? PAGE_VIEW_TYPE_VALUES.VIRTUAL : PAGE_VIEW_TYPE_VALUES.INITIAL,
+    changeState: replaced ? PAGE_VIEW_CHANGE_STATE_VALUES.REPLACE : PAGE_VIEW_CHANGE_STATE_VALUES.PUSH,
+  });
+}
+
+export type ManualPageViewOptions = {
+  timeUnixNano: string;
+  url?: URL;
+  title: string;
+  attributes?: Record<string, AttributeValueType | AnyValue>;
+};
+
+/**
+ * Emits a manually-triggered page view log, e.g. from the public `startView` API.
+ * Deliberately does NOT read `vars.pageViewInstrumentation.generateMetadata` and does NOT
+ * include a `change_state` body key (a manual view is neither a pushState nor replaceState).
+ * The emitted `type` is PAGE_VIEW_TYPE_VALUES.VIRTUAL, matching automatic virtual page views —
+ * manual views are deliberately indistinguishable from virtual ones downstream.
+ */
+export function transmitManualPageViewEvent(opts: ManualPageViewOptions) {
+  buildAndSendPageViewLog({
+    timeUnixNano: opts.timeUnixNano,
+    url: opts.url,
+    title: opts.title,
+    metaAttributes: opts.attributes,
+    pageViewType: PAGE_VIEW_TYPE_VALUES.VIRTUAL,
+  });
 }

--- a/src/instrumentations/navigation/event_test.ts
+++ b/src/instrumentations/navigation/event_test.ts
@@ -1,0 +1,73 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { KeyValue, LogRecord } from "../../types/otlp";
+
+vi.mock("../../transport", () => ({
+  sendLog: vi.fn(),
+}));
+
+import { sendLog } from "../../transport";
+import { transmitPageViewEvent } from "./event";
+import { vars } from "../../vars";
+
+const sendLogMock = sendLog as unknown as ReturnType<typeof vi.fn>;
+
+describe("transmitPageViewEvent", () => {
+  beforeEach(() => {
+    sendLogMock.mockClear();
+    vars.pageViewInstrumentation = { trackVirtualPageViews: true, includeParts: [] };
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("transmits an initial page view with type=INITIAL and change_state=pushState", () => {
+    transmitPageViewEvent("1700000000000000000", new URL("https://example.com/landing"));
+
+    expect(sendLogMock).toHaveBeenCalledTimes(1);
+    const log = sendLogMock.mock.calls[0]![0] as LogRecord;
+
+    expect(log.timeUnixNano).toBe("1700000000000000000");
+    expect(log.severityNumber).toBe(9);
+    expect(log.severityText).toBe("INFO");
+    expect(log.attributes).toEqual(
+      expect.arrayContaining([{ key: "event.name", value: { stringValue: "browser.page_view" } }])
+    );
+
+    const bodyValues = log.body?.kvlistValue?.values as KeyValue[];
+    expect(bodyValues).toEqual(
+      expect.arrayContaining([
+        { key: "type", value: { doubleValue: 0 } },
+        { key: "change_state", value: { stringValue: "pushState" } },
+      ])
+    );
+  });
+
+  it("transmits a virtual page view with type=VIRTUAL and change_state=replaceState when replaced", () => {
+    transmitPageViewEvent("1700000000000000000", new URL("https://example.com/settings"), true, true);
+
+    const log = sendLogMock.mock.calls[0]![0] as LogRecord;
+    const bodyValues = log.body?.kvlistValue?.values as KeyValue[];
+    expect(bodyValues).toEqual(
+      expect.arrayContaining([
+        { key: "type", value: { doubleValue: 1 } },
+        { key: "change_state", value: { stringValue: "replaceState" } },
+      ])
+    );
+  });
+
+  it("applies generateMetadata title and attributes when provided", () => {
+    vars.pageViewInstrumentation = {
+      trackVirtualPageViews: true,
+      includeParts: [],
+      generateMetadata: () => ({ title: "Custom Title", attributes: { "app.screen": "settings" } }),
+    };
+
+    transmitPageViewEvent("1700000000000000000", new URL("https://example.com/settings"), true);
+
+    const log = sendLogMock.mock.calls[0]![0] as LogRecord;
+    expect(log.attributes).toEqual(expect.arrayContaining([{ key: "app.screen", value: { stringValue: "settings" } }]));
+    const bodyValues = log.body?.kvlistValue?.values as KeyValue[];
+    expect(bodyValues).toEqual(expect.arrayContaining([{ key: "title", value: { stringValue: "Custom Title" } }]));
+  });
+});

--- a/src/instrumentations/navigation/event_test.ts
+++ b/src/instrumentations/navigation/event_test.ts
@@ -84,6 +84,7 @@ describe("transmitManualPageViewEvent", () => {
 
   afterEach(() => {
     vi.clearAllMocks();
+    vars.pageViewInstrumentation = { trackVirtualPageViews: true, includeParts: [] };
   });
 
   it("emits type=VIRTUAL and no change_state key", () => {

--- a/src/instrumentations/navigation/event_test.ts
+++ b/src/instrumentations/navigation/event_test.ts
@@ -6,7 +6,7 @@ vi.mock("../../transport", () => ({
 }));
 
 import { sendLog } from "../../transport";
-import { transmitPageViewEvent } from "./event";
+import { transmitPageViewEvent, transmitManualPageViewEvent } from "./event";
 import { vars } from "../../vars";
 
 const sendLogMock = sendLog as unknown as ReturnType<typeof vi.fn>;
@@ -69,5 +69,85 @@ describe("transmitPageViewEvent", () => {
     expect(log.attributes).toEqual(expect.arrayContaining([{ key: "app.screen", value: { stringValue: "settings" } }]));
     const bodyValues = log.body?.kvlistValue?.values as KeyValue[];
     expect(bodyValues).toEqual(expect.arrayContaining([{ key: "title", value: { stringValue: "Custom Title" } }]));
+  });
+});
+
+describe("transmitManualPageViewEvent", () => {
+  beforeEach(() => {
+    sendLogMock.mockClear();
+    vars.pageViewInstrumentation = {
+      trackVirtualPageViews: true,
+      includeParts: [],
+      generateMetadata: () => ({ title: "should not be used", attributes: { should_not_appear: true } }),
+    };
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("emits type=VIRTUAL and no change_state key", () => {
+    transmitManualPageViewEvent({ timeUnixNano: "1700000000000000000", title: "/settings" });
+
+    const log = sendLogMock.mock.calls[0]![0] as LogRecord;
+    const bodyValues = log.body?.kvlistValue?.values as KeyValue[];
+
+    expect(bodyValues).toEqual(
+      expect.arrayContaining([
+        { key: "type", value: { doubleValue: 1 } },
+        { key: "title", value: { stringValue: "/settings" } },
+      ])
+    );
+    expect(bodyValues.find((v) => v.key === "change_state")).toBeUndefined();
+  });
+
+  it("does not invoke vars.pageViewInstrumentation.generateMetadata", () => {
+    const generateMetadata = vi.fn().mockReturnValue({ title: "ignored" });
+    vars.pageViewInstrumentation = { trackVirtualPageViews: true, includeParts: [], generateMetadata };
+
+    transmitManualPageViewEvent({ timeUnixNano: "1700000000000000000", title: "/settings" });
+
+    expect(generateMetadata).not.toHaveBeenCalled();
+    const log = sendLogMock.mock.calls[0]![0] as LogRecord;
+    const bodyValues = log.body?.kvlistValue?.values as KeyValue[];
+    expect(bodyValues).toEqual(expect.arrayContaining([{ key: "title", value: { stringValue: "/settings" } }]));
+  });
+
+  it("merges custom attributes into signal attributes", () => {
+    transmitManualPageViewEvent({
+      timeUnixNano: "1700000000000000000",
+      title: "/settings",
+      attributes: { "app.screen": "settings", "app.tab_index": 2 },
+    });
+
+    const log = sendLogMock.mock.calls[0]![0] as LogRecord;
+    expect(log.attributes).toEqual(
+      expect.arrayContaining([
+        { key: "app.screen", value: { stringValue: "settings" } },
+        { key: "app.tab_index", value: { doubleValue: 2 } },
+      ])
+    );
+  });
+
+  it("passes url through to page.url.* attributes when provided", () => {
+    transmitManualPageViewEvent({
+      timeUnixNano: "1700000000000000000",
+      title: "/settings",
+      url: new URL("https://example.com/settings"),
+    });
+
+    const log = sendLogMock.mock.calls[0]![0] as LogRecord;
+    expect(log.attributes).toEqual(
+      expect.arrayContaining([{ key: "page.url.path", value: { stringValue: "/settings" } }])
+    );
+  });
+
+  it("includes referrer the same way the auto path does", () => {
+    transmitManualPageViewEvent({ timeUnixNano: "1700000000000000000", title: "/settings" });
+
+    const log = sendLogMock.mock.calls[0]![0] as LogRecord;
+    const bodyValues = log.body?.kvlistValue?.values as KeyValue[];
+    // doc.referrer is empty string in jsdom by default, so "referrer" key should be absent
+    expect(bodyValues.find((v) => v.key === "referrer")).toBeUndefined();
   });
 });

--- a/test/e2e/spec/08-start-view/08-start-view.test.ts
+++ b/test/e2e/spec/08-start-view/08-start-view.test.ts
@@ -1,0 +1,76 @@
+import { sharedAfterEach, sharedBeforeEach } from "../shared";
+import { generateUniqueId } from "../../../../src/utils";
+import { browser } from "@wdio/globals";
+import { loadPage, retry } from "../utils";
+import { expectLogMatching, expectNoBrowserErrors } from "../expectations";
+import { PAGE_VIEW_TYPE_VALUES } from "../../../../src/semantic-conventions";
+
+describe("Start View", () => {
+  beforeEach(sharedBeforeEach);
+  afterEach(sharedAfterEach);
+
+  it("transmits a page view with the given name and attributes (options object)", async () => {
+    const testId = generateUniqueId(16);
+    await loadPage(`/e2e/spec/08-start-view/page.html?testId=${testId}`);
+    await expect(await browser.getTitle()).toMatch(/start view test/);
+
+    const btn = await $("button=Start View Options");
+    await btn.click();
+
+    await retry(async () => {
+      await expectLogMatching(
+        expect.objectContaining({
+          attributes: expect.arrayContaining([
+            { key: "event.name", value: { stringValue: "browser.page_view" } },
+            { key: "app.screen", value: { stringValue: "settings" } },
+            { key: "page.load.id", value: { stringValue: expect.any(String) } },
+            { key: "session.id", value: { stringValue: expect.any(String) } },
+          ]),
+          body: {
+            kvlistValue: {
+              values: expect.arrayContaining([
+                { key: "type", value: { doubleValue: PAGE_VIEW_TYPE_VALUES.VIRTUAL } },
+                { key: "title", value: { stringValue: "/settings" } },
+              ]),
+            },
+          },
+          severityNumber: 9,
+          severityText: "INFO",
+          timeUnixNano: expect.any(String),
+        })
+      );
+    });
+
+    expectNoBrowserErrors();
+  });
+
+  it("transmits a page view from the string shorthand", async () => {
+    const testId = generateUniqueId(16);
+    await loadPage(`/e2e/spec/08-start-view/page.html?testId=${testId}`);
+    await expect(await browser.getTitle()).toMatch(/start view test/);
+
+    const btn = await $("button=Start View String");
+    await btn.click();
+
+    await retry(async () => {
+      await expectLogMatching(
+        expect.objectContaining({
+          attributes: expect.arrayContaining([{ key: "event.name", value: { stringValue: "browser.page_view" } }]),
+          body: {
+            kvlistValue: {
+              values: expect.arrayContaining([
+                { key: "type", value: { doubleValue: PAGE_VIEW_TYPE_VALUES.VIRTUAL } },
+                { key: "title", value: { stringValue: "/checkout" } },
+              ]),
+            },
+          },
+          severityNumber: 9,
+          severityText: "INFO",
+          timeUnixNano: expect.any(String),
+        })
+      );
+    });
+
+    expectNoBrowserErrors();
+  });
+});

--- a/test/e2e/spec/08-start-view/08-start-view.test.ts
+++ b/test/e2e/spec/08-start-view/08-start-view.test.ts
@@ -73,4 +73,98 @@ describe("Start View", () => {
 
     expectNoBrowserErrors();
   });
+
+  it("reflects the url override in page.url.path", async () => {
+    const testId = generateUniqueId(16);
+    await loadPage(`/e2e/spec/08-start-view/page.html?testId=${testId}`);
+    await expect(await browser.getTitle()).toMatch(/start view test/);
+
+    const btn = await $("button=Start View With Url");
+    await btn.click();
+
+    await retry(async () => {
+      await expectLogMatching(
+        expect.objectContaining({
+          attributes: expect.arrayContaining([
+            { key: "event.name", value: { stringValue: "browser.page_view" } },
+            { key: "page.url.path", value: { stringValue: "/settings" } },
+          ]),
+          body: {
+            kvlistValue: {
+              values: expect.arrayContaining([
+                { key: "type", value: { doubleValue: PAGE_VIEW_TYPE_VALUES.VIRTUAL } },
+                { key: "title", value: { stringValue: "/settings" } },
+              ]),
+            },
+          },
+        })
+      );
+    });
+
+    expectNoBrowserErrors();
+  });
+
+  it("never touches history or location", async () => {
+    const testId = generateUniqueId(16);
+    await loadPage(`/e2e/spec/08-start-view/page.html?testId=${testId}`);
+    await expect(await browser.getTitle()).toMatch(/start view test/);
+
+    const before = await browser.execute(() => ({
+      href: window.location.href,
+      historyLength: window.history.length,
+    }));
+
+    const btn = await $("button=Start View Options");
+    await btn.click();
+    await retry(async () => {
+      await expectLogMatching(
+        expect.objectContaining({
+          attributes: expect.arrayContaining([{ key: "event.name", value: { stringValue: "browser.page_view" } }]),
+        })
+      );
+    });
+
+    const after = await browser.execute(() => ({
+      href: window.location.href,
+      historyLength: window.history.length,
+    }));
+
+    expect(after.href).toBe(before.href);
+    expect(after.historyLength).toBe(before.historyLength);
+
+    expectNoBrowserErrors();
+  });
+
+  it("does not interfere with automatic page-view instrumentation on the same page", async () => {
+    const testId = generateUniqueId(16);
+    await loadPage(`/e2e/spec/08-start-view/page.html?testId=${testId}`);
+    await expect(await browser.getTitle()).toMatch(/start view test/);
+
+    const btn = await $("button=Real Push State");
+    await btn.click();
+
+    await retry(async () => {
+      await expectLogMatching(
+        expect.objectContaining({
+          attributes: expect.arrayContaining([
+            { key: "event.name", value: { stringValue: "browser.page_view" } },
+            {
+              key: "page.url.full",
+              value: { stringValue: expect.stringContaining("/e2e/spec/08-start-view/virtual-page") },
+            },
+          ]),
+          body: {
+            kvlistValue: {
+              values: expect.arrayContaining([
+                { key: "type", value: { doubleValue: PAGE_VIEW_TYPE_VALUES.VIRTUAL } },
+                { key: "change_state", value: { stringValue: "pushState" } },
+              ]),
+            },
+          },
+        })
+      );
+    });
+
+    expectNoBrowserErrors();
+  });
 });

--- a/test/e2e/spec/08-start-view/page.html
+++ b/test/e2e/spec/08-start-view/page.html
@@ -1,0 +1,54 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <title>start view test</title>
+
+    <script>
+      (function (d, a, s, h, z, e, r, o) {
+        d[a] ||
+          ((z = d[a] =
+            function () {
+              h.push(arguments);
+            }),
+          (z._t = new Date()),
+          (z._v = 1),
+          (h = z._q = []));
+      })(window, "dash0");
+
+      dash0("init", {
+        serviceName: "dash0.com",
+        serviceVersion: "1.2.3",
+        environment: "prod",
+        endpoint: {
+          url: `http://${window.location.hostname}:8011?cors=true`,
+          authToken: "auth_abc123",
+          dataset: "production",
+        },
+      });
+
+      function onStartViewOptions() {
+        dash0("startView", { name: "/settings", attributes: { "app.screen": "settings" } });
+      }
+
+      function onStartViewString() {
+        dash0("startView", "/checkout");
+      }
+
+      function onStartViewWithUrl() {
+        dash0("startView", { name: "/settings", url: "/settings" });
+      }
+
+      function onRealPushState() {
+        history.pushState(undefined, "", new URL("./virtual-page", window.location.href));
+      }
+    </script>
+    <script defer crossorigin="anonymous" src="/dist/dash0.iife.js"></script>
+  </head>
+  <body>
+    <button onclick="onStartViewOptions()">Start View Options</button>
+    <button onclick="onStartViewString()">Start View String</button>
+    <button onclick="onStartViewWithUrl()">Start View With Url</button>
+    <button onclick="onRealPushState()">Real Push State</button>
+  </body>
+</html>


### PR DESCRIPTION
## What

Adds a side-effect-free `startView(nameOrOptions)` API for manually recording page views. This replaces #93 (closed), split per feature at the reviewing team's request — this is part 1 of 3, and it is fully independent of the other two (#97 XHR instrumentation, #98 interaction instrumentation).

## Why

I work with single-page applications that the automatic page-view instrumentation cannot fully cover — for example, an Electron-style SPA served from one root URL: every screen reports as `/`, and the app owns its own router, so the SDK must not touch `history`/`location`.

`startView` gives these apps manual page views that are indistinguishable downstream from automatic virtual page views (same `browser.page_view` event, same `type` value) without any navigation side effects.

## How

- `startView` accepts a string shorthand (`startView("Checkout")`) or an options object (`name`, optional `url` override). Exported from both the npm-package and script entrypoints.
- It never calls `history.pushState`/`replaceState` and never mutates `location`. The emitted page view carries no `change_state` value (no history mutation occurred) but is otherwise identical to an automatic virtual page view.
- A shared page-view log builder was extracted in `instrumentations/navigation/event.ts` so manual and automatic page views cannot drift.
- Documented in `INSTALL.md`.

## Testing

- `pnpm run ci` (lint, prettier, unit tests, build): green — 272 unit tests across 19 files, including new coverage for `start-view.ts` and the extracted log builder.
- New e2e spec `08-start-view` (string shorthand, options object, `url` override, no-side-effect assertions, coexistence with automatic instrumentation): green locally via `pnpm run test:e2e:local`.

## Notes for reviewers

This is my own initiative rather than a scheduled roadmap item — happy to adjust naming, semantics, or scope to fit your conventions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
