### PR TITLE
feat: add opt-in interaction instrumentation with click-to-request correlation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Features include:
 - Navigation timing instrumentation
 - HTTP request instrumentation (fetch and XMLHttpRequest)
 - Error tracking
+- Opt-in user interaction instrumentation with click-to-request correlation
 
 ## Getting started
 

--- a/docs/sdk/configuration.md
+++ b/docs/sdk/configuration.md
@@ -448,20 +448,45 @@ for `fetch`, while an `XMLHttpRequest` timeout is an error — this asymmetry is
 
 #### Interaction instrumentation
 
-Opt-in automatic capture of click interactions (Datadog RUM `trackUserInteractions` parity). Disabled by default --
-set `interactionInstrumentation.enabled: true` to turn it on. When enabled, a single capture-phase listener on
-`window` observes clicks anywhere on the page (no per-element wiring, no listener leakage) and emits a
-`browser.interaction` web event per click with a derived, privacy-conscious interaction name and a compact
-target-element selector.
+Opt-in automatic capture of user interactions. Disabled by default --
+set `interactionInstrumentation.enabled: true` to turn it on. When enabled, the SDK attaches capture-phase listeners
+on `window` (no per-element wiring, no listener leakage) and emits one `browser.interaction` web event per
+interaction, carrying a derived, privacy-conscious interaction name and a compact target-element selector.
+
+Clicks are captured whenever the instrumentation is enabled. Scroll, key-press and form-change capture are each
+_additionally_ opt-in via their own flags below.
 
 - **Enable Interaction Instrumentation**<br>
   key: `interactionInstrumentation.enabled`<br>
   type: `boolean`<br>
   optional: `true`<br>
   default: `false`<br>
-  Whether the SDK should automatically capture click interactions. Also requires `'@dash0/interactions'` to be
-  present in `enabledInstrumentations` when that option is explicitly set (it is included by default when
+  Whether the SDK should automatically capture user interactions. Enables click capture; the three capture flags
+  below have no effect unless this is `true`. Also requires `'@dash0/interactions'` to be present in
+  `enabledInstrumentations` when that option is explicitly set (it is included by default when
   `enabledInstrumentations` is left `undefined`).
+- **Capture Scrolls**<br>
+  key: `interactionInstrumentation.captureScrolls`<br>
+  type: `boolean`<br>
+  optional: `true`<br>
+  default: `false`<br>
+  Emit one `scroll` interaction per scroll burst, with the burst's net direction in `interaction.direction`.
+  Consecutive scroll events are coalesced; bursts smaller than a few pixels are discarded.
+- **Capture Key Presses**<br>
+  key: `interactionInstrumentation.captureKeyPresses`<br>
+  type: `boolean`<br>
+  optional: `true`<br>
+  default: `false`<br>
+  Emit a `key_press` interaction for allow-listed navigation and activation keys only (e.g. `Enter`, `Tab`,
+  `Escape`, arrow keys). Printable characters are never recorded -- see the privacy note below.
+- **Capture Changes**<br>
+  key: `interactionInstrumentation.captureChanges`<br>
+  type: `boolean`<br>
+  optional: `true`<br>
+  default: `false`<br>
+  Emit a `change` interaction when a form control's value is committed. Reports only `interaction.value_length`
+  for text fields and `interaction.selected_count` for selects -- never the value itself, and neither for
+  password fields.
 - **Action Name Attribute**<br>
   key: `interactionInstrumentation.actionNameAttribute`<br>
   type: `string`<br>
@@ -478,21 +503,37 @@ the first `FORM`, `BODY`, `HTML`, or `HEAD` boundary):
 2. `standard_attribute` -- attribute-derived names checked on the target then ancestors: for `button`/`submit`/`reset`
    inputs, `.value`; then `aria-label`, `aria-labelledby` (resolved via the referenced element(s)' text), `alt`,
    `title`, or `placeholder`.
-3. `text_content` -- visible text: first the text of clickable-tag elements (`BUTTON`, `LABEL`, `A`, or
-   `role="button"`) found while walking up from the target, then the target's own visible text. This fallback never
-   applies when the click target itself is an `INPUT`, `TEXTAREA`, `SELECT`, or `OPTION` element, since their text
-   content is user data rather than an action label.
+3. `text_content` -- the visible text of clickable-tag elements (`BUTTON`, `LABEL`, `A`, or `role="button"`) found
+   while walking up from the target. The target's own text is only read when the target is itself one of those
+   clickable tags: a click landing on a plain container (a layout `<div>`, `<footer>`, …) with no clickable element
+   in its ancestor path deliberately yields a blank name plus target metadata, rather than the container's entire
+   visible text. This phase is skipped entirely when the click target is an `INPUT`, `TEXTAREA`, `SELECT`, or
+   `OPTION` element, since their text content is user data rather than an action label.
 4. `blank` -- an empty name, if nothing above matched.
 
 Attribute-derived sources always outrank text: the full phase order is custom attribute → standard attributes
-(walk) → text content (walk, then target) → blank. Each captured event's `name_source` attribute reflects which
+(walk) → text content (walk) → blank. Each captured event's `interaction.name_source` attribute reflects which
 phase produced the name.
 
 **Privacy defaults (not configurable):** the SDK never reads the value of `password`, `text`, `textarea`, or
 `select` elements -- only `button`/`submit`/`reset` inputs expose their value for name derivation, and the
-text-content fallback above never applies to `INPUT`/`TEXTAREA`/`SELECT`/`OPTION` targets. Derived names are
-whitespace-normalized and truncated to 100 characters. The target-element selector is independently capped at 128
-characters.
+text-content phase above never applies to `INPUT`/`TEXTAREA`/`SELECT`/`OPTION` click targets. Key-press capture
+records only allow-listed control keys, never printable characters. Change capture records value length and
+selected count, never values. Derived names are whitespace-normalized and truncated to 100 characters (plus a
+` [...]` marker when truncation occurred). The target-element selector is independently capped at 128 characters.
+
+**Emitted attributes.** Every `browser.interaction` event carries `interaction.id`, `interaction.type` (`click`,
+`scroll`, `key_press`, or `change`), `interaction.name`, `interaction.name_source`, `interaction.target.tag`,
+`interaction.target.selector`, and `interaction.target.id` when the element has one. Type-specific attributes:
+`interaction.direction` (scroll), `interaction.key` (key press), and `interaction.value_length` /
+`interaction.selected_count` (change). The event body is a human-readable string such as
+`Click "Save Settings" on /settings`; treat the attributes, not the body, as the stable contract.
+
+**Click-to-request correlation.** A click registers a short-lived (2 second) active interaction before the page's
+own handlers run. Any `fetch` or `XMLHttpRequest` span started inside that window is stamped with
+`user_interaction.id` and, when a name was derived, `user_interaction.name` -- joining a user action to the HTTP
+requests it triggered. Join a span to its interaction event by matching the span's `user_interaction.id` against
+the event's `interaction.id`. Key presses open the window only for activation keys (`Enter` and `Space`).
 
 Note: capturing interaction events requires both `interactionInstrumentation.enabled: true` **and**
 `'@dash0/interactions'` present in `enabledInstrumentations` if that option is explicitly set to a non-default

--- a/docs/sdk/configuration.md
+++ b/docs/sdk/configuration.md
@@ -547,7 +547,10 @@ cannot know about, such as a `title` or `alt` attribute your application interpo
 `interaction.target.selector`, and `interaction.target.id` when the element has one. Type-specific attributes:
 `interaction.direction` (scroll), `interaction.key` (key press), and `interaction.value_length` /
 `interaction.selected_count` (change). The event body is a human-readable string such as
-`Click "Save Settings" on /settings`; treat the attributes, not the body, as the stable contract.
+`Click "Save Settings" on /settings`; treat the attributes, not the body, as the stable contract. The path in the
+body is the same scrubbed value as the event's `page.url.path` attribute, so a configured `urlAttributeScrubber`
+applies to it too -- if the scrubber drops `url.path`, the body omits the ` on <path>` suffix entirely rather than
+falling back to the raw location.
 
 **Click-to-request correlation.** A click registers a short-lived (2 second) active interaction before the page's
 own handlers run. Any `fetch` or `XMLHttpRequest` span started inside that window is stamped with

--- a/docs/sdk/configuration.md
+++ b/docs/sdk/configuration.md
@@ -552,6 +552,13 @@ body is the same scrubbed value as the event's `page.url.path` attribute, so a c
 applies to it too -- if the scrubber drops `url.path`, the body omits the ` on <path>` suffix entirely rather than
 falling back to the raw location.
 
+**One event per gesture.** Clicking a `<label>` makes the browser fire a second click at the label's control, so a
+single user action reaches the SDK twice. Only the click the user actually made is reported: the forwarded
+duplicate is dropped, for both `<label>Text <input></label>` and `<label for="…">`. This means
+`interaction.target.tag` / `.selector` / `.id` describe the label (or the element inside it that was clicked)
+rather than the control it activates -- enable `captureChanges` if you also need a record naming the control whose
+value changed.
+
 **Click-to-request correlation.** A click registers a short-lived (2 second) active interaction before the page's
 own handlers run. Any `fetch` or `XMLHttpRequest` span started inside that window is stamped with
 `user_interaction.id` and, when a name was derived, `user_interaction.name` -- joining a user action to the HTTP

--- a/docs/sdk/configuration.md
+++ b/docs/sdk/configuration.md
@@ -487,6 +487,17 @@ _additionally_ opt-in via their own flags below.
   Emit a `change` interaction when a form control's value is committed. Reports only `interaction.value_length`
   for text fields and `interaction.selected_count` for selects -- never the value itself, and neither for
   password fields.
+- **Max Events Per Ten Seconds**<br>
+  key: `interactionInstrumentation.maxEventsPerTenSeconds`<br>
+  type: `number`<br>
+  optional: `true`<br>
+  default: `32`<br>
+  Maximum number of interaction events emitted per ten seconds. Interaction capture has its own budget rather
+  than competing for the transport-wide one, so a burst of interactions can never displace spans, errors, page
+  views or web vitals; events over the budget are dropped at the source. The ten-minute allowance is derived as
+  16x this value, keeping interactions at the same share of the transport budget in both windows. Values are
+  clamped to `[1, 128]`, `128` being the transport's own per-ten-second ceiling. Note that HTTP spans stay
+  correlated to the interaction that caused them even when the interaction's own event is dropped.
 - **Action Name Attribute**<br>
   key: `interactionInstrumentation.actionNameAttribute`<br>
   type: `string`<br>

--- a/docs/sdk/configuration.md
+++ b/docs/sdk/configuration.md
@@ -478,7 +478,9 @@ _additionally_ opt-in via their own flags below.
   optional: `true`<br>
   default: `false`<br>
   Emit a `key_press` interaction for allow-listed navigation and activation keys only (e.g. `Enter`, `Tab`,
-  `Escape`, arrow keys). Printable characters are never recorded -- see the privacy note below.
+  `Escape`, arrow keys). Printable characters are never recorded -- see the privacy note below. Repeated presses
+  of the same key on the same element are coalesced into one event carrying `interaction.repeat_count`; `Enter` is
+  always emitted immediately.
 - **Capture Changes**<br>
   key: `interactionInstrumentation.captureChanges`<br>
   type: `boolean`<br>
@@ -486,7 +488,8 @@ _additionally_ opt-in via their own flags below.
   default: `false`<br>
   Emit a `change` interaction when a form control's value is committed. Reports only `interaction.value_length`
   for text fields and `interaction.selected_count` for selects -- never the value itself, and neither for
-  password fields.
+  password fields. Successive changes to the same control are coalesced into one event describing its latest
+  state.
 - **Max Events Per Ten Seconds**<br>
   key: `interactionInstrumentation.maxEventsPerTenSeconds`<br>
   type: `number`<br>
@@ -556,14 +559,21 @@ cannot know about, such as a `title` or `alt` attribute your application interpo
 **Emitted attributes.** Every `browser.interaction` event carries `interaction.id`, `interaction.type` (`click`,
 `scroll`, `key_press`, or `change`), `interaction.name`, `interaction.name_source`, `interaction.target.tag`,
 `interaction.target.selector`, and `interaction.target.id` when the element has one. Type-specific attributes:
-`interaction.direction` (scroll), `interaction.key` (key press), and `interaction.value_length` /
-`interaction.selected_count` (change). The event body is a human-readable string such as
+`interaction.direction` (scroll), `interaction.key` plus `interaction.repeat_count` (key press), and
+`interaction.value_length` / `interaction.selected_count` (change). The event body is a human-readable string such as
 `Click "Save Settings" on /settings`; treat the attributes, not the body, as the stable contract. The path in the
 body is the same scrubbed value as the event's `page.url.path` attribute, so a configured `urlAttributeScrubber`
 applies to it too -- if the scrubber drops `url.path`, the body omits the ` on <path>` suffix entirely rather than
 falling back to the raw location.
 
-**One event per gesture.** Clicking a `<label>` makes the browser fire a second click at the label's control, so a
+**One event per gesture.** Scroll, key-press and change capture coalesce bursts of DOM events into a single
+interaction event, finalized 300 ms after the last event in the burst -- one event per scroll burst, per run of
+presses of the same key, and per run of changes to the same control. A burst is also finalized immediately when
+the user moves on (a different key, a different control) and when the page is being unloaded, so the last
+interaction before a navigation is not lost. Coalesced events are timestamped when the burst _started_, and every
+request attributed during a burst shares the one correlation id the burst emits.
+
+Clicking a `<label>` makes the browser fire a second click at the label's control, so a
 single user action reaches the SDK twice. Only the click the user actually made is reported: the forwarded
 duplicate is dropped, for both `<label>Text <input></label>` and `<label for="…">`. This means
 `interaction.target.tag` / `.selector` / `.id` describe the label (or the element inside it that was clicked)

--- a/docs/sdk/configuration.md
+++ b/docs/sdk/configuration.md
@@ -495,32 +495,52 @@ _additionally_ opt-in via their own flags below.
   The element attribute the SDK checks first (on the clicked element or any of its ancestors) when deriving a
   human-readable interaction name. Set this attribute on interactive elements for full control over the captured
   name, e.g. `<button data-dash0-action-name="Save Settings">`.
+- **Action Name Scrubber**<br>
+  key: `interactionInstrumentation.actionNameScrubber`<br>
+  type: `(name: string, source: ActionNameSource, target: Element) => string`<br>
+  optional: `true`<br>
+  default: `undefined`<br>
+  Last-chance hook to replace or drop a derived interaction name. It runs as the final step of name derivation,
+  so it covers every place the name is emitted: the `interaction.name` attribute, the human-readable event body,
+  and `user_interaction.name` on correlated HTTP spans. It receives the name the SDK would otherwise emit
+  (already whitespace-normalized and truncated), which phase derived it, and the interaction target; return a
+  replacement, or an empty string to drop the name entirely. The return value is normalized and truncated again.
+  It is only invoked when a name was actually derived, so it cannot invent a name for an interaction the SDK
+  could not name. It **fails closed**: if the scrubber throws or returns a non-string, the name is dropped rather
+  than emitted unscrubbed.
 
 **Name derivation priority** (first match wins, walking from the clicked element up to 10 ancestors, stopping at
 the first `FORM`, `BODY`, `HTML`, or `HEAD` boundary):
 
 1. `custom_attribute` -- the configured `actionNameAttribute`, on the target or a qualifying ancestor.
 2. `standard_attribute` -- attribute-derived names checked on the target then ancestors: for `button`/`submit`/`reset`
-   inputs, `.value`; then `aria-label`, `aria-labelledby` (resolved via the referenced element(s)' text), `alt`,
-   `title`, or `placeholder`.
-3. `text_content` -- the visible text of clickable-tag elements (`BUTTON`, `LABEL`, `A`, or `role="button"`) found
-   while walking up from the target. The target's own text is only read when the target is itself one of those
-   clickable tags: a click landing on a plain container (a layout `<div>`, `<footer>`, …) with no clickable element
-   in its ancestor path deliberately yields a blank name plus target metadata, rather than the container's entire
-   visible text. This phase is skipped entirely when the click target is an `INPUT`, `TEXTAREA`, `SELECT`, or
-   `OPTION` element, since their text content is user data rather than an action label.
+   inputs, `.value`; then `aria-label`, `aria-labelledby` (resolved via the privacy-aware label text of the
+   referenced element(s) -- a reference to, or wrapping, a form control contributes nothing), `alt`, `title`, or
+   `placeholder`.
+3. `text_content` -- the label text of clickable-tag elements (`BUTTON`, `LABEL`, `A`, or `role="button"`) found
+   while walking up from the target. This is _not_ `textContent`: the collector never descends into a nested
+   `input`, `textarea`, `select`, `option`, `output`, `script`, `style`, `noscript`, or `contenteditable` element,
+   because a `<label>` or `<button>` normally _wraps_ its control, so its raw `textContent` would contain the
+   user's entered value. `<label>Notes <textarea>my private note</textarea></label>` therefore yields `Notes`,
+   never the note -- whether the click landed on the label or on the textarea inside it. Shadow roots are never
+   traversed. A click landing on a plain container (a layout `<div>`, `<footer>`, …) with no clickable element in
+   its ancestor path deliberately yields a blank name plus target metadata, rather than the container's entire
+   visible text.
 4. `blank` -- an empty name, if nothing above matched.
 
 Attribute-derived sources always outrank text: the full phase order is custom attribute → standard attributes
 (walk) → text content (walk) → blank. Each captured event's `interaction.name_source` attribute reflects which
 phase produced the name.
 
-**Privacy defaults (not configurable):** the SDK never reads the value of `password`, `text`, `textarea`, or
-`select` elements -- only `button`/`submit`/`reset` inputs expose their value for name derivation, and the
-text-content phase above never applies to `INPUT`/`TEXTAREA`/`SELECT`/`OPTION` click targets. Key-press capture
-records only allow-listed control keys, never printable characters. Change capture records value length and
-selected count, never values. Derived names are whitespace-normalized and truncated to 100 characters (plus a
-` [...]` marker when truncation occurred). The target-element selector is independently capped at 128 characters.
+**Privacy defaults.** The SDK never reads the value of `password`, `text`, `textarea`, or `select` elements --
+only `button`/`submit`/`reset` inputs expose their value for name derivation -- and it never reads text from a
+form control, `<output>`, `contenteditable` region, or `<script>`/`<style>` **nested anywhere inside** the element
+it names, including via `aria-labelledby`. Key-press capture records only allow-listed control keys, never
+printable characters. Change capture records value length and selected count, never values. Derived names are
+whitespace-normalized and truncated to 100 characters (plus a ` [...]` marker when truncation occurred); the text
+scan itself is bounded to 1024 characters and 1000 DOM nodes. The target-element selector is independently capped
+at 128 characters. None of these limits is configurable -- use `actionNameScrubber` for cases the heuristics
+cannot know about, such as a `title` or `alt` attribute your application interpolates user data into.
 
 **Emitted attributes.** Every `browser.interaction` event carries `interaction.id`, `interaction.type` (`click`,
 `scroll`, `key_press`, or `change`), `interaction.name`, `interaction.name_source`, `interaction.target.tag`,
@@ -545,6 +565,8 @@ init({
   endpoint: { url: "{OTLP via HTTP endpoint}", authToken: "{authToken}" },
   interactionInstrumentation: {
     enabled: true,
+    // Optional: redact anything the derivation heuristics cannot know about.
+    actionNameScrubber: (name) => name.replace(/[^\s@]+@[^\s@]+/g, "[email]"),
   },
 });
 ```

--- a/docs/sdk/configuration.md
+++ b/docs/sdk/configuration.md
@@ -124,7 +124,7 @@ The SDK enumerates the env vars above under every framework prefix the bundler e
   optional: `true`<br>
   default: `undefined`<br>
   List of instrumentations to enable. Defaults to `undefined`, enabling all instrumentations.
-  Supported values: `'@dash0/navigation' | '@dash0/web-vitals' | '@dash0/error' | '@dash0/fetch' | '@dash0/xhr'`
+  Supported values: `'@dash0/navigation' | '@dash0/web-vitals' | '@dash0/error' | '@dash0/fetch' | '@dash0/xhr' | '@dash0/interactions'`
   Please note that some dash0 features might not work as expected if instrumentations are disabled.
 
 - **Ignore URLs**<br>
@@ -445,3 +445,65 @@ for `fetch`, while an `XMLHttpRequest` timeout is an error — this asymmetry is
   Additionally generate virtual page views when these url parts change.
   - "HASH" changes to the urls hash / fragment
   - "SEARCH" changes to the urls search / query parameters
+
+#### Interaction instrumentation
+
+Opt-in automatic capture of click interactions (Datadog RUM `trackUserInteractions` parity). Disabled by default --
+set `interactionInstrumentation.enabled: true` to turn it on. When enabled, a single capture-phase listener on
+`window` observes clicks anywhere on the page (no per-element wiring, no listener leakage) and emits a
+`browser.interaction` web event per click with a derived, privacy-conscious interaction name and a compact
+target-element selector.
+
+- **Enable Interaction Instrumentation**<br>
+  key: `interactionInstrumentation.enabled`<br>
+  type: `boolean`<br>
+  optional: `true`<br>
+  default: `false`<br>
+  Whether the SDK should automatically capture click interactions. Also requires `'@dash0/interactions'` to be
+  present in `enabledInstrumentations` when that option is explicitly set (it is included by default when
+  `enabledInstrumentations` is left `undefined`).
+- **Action Name Attribute**<br>
+  key: `interactionInstrumentation.actionNameAttribute`<br>
+  type: `string`<br>
+  optional: `true`<br>
+  default: `"data-dash0-action-name"`<br>
+  The element attribute the SDK checks first (on the clicked element or any of its ancestors) when deriving a
+  human-readable interaction name. Set this attribute on interactive elements for full control over the captured
+  name, e.g. `<button data-dash0-action-name="Save Settings">`.
+
+**Name derivation priority** (first match wins, walking from the clicked element up to 10 ancestors, stopping at
+the first `FORM`, `BODY`, `HTML`, or `HEAD` boundary):
+
+1. `custom_attribute` -- the configured `actionNameAttribute`, on the target or a qualifying ancestor.
+2. `standard_attribute` -- attribute-derived names checked on the target then ancestors: for `button`/`submit`/`reset`
+   inputs, `.value`; then `aria-label`, `aria-labelledby` (resolved via the referenced element(s)' text), `alt`,
+   `title`, or `placeholder`.
+3. `text_content` -- visible text: first the text of clickable-tag elements (`BUTTON`, `LABEL`, `A`, or
+   `role="button"`) found while walking up from the target, then the target's own visible text. This fallback never
+   applies when the click target itself is an `INPUT`, `TEXTAREA`, `SELECT`, or `OPTION` element, since their text
+   content is user data rather than an action label.
+4. `blank` -- an empty name, if nothing above matched.
+
+Attribute-derived sources always outrank text: the full phase order is custom attribute → standard attributes
+(walk) → text content (walk, then target) → blank. Each captured event's `name_source` attribute reflects which
+phase produced the name.
+
+**Privacy defaults (not configurable):** the SDK never reads the value of `password`, `text`, `textarea`, or
+`select` elements -- only `button`/`submit`/`reset` inputs expose their value for name derivation, and the
+text-content fallback above never applies to `INPUT`/`TEXTAREA`/`SELECT`/`OPTION` targets. Derived names are
+whitespace-normalized and truncated to 100 characters. The target-element selector is independently capped at 128
+characters.
+
+Note: capturing interaction events requires both `interactionInstrumentation.enabled: true` **and**
+`'@dash0/interactions'` present in `enabledInstrumentations` if that option is explicitly set to a non-default
+list -- either gate alone is not sufficient.
+
+```ts
+init({
+  serviceName: "my-website",
+  endpoint: { url: "{OTLP via HTTP endpoint}", authToken: "{authToken}" },
+  interactionInstrumentation: {
+    enabled: true,
+  },
+});
+```

--- a/src/api/init.ts
+++ b/src/api/init.ts
@@ -31,6 +31,7 @@ import { addAttribute } from "../utils/otel";
 import { instrumentFetch } from "../instrumentations/http/fetch";
 import { instrumentXhr } from "../instrumentations/http/xhr";
 import { startNavigationInstrumentation } from "../instrumentations/navigation";
+import { startInteractionInstrumentation } from "../instrumentations/interactions";
 import { initializeTabId } from "../utils/tab-id";
 import { InitOptions, InstrumentationName } from "../types/options";
 import { BrowserBuildEnv, pickFirstString } from "./browser-env";
@@ -86,6 +87,7 @@ export function init(opts: InitOptions) {
         "headersToCapture",
         "urlAttributeScrubber",
         "pageViewInstrumentation",
+        "interactionInstrumentation",
         "enableTransportCompression",
       ])
     )
@@ -123,6 +125,9 @@ export function init(opts: InitOptions) {
   }
   if (isInstrumentationEnabled("@dash0/xhr", opts)) {
     instrumentXhr();
+  }
+  if (isInstrumentationEnabled("@dash0/interactions", opts) && vars.interactionInstrumentation.enabled) {
+    startInteractionInstrumentation();
   }
 
   hasBeenInitialised = true;

--- a/src/api/init.ts
+++ b/src/api/init.ts
@@ -126,6 +126,7 @@ export function init(opts: InitOptions) {
   if (isInstrumentationEnabled("@dash0/xhr", opts)) {
     instrumentXhr();
   }
+  // Both gates must pass: the instrumentation-name allowlist and the opt-in settings flag.
   if (isInstrumentationEnabled("@dash0/interactions", opts) && vars.interactionInstrumentation.enabled) {
     startInteractionInstrumentation();
   }

--- a/src/api/init_test.ts
+++ b/src/api/init_test.ts
@@ -201,9 +201,24 @@ describe("init", () => {
       expect(vars.interactionInstrumentation).toEqual({
         enabled: true,
         actionNameAttribute: "data-dash0-action-name",
+        captureScrolls: false,
+        captureKeyPresses: false,
+        captureChanges: false,
+      });
+    });
+
+    it("allows opting into scroll/key-press/change capture individually", async () => {
+      init({
+        ...baseOptions,
+        interactionInstrumentation: { enabled: true, captureScrolls: true, captureKeyPresses: true },
+      });
+
+      expect(vars.interactionInstrumentation).toEqual({
+        enabled: true,
+        actionNameAttribute: "data-dash0-action-name",
         captureScrolls: true,
         captureKeyPresses: true,
-        captureChanges: true,
+        captureChanges: false,
       });
     });
 
@@ -216,9 +231,9 @@ describe("init", () => {
       expect(vars.interactionInstrumentation).toEqual({
         enabled: true,
         actionNameAttribute: "data-custom-name",
-        captureScrolls: true,
-        captureKeyPresses: true,
-        captureChanges: true,
+        captureScrolls: false,
+        captureKeyPresses: false,
+        captureChanges: false,
       });
     });
   });

--- a/src/api/init_test.ts
+++ b/src/api/init_test.ts
@@ -38,6 +38,10 @@ vi.mock("../instrumentations/navigation", () => ({
   startNavigationInstrumentation: vi.fn(),
 }));
 
+vi.mock("../instrumentations/interactions", () => ({
+  startInteractionInstrumentation: vi.fn(),
+}));
+
 // Mock the utils module to control loc.hostname
 vi.mock("../utils", async () => {
   const actual = await vi.importActual("../utils");
@@ -52,6 +56,7 @@ import { instrumentFetch } from "../instrumentations/http/fetch";
 import { instrumentXhr } from "../instrumentations/http/xhr";
 import { startNavigationInstrumentation } from "../instrumentations/navigation";
 import { startWebVitalsInstrumentation } from "../instrumentations/web-vitals";
+import { startInteractionInstrumentation } from "../instrumentations/interactions";
 
 describe("init", () => {
   const baseOptions: InitOptions = {
@@ -79,6 +84,10 @@ describe("init", () => {
   });
 
   describe("instrumentation enablement", () => {
+    beforeEach(() => {
+      vars.interactionInstrumentation.enabled = true;
+    });
+
     it("should enable all instrumentations when enabledInstrumentations is undefined", async () => {
       init({
         ...baseOptions,
@@ -98,6 +107,7 @@ describe("init", () => {
       "@dash0/error",
       "@dash0/fetch",
       "@dash0/xhr",
+      "@dash0/interactions",
     ];
     const instrumentationMocks = {
       "@dash0/navigation": startNavigationInstrumentation,
@@ -105,6 +115,7 @@ describe("init", () => {
       "@dash0/error": startErrorInstrumentation,
       "@dash0/fetch": instrumentFetch,
       "@dash0/xhr": instrumentXhr,
+      "@dash0/interactions": startInteractionInstrumentation,
     };
 
     instrumentations.forEach((instrumentation) => {
@@ -138,6 +149,70 @@ describe("init", () => {
         otherInstrumentations.forEach((name) => {
           expect(instrumentationMocks[name]).toHaveBeenCalled();
         });
+      });
+    });
+  });
+
+  describe("interaction instrumentation settings gate", () => {
+    it("does not start interactions when enabledInstrumentations includes it but interactionInstrumentation.enabled is false (default)", async () => {
+      init({
+        ...baseOptions,
+        enabledInstrumentations: ["@dash0/interactions"],
+      });
+
+      expect(startInteractionInstrumentation).not.toHaveBeenCalled();
+    });
+
+    it("does not start interactions when interactionInstrumentation.enabled is true but enabledInstrumentations excludes it", async () => {
+      init({
+        ...baseOptions,
+        enabledInstrumentations: ["@dash0/navigation"],
+        interactionInstrumentation: { enabled: true },
+      });
+
+      expect(startInteractionInstrumentation).not.toHaveBeenCalled();
+    });
+
+    it("starts interactions when both gates pass: enabledInstrumentations includes it and interactionInstrumentation.enabled is true", async () => {
+      init({
+        ...baseOptions,
+        enabledInstrumentations: ["@dash0/interactions"],
+        interactionInstrumentation: { enabled: true },
+      });
+
+      expect(startInteractionInstrumentation).toHaveBeenCalled();
+    });
+
+    it("starts interactions when enabledInstrumentations is undefined (all enabled) and interactionInstrumentation.enabled is true", async () => {
+      init({
+        ...baseOptions,
+        interactionInstrumentation: { enabled: true },
+      });
+
+      expect(startInteractionInstrumentation).toHaveBeenCalled();
+    });
+
+    it("preserves the default actionNameAttribute when only enabled is overridden (nested settings shallow-merge)", async () => {
+      init({
+        ...baseOptions,
+        interactionInstrumentation: { enabled: true },
+      });
+
+      expect(vars.interactionInstrumentation).toEqual({
+        enabled: true,
+        actionNameAttribute: "data-dash0-action-name",
+      });
+    });
+
+    it("allows overriding actionNameAttribute independently", async () => {
+      init({
+        ...baseOptions,
+        interactionInstrumentation: { enabled: true, actionNameAttribute: "data-custom-name" },
+      });
+
+      expect(vars.interactionInstrumentation).toEqual({
+        enabled: true,
+        actionNameAttribute: "data-custom-name",
       });
     });
   });

--- a/src/api/init_test.ts
+++ b/src/api/init_test.ts
@@ -201,6 +201,9 @@ describe("init", () => {
       expect(vars.interactionInstrumentation).toEqual({
         enabled: true,
         actionNameAttribute: "data-dash0-action-name",
+        captureScrolls: true,
+        captureKeyPresses: true,
+        captureChanges: true,
       });
     });
 
@@ -213,6 +216,9 @@ describe("init", () => {
       expect(vars.interactionInstrumentation).toEqual({
         enabled: true,
         actionNameAttribute: "data-custom-name",
+        captureScrolls: true,
+        captureKeyPresses: true,
+        captureChanges: true,
       });
     });
   });

--- a/src/api/init_test.ts
+++ b/src/api/init_test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { InitOptions, InstrumentationName } from "../types/options";
-import { PropagatorConfig, Vars } from "../vars";
+import { DEFAULT_MAX_INTERACTION_EVENTS_PER_TEN_SECONDS, PropagatorConfig, Vars } from "../vars";
 import {
   DEPLOYMENT_ENVIRONMENT_NAME,
   DEPLOYMENT_ID,
@@ -204,6 +204,7 @@ describe("init", () => {
         captureScrolls: false,
         captureKeyPresses: false,
         captureChanges: false,
+        maxEventsPerTenSeconds: DEFAULT_MAX_INTERACTION_EVENTS_PER_TEN_SECONDS,
       });
     });
 
@@ -219,6 +220,7 @@ describe("init", () => {
         captureScrolls: true,
         captureKeyPresses: true,
         captureChanges: false,
+        maxEventsPerTenSeconds: DEFAULT_MAX_INTERACTION_EVENTS_PER_TEN_SECONDS,
       });
     });
 
@@ -234,6 +236,7 @@ describe("init", () => {
         captureScrolls: false,
         captureKeyPresses: false,
         captureChanges: false,
+        maxEventsPerTenSeconds: DEFAULT_MAX_INTERACTION_EVENTS_PER_TEN_SECONDS,
       });
     });
   });

--- a/src/entrypoint/npm-package.ts
+++ b/src/entrypoint/npm-package.ts
@@ -14,8 +14,9 @@ export { startView } from "../api/start-view";
 // Additional utility types
 export type { AttributeValueType } from "../utils/otel";
 export type { AnyValue } from "../types/otlp";
-export type { PageViewMeta, PropagatorConfig, PropagatorType } from "../vars";
+export type { PageViewMeta, PropagatorConfig, PropagatorType, InteractionInstrumentationSettings } from "../vars";
 export type { UrlAttributeScrubber, UrlAttributeRecord } from "../attributes/url";
+export type { ActionNameScrubber, ActionNameSource } from "../instrumentations/interactions/action-name";
 export type { StartViewOptions } from "../api/start-view";
 
 export function init(opts: InitOptions): void {

--- a/src/instrumentations/http/fetch.ts
+++ b/src/instrumentations/http/fetch.ts
@@ -13,6 +13,7 @@ import { vars } from "../../vars";
 import { httpRequestHeaderKey, httpResponseHeaderKey } from "../../utils/otel/http";
 import { sendSpan } from "../../transport";
 import {
+  addInteractionAttributes,
   addResourceNetworkEvents,
   addResourceSize,
   addTraceContextHttpHeaders,
@@ -129,6 +130,7 @@ function onFetchStart(
   if (!isWellKnownMethod) {
     addAttribute(span.attributes, HTTP_REQUEST_METHOD_ORIGINAL, originalMethod);
   }
+  addInteractionAttributes(span);
 
   const propagatorTypes = determinePropagatorTypes(url);
   const shouldSetCorrelationHeaders = propagatorTypes.length > 0;

--- a/src/instrumentations/http/fetch_test.ts
+++ b/src/instrumentations/http/fetch_test.ts
@@ -3,6 +3,8 @@ import { vars } from "../../vars";
 import { instrumentFetch } from "./fetch";
 import { sendSpan } from "../../transport";
 import type { Span } from "../../types/otlp";
+import { USER_INTERACTION_ID, USER_INTERACTION_NAME } from "../../semantic-conventions";
+import { clearActiveInteractionForTests, registerActiveInteraction } from "../interactions/active-interaction";
 
 vi.mock("../../transport", () => ({
   sendSpan: vi.fn(),
@@ -10,6 +12,18 @@ vi.mock("../../transport", () => ({
 
 describe("fetch test", () => {
   let fetchMock: any;
+
+  const sendSpanMock = sendSpan as unknown as ReturnType<typeof vi.fn>;
+
+  const lastSpan = (): Span => {
+    const calls = sendSpanMock.mock.calls;
+    return calls[calls.length - 1]![0] as Span;
+  };
+
+  const hasAttribute = (span: Span, key: string, expectedValue: unknown) =>
+    span.attributes.some((a) => a.key === key && JSON.stringify(a.value) === JSON.stringify(expectedValue));
+
+  const hasAttributeKey = (span: Span, key: string) => span.attributes.some((a) => a.key === key);
 
   beforeEach(() => {
     fetchMock = vi.fn(() => ({
@@ -225,16 +239,7 @@ describe("fetch test", () => {
   });
 
   describe("aborted requests", () => {
-    const sendSpanMock = sendSpan as unknown as ReturnType<typeof vi.fn>;
     const NativeRequest = Request;
-
-    const lastSpan = (): Span => {
-      const calls = sendSpanMock.mock.calls;
-      return calls[calls.length - 1]![0] as Span;
-    };
-
-    const hasAttribute = (span: Span, key: string, expectedValue: unknown) =>
-      span.attributes.some((a) => a.key === key && JSON.stringify(a.value) === JSON.stringify(expectedValue));
 
     beforeEach(() => {
       sendSpanMock.mockClear();
@@ -367,6 +372,66 @@ describe("fetch test", () => {
       expect(hasAttribute(span, "dash0.web.request.cancelled", { boolValue: true })).toBe(false);
       expect(span.events.some((e) => e.name === "exception")).toBe(true);
       expect(hasAttribute(span, "error.type", { stringValue: "TypeError" })).toBe(true);
+    });
+  });
+
+  // Drives a real fetch call through the instrumentation so the addInteractionAttributes() call
+  // site in onFetchStart() is actually reached -- asserting on addInteractionAttributes() in
+  // isolation (see interaction-attribution_test.ts) would stay green even if the call moved to an
+  // unreachable branch.
+  describe("interaction attribution", () => {
+    beforeEach(() => {
+      sendSpanMock.mockClear();
+      // The success path completes the span through observeResourcePerformance, which resolves
+      // asynchronously. Holding the wait at 0 keeps these tests fast; see the equivalent comment
+      // in xhr_test.ts.
+      vars.maxWaitForResourceTimingsMillis = 0;
+    });
+
+    afterEach(() => {
+      clearActiveInteractionForTests();
+      vars.maxWaitForResourceTimingsMillis = 10000;
+    });
+
+    async function fetchAndAwaitSpan(): Promise<Span> {
+      instrumentFetch();
+      // eslint-disable-next-line no-restricted-globals
+      await fetch("http://localhost:3000/api/test");
+
+      await vi.waitFor(() => expect(sendSpanMock).toHaveBeenCalledTimes(1));
+      return lastSpan();
+    }
+
+    it("stamps the active interaction onto the fetch span", async () => {
+      const interaction = registerActiveInteraction("Save Part");
+
+      const span = await fetchAndAwaitSpan();
+
+      expect(hasAttribute(span, USER_INTERACTION_ID, { stringValue: interaction.id })).toBe(true);
+      expect(hasAttribute(span, USER_INTERACTION_NAME, { stringValue: "Save Part" })).toBe(true);
+    });
+
+    it("leaves the fetch span unattributed when no interaction is active", async () => {
+      const span = await fetchAndAwaitSpan();
+
+      expect(hasAttributeKey(span, USER_INTERACTION_ID)).toBe(false);
+      expect(hasAttributeKey(span, USER_INTERACTION_NAME)).toBe(false);
+    });
+
+    it("leaves the fetch span unattributed once the attribution window has elapsed", async () => {
+      // Back-date the registration instead of freezing the clock for the whole test: vi.waitFor
+      // below relies on real time passing. active-interaction.ts is the SDK's only Date.now()
+      // consumer (span timestamps go through new Date().getTime() in utils/time.ts), so this
+      // shifts nothing else.
+      const t0 = Date.now();
+      const nowSpy = vi.spyOn(Date, "now").mockReturnValueOnce(t0 - 2001);
+      registerActiveInteraction("Save Part");
+      nowSpy.mockRestore();
+
+      const span = await fetchAndAwaitSpan();
+
+      expect(hasAttributeKey(span, USER_INTERACTION_ID)).toBe(false);
+      expect(hasAttributeKey(span, USER_INTERACTION_NAME)).toBe(false);
     });
   });
 });

--- a/src/instrumentations/http/fetch_test.ts
+++ b/src/instrumentations/http/fetch_test.ts
@@ -3,7 +3,7 @@ import { vars } from "../../vars";
 import { instrumentFetch } from "./fetch";
 import { sendSpan } from "../../transport";
 import type { Span } from "../../types/otlp";
-import { USER_INTERACTION_ID, USER_INTERACTION_NAME } from "../../semantic-conventions";
+import { URL_PATH, USER_INTERACTION_ID, USER_INTERACTION_NAME } from "../../semantic-conventions";
 import { clearActiveInteractionForTests, registerActiveInteraction } from "../interactions/active-interaction";
 
 vi.mock("../../transport", () => ({
@@ -36,12 +36,21 @@ describe("fetch test", () => {
     }));
     vi.stubGlobal("fetch", fetchMock);
     vi.stubGlobal("location", { origin: "http://localhost:3000" });
+    // Tests that do not wait for their span still leave a resource-timing observer pending, and its
+    // end() timer is what eventually calls sendSpan. Holding the wait at 0 queues that timer for the
+    // next macrotask instead of ~300ms later, so the afterEach below can flush it before the next
+    // test starts. See the equivalent comment in xhr_test.ts.
+    vars.maxWaitForResourceTimingsMillis = 0;
   });
 
-  afterEach(() => {
+  afterEach(async () => {
+    // Give any observer left pending by this test its macrotask turn, so the span it flushes is
+    // cleared by the reset below instead of landing in a later test's sendSpan expectations.
+    await new Promise((resolve) => setTimeout(resolve, 0));
     vi.resetAllMocks();
     vars.propagators = undefined;
     vars.ignoreUrls = [];
+    vars.maxWaitForResourceTimingsMillis = 10000;
   });
 
   it("should inject traceparent header for cross-origin requests", async () => {
@@ -380,26 +389,33 @@ describe("fetch test", () => {
   // isolation (see interaction-attribution_test.ts) would stay green even if the call moved to an
   // unreachable branch.
   describe("interaction attribution", () => {
-    beforeEach(() => {
-      sendSpanMock.mockClear();
-      // The success path completes the span through observeResourcePerformance, which resolves
-      // asynchronously. Holding the wait at 0 keeps these tests fast; see the equivalent comment
-      // in xhr_test.ts.
-      vars.maxWaitForResourceTimingsMillis = 0;
-    });
+    let requestCount = 0;
 
     afterEach(() => {
       clearActiveInteractionForTests();
-      vars.maxWaitForResourceTimingsMillis = 10000;
     });
 
     async function fetchAndAwaitSpan(): Promise<Span> {
+      // The span this test cares about is picked out of sendSpan's calls by URL rather than by call
+      // count. The success path completes spans asynchronously through observeResourcePerformance,
+      // so a span belonging to another test can be flushed inside the wait below and would
+      // otherwise either be mistaken for this request's span or keep a call-count expectation from
+      // ever matching. A per-request path keeps the selection unambiguous.
+      const path = `/api/interaction-${++requestCount}`;
       instrumentFetch();
       // eslint-disable-next-line no-restricted-globals
-      await fetch("http://localhost:3000/api/test");
+      await fetch(`http://localhost:3000${path}`);
 
-      await vi.waitFor(() => expect(sendSpanMock).toHaveBeenCalledTimes(1));
-      return lastSpan();
+      return vi.waitFor(
+        () => {
+          const span = sendSpanMock.mock.calls
+            .map((call) => call[0] as Span)
+            .find((s) => hasAttribute(s, URL_PATH, { stringValue: path }));
+          expect(span, `no span sent for ${path} yet`).toBeDefined();
+          return span!;
+        },
+        { timeout: 5000, interval: 20 }
+      );
     }
 
     it("stamps the active interaction onto the fetch span", async () => {

--- a/src/instrumentations/http/interaction-attribution_test.ts
+++ b/src/instrumentations/http/interaction-attribution_test.ts
@@ -1,0 +1,45 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { addInteractionAttributes } from "./utils";
+import type { InProgressSpan } from "../../utils/otel";
+import { USER_INTERACTION_ID, USER_INTERACTION_NAME } from "../../semantic-conventions";
+import { clearActiveInteractionForTests, registerActiveInteraction } from "../interactions/active-interaction";
+
+function newSpan(): InProgressSpan {
+  return { attributes: [] } as unknown as InProgressSpan;
+}
+
+describe("HTTP span interaction attribution", () => {
+  afterEach(() => {
+    clearActiveInteractionForTests();
+  });
+
+  it("stamps user_interaction.id and .name when a named interaction is active", () => {
+    const interaction = registerActiveInteraction("Fire 10 concurrent requests");
+
+    const span = newSpan();
+    addInteractionAttributes(span);
+
+    expect(span.attributes).toEqual(
+      expect.arrayContaining([
+        { key: USER_INTERACTION_ID, value: { stringValue: interaction.id } },
+        { key: USER_INTERACTION_NAME, value: { stringValue: "Fire 10 concurrent requests" } },
+      ])
+    );
+  });
+
+  it("stamps only the id when the interaction has no derived name", () => {
+    const interaction = registerActiveInteraction("");
+
+    const span = newSpan();
+    addInteractionAttributes(span);
+
+    expect(span.attributes).toEqual([{ key: USER_INTERACTION_ID, value: { stringValue: interaction.id } }]);
+  });
+
+  it("adds nothing when no interaction is active", () => {
+    const span = newSpan();
+    addInteractionAttributes(span);
+
+    expect(span.attributes).toEqual([]);
+  });
+});

--- a/src/instrumentations/http/utils.ts
+++ b/src/instrumentations/http/utils.ts
@@ -11,9 +11,16 @@ import {
 } from "../../utils/otel";
 import { domHRTimestampToNanos, hasKey, isSameOrigin, PerformanceTimingNames } from "../../utils";
 import { matchesAny } from "../../utils/ignore-rules";
-import { ERROR_TYPE, HTTP_RESPONSE_BODY_SIZE, WEB_REQUEST_CANCELLED } from "../../semantic-conventions";
+import {
+  ERROR_TYPE,
+  HTTP_RESPONSE_BODY_SIZE,
+  USER_INTERACTION_ID,
+  USER_INTERACTION_NAME,
+  WEB_REQUEST_CANCELLED,
+} from "../../semantic-conventions";
 import { vars, PropagatorType } from "../../vars";
 import { sendSpan } from "../../transport";
+import { getActiveInteraction } from "../interactions/active-interaction";
 
 // SEE: https://github.com/open-telemetry/semantic-conventions/blob/main/docs/attributes-registry/http.md?plain=1#L67
 const KNOWN_HTTP_METHODS = ["GET", "HEAD", "POST", "PUT", "DELETE", "CONNECT", "OPTIONS", "TRACE", "PATCH"];
@@ -21,6 +28,23 @@ export const HTTP_METHOD_OTHER = "_OTHER";
 
 export function isWellKnownHttpMethod(method: string): boolean {
   return KNOWN_HTTP_METHODS.includes(method);
+}
+
+/**
+ * Stamps `user_interaction.id` (and `.name` when one was derived) onto an HTTP
+ * request span when the request was started while a user interaction (click)
+ * is active — attributing the request to the click that caused it, the same
+ * causality RUM products surface as "user actions". Shared by the XHR and
+ * fetch instrumentations so both report identical correlation attributes.
+ */
+export function addInteractionAttributes(span: InProgressSpan) {
+  const interaction = getActiveInteraction();
+  if (!interaction) return;
+
+  addAttribute(span.attributes, USER_INTERACTION_ID, interaction.id);
+  if (interaction.name) {
+    addAttribute(span.attributes, USER_INTERACTION_NAME, interaction.name);
+  }
 }
 
 export function addResourceNetworkEvents(span: InProgressSpan, resource: PerformanceResourceTiming) {

--- a/src/instrumentations/http/xhr.ts
+++ b/src/instrumentations/http/xhr.ts
@@ -29,6 +29,7 @@ import { vars, PropagatorType } from "../../vars";
 import { httpRequestHeaderKey, httpResponseHeaderKey } from "../../utils/otel/http";
 import { sendSpan } from "../../transport";
 import {
+  addInteractionAttributes,
   addResourceNetworkEvents,
   addResourceSize,
   addTraceContextHttpHeaders,
@@ -259,6 +260,7 @@ function onSend(xhr: InstrumentedXhr, state: XhrState) {
   if (!state.isWellKnownMethod) {
     addAttribute(span.attributes, HTTP_REQUEST_METHOD_ORIGINAL, state.originalMethod);
   }
+  addInteractionAttributes(span);
   state.span = span;
 
   if (state.propagatorTypes.length > 0) {

--- a/src/instrumentations/http/xhr_test.ts
+++ b/src/instrumentations/http/xhr_test.ts
@@ -4,6 +4,8 @@ import { instrumentXhr } from "./xhr";
 import { doc } from "../../utils/globals";
 import { sendSpan } from "../../transport";
 import type { Span } from "../../types/otlp";
+import { USER_INTERACTION_ID, USER_INTERACTION_NAME } from "../../semantic-conventions";
+import { clearActiveInteractionForTests, registerActiveInteraction } from "../interactions/active-interaction";
 
 vi.mock("../../transport", () => ({
   sendSpan: vi.fn(),
@@ -846,5 +848,66 @@ describe("xhr test", () => {
     vi.stubGlobal("XMLHttpRequest", LockedXhr);
 
     expect(() => instrumentXhr()).not.toThrow();
+  });
+
+  // Drives a real XMLHttpRequest through the instrumentation so the addInteractionAttributes()
+  // call site in onSend() is actually reached -- asserting on addInteractionAttributes() in
+  // isolation (see interaction-attribution_test.ts) would stay green even if the call moved to an
+  // unreachable branch.
+  describe("interaction attribution", () => {
+    const sendSpanMock = sendSpan as unknown as ReturnType<typeof vi.fn>;
+
+    const hasAttribute = (span: Span, key: string, expectedValue: unknown) =>
+      span.attributes.some((a) => a.key === key && JSON.stringify(a.value) === JSON.stringify(expectedValue));
+
+    const hasAttributeKey = (span: Span, key: string) => span.attributes.some((a) => a.key === key);
+
+    afterEach(() => {
+      clearActiveInteractionForTests();
+    });
+
+    async function sendAndAwaitSpan(): Promise<Span> {
+      instrumentXhr();
+
+      const xhr = new XMLHttpRequest() as unknown as FakeXMLHttpRequest;
+      xhr.open("GET", "/api/test");
+      xhr.send();
+      xhr.respond(200);
+
+      await vi.waitFor(() => expect(sendSpanMock).toHaveBeenCalledTimes(1));
+      return sendSpanMock.mock.calls[0]![0] as Span;
+    }
+
+    it("stamps the active interaction onto the XHR span", async () => {
+      const interaction = registerActiveInteraction("Save Part");
+
+      const span = await sendAndAwaitSpan();
+
+      expect(hasAttribute(span, USER_INTERACTION_ID, { stringValue: interaction.id })).toBe(true);
+      expect(hasAttribute(span, USER_INTERACTION_NAME, { stringValue: "Save Part" })).toBe(true);
+    });
+
+    it("leaves the XHR span unattributed when no interaction is active", async () => {
+      const span = await sendAndAwaitSpan();
+
+      expect(hasAttributeKey(span, USER_INTERACTION_ID)).toBe(false);
+      expect(hasAttributeKey(span, USER_INTERACTION_NAME)).toBe(false);
+    });
+
+    it("leaves the XHR span unattributed once the attribution window has elapsed", async () => {
+      // Back-date the registration instead of freezing the clock for the whole test: vi.waitFor
+      // below relies on real time passing. active-interaction.ts is the SDK's only Date.now()
+      // consumer (span timestamps go through new Date().getTime() in utils/time.ts), so this
+      // shifts nothing else.
+      const t0 = Date.now();
+      const nowSpy = vi.spyOn(Date, "now").mockReturnValueOnce(t0 - 2001);
+      registerActiveInteraction("Save Part");
+      nowSpy.mockRestore();
+
+      const span = await sendAndAwaitSpan();
+
+      expect(hasAttributeKey(span, USER_INTERACTION_ID)).toBe(false);
+      expect(hasAttributeKey(span, USER_INTERACTION_NAME)).toBe(false);
+    });
   });
 });

--- a/src/instrumentations/http/xhr_test.ts
+++ b/src/instrumentations/http/xhr_test.ts
@@ -4,7 +4,7 @@ import { instrumentXhr } from "./xhr";
 import { doc } from "../../utils/globals";
 import { sendSpan } from "../../transport";
 import type { Span } from "../../types/otlp";
-import { USER_INTERACTION_ID, USER_INTERACTION_NAME } from "../../semantic-conventions";
+import { URL_PATH, USER_INTERACTION_ID, USER_INTERACTION_NAME } from "../../semantic-conventions";
 import { clearActiveInteractionForTests, registerActiveInteraction } from "../interactions/active-interaction";
 
 vi.mock("../../transport", () => ({
@@ -115,7 +115,11 @@ describe("xhr test", () => {
     vars.maxWaitForResourceTimingsMillis = 0;
   });
 
-  afterEach(() => {
+  afterEach(async () => {
+    // Give any resource-timing observer left pending by this test its macrotask turn, so the span it
+    // flushes is cleared by the reset below instead of landing in a later test's sendSpan
+    // expectations.
+    await new Promise((resolve) => setTimeout(resolve, 0));
     vi.stubGlobal("XMLHttpRequest", NativeXHR);
     vi.resetAllMocks();
     vars.propagators = undefined;
@@ -862,20 +866,36 @@ describe("xhr test", () => {
 
     const hasAttributeKey = (span: Span, key: string) => span.attributes.some((a) => a.key === key);
 
+    let requestCount = 0;
+
     afterEach(() => {
       clearActiveInteractionForTests();
     });
 
     async function sendAndAwaitSpan(): Promise<Span> {
+      // The span this test cares about is picked out of sendSpan's calls by URL rather than by call
+      // count. The success path completes spans asynchronously through observeResourcePerformance,
+      // so a span belonging to another test can be flushed inside the wait below and would
+      // otherwise be asserted on in place of this request's span. A per-request path keeps the
+      // selection unambiguous.
+      const path = `/api/interaction-${++requestCount}`;
       instrumentXhr();
 
       const xhr = new XMLHttpRequest() as unknown as FakeXMLHttpRequest;
-      xhr.open("GET", "/api/test");
+      xhr.open("GET", path);
       xhr.send();
       xhr.respond(200);
 
-      await vi.waitFor(() => expect(sendSpanMock).toHaveBeenCalledTimes(1));
-      return sendSpanMock.mock.calls[0]![0] as Span;
+      return vi.waitFor(
+        () => {
+          const span = sendSpanMock.mock.calls
+            .map((call) => call[0] as Span)
+            .find((s) => hasAttribute(s, URL_PATH, { stringValue: path }));
+          expect(span, `no span sent for ${path} yet`).toBeDefined();
+          return span!;
+        },
+        { timeout: 5000, interval: 20 }
+      );
     }
 
     it("stamps the active interaction onto the XHR span", async () => {

--- a/src/instrumentations/interactions/action-name.ts
+++ b/src/instrumentations/interactions/action-name.ts
@@ -1,0 +1,181 @@
+export type ActionNameSource = "custom_attribute" | "standard_attribute" | "text_content" | "blank";
+
+export type ActionNameResult = {
+  name: string;
+  nameSource: ActionNameSource;
+};
+
+const MAX_ANCESTOR_WALK = 10;
+const MAX_NAME_LENGTH = 100;
+const TRUNCATION_MARKER = " [...]";
+const BOUNDARY_TAGS = new Set(["FORM", "BODY", "HTML", "HEAD"]);
+const VALUE_READABLE_INPUT_TYPES = new Set(["button", "submit", "reset"]);
+// Elements whose visible text is read during the text-content phase because their
+// text is an action label rather than page content.
+const CLICKABLE_TEXT_TAGS = new Set(["BUTTON", "LABEL", "A"]);
+// Never derive a name from the text content of these click targets: an OPTION's /
+// SELECT's visible text is the user's chosen value and a TEXTAREA's text IS its
+// value — all user data, not an action label. (They may still be named via
+// attribute sources such as aria-label or placeholder.)
+const TEXT_FALLBACK_EXCLUDED_TAGS = new Set(["INPUT", "TEXTAREA", "SELECT", "OPTION"]);
+
+function normalizeWhitespace(value: string): string {
+  return value.replace(/\s+/g, " ").trim();
+}
+
+function truncate(name: string): string {
+  if (name.length <= MAX_NAME_LENGTH) {
+    return name;
+  }
+  return name.substring(0, MAX_NAME_LENGTH) + TRUNCATION_MARKER;
+}
+
+function finalize(name: string, nameSource: ActionNameSource): ActionNameResult {
+  const normalized = normalizeWhitespace(name);
+  if (!normalized) {
+    return { name: "", nameSource: "blank" };
+  }
+  return { name: truncate(normalized), nameSource };
+}
+
+/**
+ * Collects the click target plus up to MAX_ANCESTOR_WALK ancestor elements,
+ * stopping (inclusively) at the first FORM/BODY/HTML/HEAD boundary.
+ */
+function collectWalkPath(target: Element): Element[] {
+  const path: Element[] = [target];
+  let current: Element | null = target;
+
+  if (BOUNDARY_TAGS.has(target.tagName)) {
+    return path;
+  }
+
+  for (let i = 0; i < MAX_ANCESTOR_WALK; i++) {
+    current = current.parentElement;
+    if (!current) break;
+    path.push(current);
+    if (BOUNDARY_TAGS.has(current.tagName)) break;
+  }
+
+  return path;
+}
+
+function findCustomAttributeName(path: Element[], actionNameAttribute: string): string | undefined {
+  for (const el of path) {
+    const value = el.getAttribute(actionNameAttribute);
+    if (value != null && normalizeWhitespace(value)) {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+function resolveAriaLabelledBy(el: Element): string | undefined {
+  const labelledBy = el.getAttribute("aria-labelledby");
+  if (!labelledBy) return undefined;
+
+  const doc = el.ownerDocument;
+  const parts = labelledBy
+    .split(/\s+/)
+    .map((id) => doc.getElementById(id)?.textContent ?? "")
+    .map((text) => normalizeWhitespace(text))
+    .filter((text) => text.length > 0);
+
+  return parts.length > 0 ? parts.join(" ") : undefined;
+}
+
+function readInputValueIfSafe(el: Element): string | undefined {
+  if (el.tagName !== "INPUT") return undefined;
+  const type = (el.getAttribute("type") || "text").toLowerCase();
+  if (!VALUE_READABLE_INPUT_TYPES.has(type)) return undefined;
+  const value = (el as HTMLInputElement).value;
+  return value ? value : undefined;
+}
+
+/**
+ * Attribute-only sources: the value of button/submit/reset inputs, aria-label,
+ * aria-labelledby resolution, alt, title, and placeholder. Visible text is
+ * deliberately NOT read here — it belongs to the text-content phase.
+ */
+function findStandardAttributeName(path: Element[]): string | undefined {
+  for (const el of path) {
+    const inputValue = readInputValueIfSafe(el);
+    if (inputValue) return inputValue;
+
+    const ariaLabel = el.getAttribute("aria-label");
+    if (ariaLabel && normalizeWhitespace(ariaLabel)) return ariaLabel;
+
+    const labelledByText = resolveAriaLabelledBy(el);
+    if (labelledByText) return labelledByText;
+
+    const alt = el.getAttribute("alt");
+    if (alt && normalizeWhitespace(alt)) return alt;
+
+    const title = el.getAttribute("title");
+    if (title && normalizeWhitespace(title)) return title;
+
+    const placeholder = el.getAttribute("placeholder");
+    if (placeholder && normalizeWhitespace(placeholder)) return placeholder;
+  }
+  return undefined;
+}
+
+/**
+ * Text-content sources: first the visible text of clickable-tag elements
+ * (BUTTON/[role=button]/LABEL/A) along the walk path, then the target's own
+ * textContent. Skipped entirely for INPUT/TEXTAREA/SELECT/OPTION targets —
+ * their text content is user data (see TEXT_FALLBACK_EXCLUDED_TAGS).
+ */
+function findTextContentName(target: Element, path: Element[]): string | undefined {
+  if (TEXT_FALLBACK_EXCLUDED_TAGS.has(target.tagName)) return undefined;
+
+  for (const el of path) {
+    if (CLICKABLE_TEXT_TAGS.has(el.tagName) || el.getAttribute("role") === "button") {
+      const text = el.textContent;
+      if (text && normalizeWhitespace(text)) return text;
+    }
+  }
+
+  const targetText = target.textContent;
+  if (targetText && normalizeWhitespace(targetText)) return targetText;
+
+  return undefined;
+}
+
+/**
+ * Derives a human-readable interaction name for a clicked element, following
+ * Datadog RUM's action-name priority order:
+ *   1. configured custom attribute (target or ancestor)
+ *   2. standard attribute-based sources (target or ancestor)
+ *   3. visible text (clickable-tag elements along the walk first, then the
+ *      target's own text content)
+ *   4. blank
+ *
+ * The ancestor walk is capped at 10 levels and stops (inclusively) at the
+ * first FORM/BODY/HTML/HEAD boundary.
+ *
+ * Privacy: never reads the value of password/text/textarea/select elements --
+ * only button/submit/reset inputs expose `.value` -- and never derives a name
+ * from the text content of INPUT/TEXTAREA/SELECT/OPTION targets. Whitespace is
+ * always normalized and the result is truncated to 100 characters.
+ */
+export function deriveActionName(target: Element, actionNameAttribute: string): ActionNameResult {
+  const path = collectWalkPath(target);
+
+  const customName = findCustomAttributeName(path, actionNameAttribute);
+  if (customName) {
+    return finalize(customName, "custom_attribute");
+  }
+
+  const standardName = findStandardAttributeName(path);
+  if (standardName) {
+    return finalize(standardName, "standard_attribute");
+  }
+
+  const textName = findTextContentName(target, path);
+  if (textName) {
+    return finalize(textName, "text_content");
+  }
+
+  return { name: "", nameSource: "blank" };
+}

--- a/src/instrumentations/interactions/action-name.ts
+++ b/src/instrumentations/interactions/action-name.ts
@@ -121,10 +121,14 @@ function findStandardAttributeName(path: Element[]): string | undefined {
 }
 
 /**
- * Text-content sources: first the visible text of clickable-tag elements
- * (BUTTON/[role=button]/LABEL/A) along the walk path, then the target's own
- * textContent. Skipped entirely for INPUT/TEXTAREA/SELECT/OPTION targets —
- * their text content is user data (see TEXT_FALLBACK_EXCLUDED_TAGS).
+ * Text-content source: the visible text of clickable-tag elements
+ * (BUTTON/[role=button]/LABEL/A) found along the walk path. A click that lands
+ * on a non-interactive container (e.g. a layout <div>/<footer>) with no such
+ * element in its path — and no naming attribute — deliberately yields no name,
+ * so deriveActionName falls through to "blank" + target metadata rather than
+ * dumping the container's entire textContent. Skipped entirely for
+ * INPUT/TEXTAREA/SELECT/OPTION targets — their text content is user data
+ * (see TEXT_FALLBACK_EXCLUDED_TAGS).
  */
 function findTextContentName(target: Element, path: Element[]): string | undefined {
   if (TEXT_FALLBACK_EXCLUDED_TAGS.has(target.tagName)) return undefined;
@@ -136,9 +140,6 @@ function findTextContentName(target: Element, path: Element[]): string | undefin
     }
   }
 
-  const targetText = target.textContent;
-  if (targetText && normalizeWhitespace(targetText)) return targetText;
-
   return undefined;
 }
 
@@ -147,8 +148,8 @@ function findTextContentName(target: Element, path: Element[]): string | undefin
  * Datadog RUM's action-name priority order:
  *   1. configured custom attribute (target or ancestor)
  *   2. standard attribute-based sources (target or ancestor)
- *   3. visible text (clickable-tag elements along the walk first, then the
- *      target's own text content)
+ *   3. visible text of clickable-tag elements (button/link/label/[role=button])
+ *      found along the walk path
  *   4. blank
  *
  * The ancestor walk is capped at 10 levels and stops (inclusively) at the

--- a/src/instrumentations/interactions/action-name.ts
+++ b/src/instrumentations/interactions/action-name.ts
@@ -1,5 +1,6 @@
 import { DEFAULT_ACTION_NAME_ATTRIBUTE, vars } from "../../vars";
 import { warn } from "../../utils/debug";
+import { elementAttribute, elementTag } from "../../utils/dom";
 
 export type ActionNameSource = "custom_attribute" | "standard_attribute" | "text_content" | "blank";
 
@@ -45,12 +46,15 @@ function normalizeWhitespace(value: string): string {
 }
 
 function isTextExcluded(el: Element): boolean {
+  // `localName` rather than the clobber-safe `elementTag`: FORM is not in the set,
+  // so a shadowed `localName` on a form yields the same `false` this returns for a
+  // form anyway. See utils/dom for what shadowing is and where it does matter.
   if (TEXT_EXCLUDED_TAGS.has(el.localName)) return true;
   // A contenteditable region holds user-typed content. The attribute is read
   // directly rather than via `isContentEditable`: that property is unimplemented
   // in jsdom and is false for elements outside a rendered document. An empty
   // value means editable per spec; only an explicit "false" opts out.
-  const editable = el.getAttribute("contenteditable");
+  const editable = elementAttribute(el, "contenteditable");
   return editable != null && editable.toLowerCase() !== "false";
 }
 
@@ -122,12 +126,16 @@ function finalize(name: string, nameSource: ActionNameSource): ActionNameResult 
 /**
  * Collects the click target plus up to MAX_ANCESTOR_WALK ancestor elements,
  * stopping (inclusively) at the first FORM/BODY/HTML/HEAD boundary.
+ *
+ * The tag is read clobber-safely: FORM is a boundary here, and a form's own named
+ * controls can shadow its `tagName` (see utils/dom), which would otherwise make the
+ * comparison silently false and let the walk cross the boundary it must stop at.
  */
 function collectWalkPath(target: Element): Element[] {
   const path: Element[] = [target];
   let current: Element | null = target;
 
-  if (BOUNDARY_TAGS.has(target.tagName)) {
+  if (BOUNDARY_TAGS.has(elementTag(target))) {
     return path;
   }
 
@@ -135,7 +143,7 @@ function collectWalkPath(target: Element): Element[] {
     current = current.parentElement;
     if (!current) break;
     path.push(current);
-    if (BOUNDARY_TAGS.has(current.tagName)) break;
+    if (BOUNDARY_TAGS.has(elementTag(current))) break;
   }
 
   return path;
@@ -143,7 +151,7 @@ function collectWalkPath(target: Element): Element[] {
 
 function findCustomAttributeName(path: Element[], actionNameAttribute: string): string | undefined {
   for (const el of path) {
-    const value = el.getAttribute(actionNameAttribute);
+    const value = elementAttribute(el, actionNameAttribute);
     if (value != null && normalizeWhitespace(value)) {
       return value;
     }
@@ -152,7 +160,7 @@ function findCustomAttributeName(path: Element[], actionNameAttribute: string): 
 }
 
 function resolveAriaLabelledBy(el: Element): string | undefined {
-  const labelledBy = el.getAttribute("aria-labelledby");
+  const labelledBy = elementAttribute(el, "aria-labelledby");
   if (!labelledBy) return undefined;
 
   const doc = el.ownerDocument;
@@ -170,8 +178,8 @@ function resolveAriaLabelledBy(el: Element): string | undefined {
 }
 
 function readInputValueIfSafe(el: Element): string | undefined {
-  if (el.tagName !== "INPUT") return undefined;
-  const type = (el.getAttribute("type") || "text").toLowerCase();
+  if (elementTag(el) !== "INPUT") return undefined;
+  const type = (elementAttribute(el, "type") || "text").toLowerCase();
   if (!VALUE_READABLE_INPUT_TYPES.has(type)) return undefined;
   const value = (el as HTMLInputElement).value;
   return value ? value : undefined;
@@ -187,19 +195,19 @@ function findStandardAttributeName(path: Element[]): string | undefined {
     const inputValue = readInputValueIfSafe(el);
     if (inputValue) return inputValue;
 
-    const ariaLabel = el.getAttribute("aria-label");
+    const ariaLabel = elementAttribute(el, "aria-label");
     if (ariaLabel && normalizeWhitespace(ariaLabel)) return ariaLabel;
 
     const labelledByText = resolveAriaLabelledBy(el);
     if (labelledByText) return labelledByText;
 
-    const alt = el.getAttribute("alt");
+    const alt = elementAttribute(el, "alt");
     if (alt && normalizeWhitespace(alt)) return alt;
 
-    const title = el.getAttribute("title");
+    const title = elementAttribute(el, "title");
     if (title && normalizeWhitespace(title)) return title;
 
-    const placeholder = el.getAttribute("placeholder");
+    const placeholder = elementAttribute(el, "placeholder");
     if (placeholder && normalizeWhitespace(placeholder)) return placeholder;
   }
   return undefined;
@@ -220,7 +228,7 @@ function findStandardAttributeName(path: Element[]): string | undefined {
  */
 function findTextContentName(path: Element[]): string | undefined {
   for (const el of path) {
-    if (CLICKABLE_TEXT_TAGS.has(el.tagName) || el.getAttribute("role") === "button") {
+    if (CLICKABLE_TEXT_TAGS.has(elementTag(el)) || elementAttribute(el, "role") === "button") {
       const text = labelText(el);
       if (text) return text;
     }

--- a/src/instrumentations/interactions/action-name.ts
+++ b/src/instrumentations/interactions/action-name.ts
@@ -1,9 +1,18 @@
+import { DEFAULT_ACTION_NAME_ATTRIBUTE, vars } from "../../vars";
+import { warn } from "../../utils/debug";
+
 export type ActionNameSource = "custom_attribute" | "standard_attribute" | "text_content" | "blank";
 
 export type ActionNameResult = {
   name: string;
   nameSource: ActionNameSource;
 };
+
+/**
+ * Last-chance hook to replace or drop a derived interaction name before it is
+ * emitted. See `InteractionInstrumentationSettings.actionNameScrubber`.
+ */
+export type ActionNameScrubber = (name: string, source: ActionNameSource, target: Element) => string;
 
 const MAX_ANCESTOR_WALK = 10;
 const MAX_NAME_LENGTH = 100;
@@ -13,14 +22,86 @@ const VALUE_READABLE_INPUT_TYPES = new Set(["button", "submit", "reset"]);
 // Elements whose visible text is read during the text-content phase because their
 // text is an action label rather than page content.
 const CLICKABLE_TEXT_TAGS = new Set(["BUTTON", "LABEL", "A"]);
-// Never derive a name from the text content of these click targets: an OPTION's /
-// SELECT's visible text is the user's chosen value and a TEXTAREA's text IS its
-// value — all user data, not an action label. (They may still be named via
-// attribute sources such as aria-label or placeholder.)
-const TEXT_FALLBACK_EXCLUDED_TAGS = new Set(["INPUT", "TEXTAREA", "SELECT", "OPTION"]);
+// Never read text from these elements OR their descendants: an OPTION's / SELECT's
+// visible text is the user's chosen value, a TEXTAREA's text IS its value, an
+// OUTPUT holds a computed result, and SCRIPT/STYLE/NOSCRIPT hold source code
+// rather than a label. Crucial for keeping such text out of the label collected
+// from ANY element, because a label almost always WRAPS its control. (Controls may
+// still be named via attribute sources such as aria-label or placeholder.)
+//
+// Matched against `localName`, which is lowercase for HTML elements in both HTML
+// and XHTML documents; `tagName` is uppercase only in HTML documents, so an
+// uppercase set silently never matches in an XHTML document.
+const TEXT_EXCLUDED_TAGS = new Set(["input", "textarea", "select", "option", "output", "script", "style", "noscript"]);
+// labelText budgets. The name is capped at MAX_NAME_LENGTH anyway, so 1024
+// characters leaves ~10x headroom for markup whitespace. The node bound is the
+// one that matters for pathological subtrees: characters only accumulate on text
+// nodes, so a virtualized grid of empty elements never reaches the char budget.
+const MAX_TEXT_SCAN_LENGTH = 1024;
+const MAX_TEXT_SCAN_NODES = 1000;
 
 function normalizeWhitespace(value: string): string {
   return value.replace(/\s+/g, " ").trim();
+}
+
+function isTextExcluded(el: Element): boolean {
+  if (TEXT_EXCLUDED_TAGS.has(el.localName)) return true;
+  // A contenteditable region holds user-typed content. The attribute is read
+  // directly rather than via `isContentEditable`: that property is unimplemented
+  // in jsdom and is false for elements outside a rendered document. An empty
+  // value means editable per spec; only an explicit "false" opts out.
+  const editable = el.getAttribute("contenteditable");
+  return editable != null && editable.toLowerCase() !== "false";
+}
+
+/**
+ * Collects the author-written label text of `el`: like `textContent`, but never
+ * descends into an element whose text is user data rather than a label (see
+ * TEXT_EXCLUDED_TAGS / contenteditable), and returns "" when `el` is itself such
+ * an element. `textContent` cannot be used for naming because a label almost
+ * always wraps its control -- `<label>Notes <textarea>...</textarea></label>` --
+ * so the control's value would end up in the interaction name and, from there, in
+ * the log body and on `user_interaction.name` of correlated HTTP spans.
+ *
+ * Shadow roots are never traversed, matching `textContent`.
+ *
+ * Bounded by MAX_TEXT_SCAN_LENGTH collected characters and MAX_TEXT_SCAN_NODES
+ * visited nodes. Traverses via firstChild/nextSibling rather than childNodes so
+ * that a node with 50k children cannot cost 50k pushes before a budget is
+ * consulted. The result is whitespace-normalized.
+ */
+function labelText(el: Element): string {
+  let text = "";
+  let visited = 0;
+  const pending: Node[] = [];
+  let node: Node | null = isTextExcluded(el) ? null : el.firstChild;
+
+  while (node && text.length < MAX_TEXT_SCAN_LENGTH && visited < MAX_TEXT_SCAN_NODES) {
+    visited++;
+    // Queued before descending, which keeps the traversal in document order.
+    // Since we start at el.firstChild and only ever queue a visited node's
+    // sibling, the walk cannot escape el's subtree.
+    if (node.nextSibling) {
+      pending.push(node.nextSibling);
+    }
+
+    let child: Node | null = null;
+    if (node.nodeType === 3) {
+      text += (node as Text).data;
+    } else if (node.nodeType === 1) {
+      if (isTextExcluded(node as Element)) {
+        // A separator, so dropping a control cannot glue its neighbours into one
+        // word: "Qty<input>units" -> "Qty units", not "Qtyunits".
+        text += " ";
+      } else {
+        child = node.firstChild;
+      }
+    }
+
+    node = child || pending.pop() || null;
+  }
+
+  return normalizeWhitespace(text);
 }
 
 function truncate(name: string): string {
@@ -77,8 +158,12 @@ function resolveAriaLabelledBy(el: Element): string | undefined {
   const doc = el.ownerDocument;
   const parts = labelledBy
     .split(/\s+/)
-    .map((id) => doc.getElementById(id)?.textContent ?? "")
-    .map((text) => normalizeWhitespace(text))
+    .map((id) => {
+      const ref = doc.getElementById(id);
+      // labelText, not textContent: an aria-labelledby target routinely wraps a
+      // form control -- or is one -- in which case it contributes nothing.
+      return ref ? labelText(ref) : "";
+    })
     .filter((text) => text.length > 0);
 
   return parts.length > 0 ? parts.join(" ") : undefined;
@@ -121,34 +206,72 @@ function findStandardAttributeName(path: Element[]): string | undefined {
 }
 
 /**
- * Text-content source: the visible text of clickable-tag elements
+ * Text-content source: the label text of clickable-tag elements
  * (BUTTON/[role=button]/LABEL/A) found along the walk path. A click that lands
  * on a non-interactive container (e.g. a layout <div>/<footer>) with no such
  * element in its path — and no naming attribute — deliberately yields no name,
  * so deriveActionName falls through to "blank" + target metadata rather than
- * dumping the container's entire textContent. Skipped entirely for
- * INPUT/TEXTAREA/SELECT/OPTION targets — their text content is user data
- * (see TEXT_FALLBACK_EXCLUDED_TAGS).
+ * dumping the container's entire text.
+ *
+ * The text is collected with `labelText`, never `textContent`, so a control
+ * nested inside the named element (the `<label>Notes <textarea>` shape) never
+ * contributes its value. That exclusion is what makes it safe to read an
+ * ancestor's text for a click that landed on the control itself.
  */
-function findTextContentName(target: Element, path: Element[]): string | undefined {
-  if (TEXT_FALLBACK_EXCLUDED_TAGS.has(target.tagName)) return undefined;
-
+function findTextContentName(path: Element[]): string | undefined {
   for (const el of path) {
     if (CLICKABLE_TEXT_TAGS.has(el.tagName) || el.getAttribute("role") === "button") {
-      const text = el.textContent;
-      if (text && normalizeWhitespace(text)) return text;
+      const text = labelText(el);
+      if (text) return text;
     }
   }
 
   return undefined;
 }
 
+let scrubberWarned = false;
+
 /**
- * Derives a human-readable interaction name for a clicked element, following
+ * Applies the consumer-configured scrubber, fail-closed: if it throws or returns
+ * a non-string the name is dropped entirely rather than emitted unscrubbed --
+ * matching how `addUrlAttributes` drops URL attributes when a custom
+ * `urlAttributeScrubber` misbehaves. Warns at most once, since a throwing
+ * scrubber would otherwise fire on every interaction.
+ *
+ * Only invoked for a derived, non-empty name: a scrubber must not be able to
+ * invent a name where the SDK derived none.
+ */
+function applyScrubber(result: ActionNameResult, target: Element, scrubber?: ActionNameScrubber): ActionNameResult {
+  if (!scrubber || !result.name) {
+    return result;
+  }
+
+  try {
+    const scrubbed = scrubber(result.name, result.nameSource, target);
+    if (typeof scrubbed !== "string") {
+      if (!scrubberWarned) {
+        scrubberWarned = true;
+        warn("Dash0 actionNameScrubber did not return a string. Dropping the interaction name.");
+      }
+      return { name: "", nameSource: "blank" };
+    }
+    // finalize again so a scrubber cannot bypass normalization or the length cap.
+    return finalize(scrubbed, result.nameSource);
+  } catch (err) {
+    if (!scrubberWarned) {
+      scrubberWarned = true;
+      warn("Dash0 actionNameScrubber threw. Dropping the interaction name.", err);
+    }
+    return { name: "", nameSource: "blank" };
+  }
+}
+
+/**
+ * Derives a human-readable interaction name for an interaction target, following
  * Datadog RUM's action-name priority order:
  *   1. configured custom attribute (target or ancestor)
  *   2. standard attribute-based sources (target or ancestor)
- *   3. visible text of clickable-tag elements (button/link/label/[role=button])
+ *   3. label text of clickable-tag elements (button/link/label/[role=button])
  *      found along the walk path
  *   4. blank
  *
@@ -156,27 +279,49 @@ function findTextContentName(target: Element, path: Element[]): string | undefin
  * first FORM/BODY/HTML/HEAD boundary.
  *
  * Privacy: never reads the value of password/text/textarea/select elements --
- * only button/submit/reset inputs expose `.value` -- and never derives a name
- * from the text content of INPUT/TEXTAREA/SELECT/OPTION targets. Whitespace is
- * always normalized and the result is truncated to 100 characters.
+ * only button/submit/reset inputs expose `.value` -- and never reads text from a
+ * form control, `<output>`, contenteditable region, or `<script>`/`<style>`
+ * anywhere inside the element it names, including via `aria-labelledby` (see
+ * `labelText`). Whitespace is always normalized and the result is truncated to
+ * 100 characters. Whatever survives is passed through the optional consumer
+ * scrubber as the final step.
  */
-export function deriveActionName(target: Element, actionNameAttribute: string): ActionNameResult {
+export function deriveActionName(
+  target: Element,
+  actionNameAttribute: string,
+  scrubber?: ActionNameScrubber
+): ActionNameResult {
   const path = collectWalkPath(target);
 
   const customName = findCustomAttributeName(path, actionNameAttribute);
   if (customName) {
-    return finalize(customName, "custom_attribute");
+    return applyScrubber(finalize(customName, "custom_attribute"), target, scrubber);
   }
 
   const standardName = findStandardAttributeName(path);
   if (standardName) {
-    return finalize(standardName, "standard_attribute");
+    return applyScrubber(finalize(standardName, "standard_attribute"), target, scrubber);
   }
 
-  const textName = findTextContentName(target, path);
+  const textName = findTextContentName(path);
   if (textName) {
-    return finalize(textName, "text_content");
+    return applyScrubber(finalize(textName, "text_content"), target, scrubber);
   }
 
   return { name: "", nameSource: "blank" };
+}
+
+/**
+ * The single choke point every interaction type goes through to name its target.
+ * Reads the naming configuration from `vars` so that no handler can accidentally
+ * bypass the configured scrubber; `deriveActionName` stays pure and takes its
+ * configuration explicitly so it remains directly unit-testable.
+ */
+export function resolveActionName(target: Element): ActionNameResult {
+  const settings = vars.interactionInstrumentation;
+  return deriveActionName(
+    target,
+    settings.actionNameAttribute ?? DEFAULT_ACTION_NAME_ATTRIBUTE,
+    settings.actionNameScrubber
+  );
 }

--- a/src/instrumentations/interactions/action-name_test.ts
+++ b/src/instrumentations/interactions/action-name_test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import {
   EVENT_NAMES,
   INTERACTION_TYPE,
@@ -8,6 +8,11 @@ import {
   INTERACTION_TARGET_TAG,
   INTERACTION_TARGET_ID,
 } from "../../semantic-conventions";
+import { doc } from "../../utils/globals";
+import { deriveActionName } from "./action-name";
+
+// Vitest runs these tests in jsdom, so the SSR-safe doc is always defined.
+const dom = doc!;
 
 describe("interaction semantic conventions", () => {
   it("defines the browser.interaction event name", () => {
@@ -21,5 +26,346 @@ describe("interaction semantic conventions", () => {
     expect(INTERACTION_TARGET_SELECTOR).toBe("target.selector");
     expect(INTERACTION_TARGET_TAG).toBe("target.tag");
     expect(INTERACTION_TARGET_ID).toBe("target.id");
+  });
+});
+
+describe("deriveActionName", () => {
+  const attributeName = "data-dash0-action-name";
+
+  beforeEach(() => {
+    dom.body.innerHTML = "";
+  });
+
+  describe("priority 1: custom attribute", () => {
+    it("uses the custom attribute on the target itself", () => {
+      dom.body.innerHTML = `<button id="btn" data-dash0-action-name="Save Settings">Save</button>`;
+      const target = dom.getElementById("btn")!;
+
+      expect(deriveActionName(target, attributeName)).toEqual({
+        name: "Save Settings",
+        nameSource: "custom_attribute",
+      });
+    });
+
+    it("uses the custom attribute on an ancestor", () => {
+      dom.body.innerHTML = `
+        <div data-dash0-action-name="Card Action">
+          <span id="inner">Click me</span>
+        </div>`;
+      const target = dom.getElementById("inner")!;
+
+      expect(deriveActionName(target, attributeName)).toEqual({
+        name: "Card Action",
+        nameSource: "custom_attribute",
+      });
+    });
+
+    it("prefers the custom attribute over standard attributes when both are present", () => {
+      dom.body.innerHTML = `<button id="btn" aria-label="Aria Label" data-dash0-action-name="Custom Name">Text</button>`;
+      const target = dom.getElementById("btn")!;
+
+      expect(deriveActionName(target, attributeName)).toEqual({
+        name: "Custom Name",
+        nameSource: "custom_attribute",
+      });
+    });
+
+    it("respects a custom actionNameAttribute name", () => {
+      dom.body.innerHTML = `<button id="btn" data-my-name="Custom">Text</button>`;
+      const target = dom.getElementById("btn")!;
+
+      expect(deriveActionName(target, "data-my-name")).toEqual({
+        name: "Custom",
+        nameSource: "custom_attribute",
+      });
+    });
+  });
+
+  describe("priority 2: standard attributes", () => {
+    it("uses .value for an input[type=button]", () => {
+      dom.body.innerHTML = `<input id="inp" type="button" value="Click Here" />`;
+      const target = dom.getElementById("inp")!;
+
+      expect(deriveActionName(target, attributeName)).toEqual({
+        name: "Click Here",
+        nameSource: "standard_attribute",
+      });
+    });
+
+    it("uses .value for an input[type=submit]", () => {
+      dom.body.innerHTML = `<input id="inp" type="submit" value="Submit Form" />`;
+      const target = dom.getElementById("inp")!;
+
+      expect(deriveActionName(target, attributeName)).toEqual({
+        name: "Submit Form",
+        nameSource: "standard_attribute",
+      });
+    });
+
+    it("uses .value for an input[type=reset]", () => {
+      dom.body.innerHTML = `<input id="inp" type="reset" value="Reset Form" />`;
+      const target = dom.getElementById("inp")!;
+
+      expect(deriveActionName(target, attributeName)).toEqual({
+        name: "Reset Form",
+        nameSource: "standard_attribute",
+      });
+    });
+
+    it("never reads .value for an input[type=text]", () => {
+      dom.body.innerHTML = `<input id="inp" type="text" value="secret-input-value" />`;
+      const target = dom.getElementById("inp")!;
+
+      expect(deriveActionName(target, attributeName)).toEqual({
+        name: "",
+        nameSource: "blank",
+      });
+    });
+
+    it("never reads .value for an input[type=password]", () => {
+      dom.body.innerHTML = `<input id="inp" type="password" value="hunter2" />`;
+      const target = dom.getElementById("inp")!;
+
+      expect(deriveActionName(target, attributeName)).toEqual({
+        name: "",
+        nameSource: "blank",
+      });
+    });
+
+    it("uses aria-label on a button before visible text", () => {
+      dom.body.innerHTML = `<button id="btn" aria-label="Close Dialog">X</button>`;
+      const target = dom.getElementById("btn")!;
+
+      expect(deriveActionName(target, attributeName)).toEqual({
+        name: "Close Dialog",
+        nameSource: "standard_attribute",
+      });
+    });
+
+    it("uses visible text on a button when aria-label is absent", () => {
+      dom.body.innerHTML = `<button id="btn">Save Settings</button>`;
+      const target = dom.getElementById("btn")!;
+
+      expect(deriveActionName(target, attributeName)).toEqual({
+        name: "Save Settings",
+        nameSource: "text_content",
+      });
+    });
+
+    it("uses aria-label on a role=button element", () => {
+      dom.body.innerHTML = `<div id="btn" role="button" aria-label="Icon Button"></div>`;
+      const target = dom.getElementById("btn")!;
+
+      expect(deriveActionName(target, attributeName)).toEqual({
+        name: "Icon Button",
+        nameSource: "standard_attribute",
+      });
+    });
+
+    it("uses aria-label on a label element", () => {
+      dom.body.innerHTML = `<label id="lbl" aria-label="Field Label">Text</label>`;
+      const target = dom.getElementById("lbl")!;
+
+      expect(deriveActionName(target, attributeName)).toEqual({
+        name: "Field Label",
+        nameSource: "standard_attribute",
+      });
+    });
+
+    it("uses aria-label on an anchor element", () => {
+      dom.body.innerHTML = `<a id="lnk" href="#" aria-label="Learn More">Read</a>`;
+      const target = dom.getElementById("lnk")!;
+
+      expect(deriveActionName(target, attributeName)).toEqual({
+        name: "Learn More",
+        nameSource: "standard_attribute",
+      });
+    });
+
+    it("resolves aria-labelledby to referenced element text, joined with a space", () => {
+      dom.body.innerHTML = `
+        <span id="label-a">Confirm</span>
+        <span id="label-b">Purchase</span>
+        <button id="btn" aria-labelledby="label-a label-b">X</button>`;
+      const target = dom.getElementById("btn")!;
+
+      expect(deriveActionName(target, attributeName)).toEqual({
+        name: "Confirm Purchase",
+        nameSource: "standard_attribute",
+      });
+    });
+
+    it("falls back to alt attribute", () => {
+      dom.body.innerHTML = `<img id="img" alt="Company Logo" />`;
+      const target = dom.getElementById("img")!;
+
+      expect(deriveActionName(target, attributeName)).toEqual({
+        name: "Company Logo",
+        nameSource: "standard_attribute",
+      });
+    });
+
+    it("falls back to title attribute", () => {
+      dom.body.innerHTML = `<span id="span" title="Tooltip Text"></span>`;
+      const target = dom.getElementById("span")!;
+
+      expect(deriveActionName(target, attributeName)).toEqual({
+        name: "Tooltip Text",
+        nameSource: "standard_attribute",
+      });
+    });
+
+    it("falls back to placeholder attribute", () => {
+      dom.body.innerHTML = `<input id="inp" type="text" placeholder="Search..." />`;
+      const target = dom.getElementById("inp")!;
+
+      expect(deriveActionName(target, attributeName)).toEqual({
+        name: "Search...",
+        nameSource: "standard_attribute",
+      });
+    });
+
+    it("finds standard attributes on an ancestor when the target has none", () => {
+      dom.body.innerHTML = `
+        <button id="btn" aria-label="Delete Item">
+          <span id="icon">🗑</span>
+        </button>`;
+      const target = dom.getElementById("icon")!;
+
+      expect(deriveActionName(target, attributeName)).toEqual({
+        name: "Delete Item",
+        nameSource: "standard_attribute",
+      });
+    });
+  });
+
+  describe("priority 3: text content fallback", () => {
+    it("uses whitespace-normalized textContent when no attributes match", () => {
+      dom.body.innerHTML = `<div id="div">  Some\n\n  Text   Here  </div>`;
+      const target = dom.getElementById("div")!;
+
+      expect(deriveActionName(target, attributeName)).toEqual({
+        name: "Some Text Here",
+        nameSource: "text_content",
+      });
+    });
+  });
+
+  describe("priority 4: blank fallback", () => {
+    it("returns blank when nothing matches", () => {
+      dom.body.innerHTML = `<div id="div"></div>`;
+      const target = dom.getElementById("div")!;
+
+      expect(deriveActionName(target, attributeName)).toEqual({
+        name: "",
+        nameSource: "blank",
+      });
+    });
+  });
+
+  describe("privacy: select and textarea values are never read", () => {
+    it("never reads a select's value or selected option text via .value", () => {
+      dom.body.innerHTML = `
+        <select id="sel">
+          <option value="secret-option" selected>Secret Option Label</option>
+        </select>`;
+      const target = dom.getElementById("sel")!;
+
+      expect(deriveActionName(target, attributeName)).toEqual({
+        name: "",
+        nameSource: "blank",
+      });
+    });
+
+    it("never reads a textarea's value", () => {
+      dom.body.innerHTML = `<textarea id="ta">secret multiline content</textarea>`;
+      const target = dom.getElementById("ta")!;
+
+      expect(deriveActionName(target, attributeName)).toEqual({
+        name: "",
+        nameSource: "blank",
+      });
+    });
+  });
+
+  describe("ancestor walk boundaries", () => {
+    it("stops walking at a FORM boundary and does not use attributes above it", () => {
+      dom.body.innerHTML = `
+        <form data-dash0-action-name="Form Name">
+          <span id="span">Inner</span>
+        </form>`;
+      const target = dom.getElementById("span")!;
+
+      // FORM itself is a valid boundary to check per Datadog prior art (closest() would match it),
+      // so the custom attribute on the FORM is still found -- the walk stops AT the boundary, not before it.
+      expect(deriveActionName(target, attributeName)).toEqual({
+        name: "Form Name",
+        nameSource: "custom_attribute",
+      });
+    });
+
+    it("does not walk past FORM to reach an ancestor's attribute", () => {
+      // The target is deliberately text-free so the blank assertion isolates
+      // the FORM walk boundary (the target's own text would otherwise
+      // legitimately resolve as text_content).
+      dom.body.innerHTML = `
+        <div data-dash0-action-name="Outer Name">
+          <form>
+            <span id="span"></span>
+          </form>
+        </div>`;
+      const target = dom.getElementById("span")!;
+
+      expect(deriveActionName(target, attributeName)).toEqual({
+        name: "",
+        nameSource: "blank",
+      });
+    });
+
+    it("caps the ancestor walk at 10 levels", () => {
+      // Build 12 nested divs; only the outermost (12 levels up) carries the attribute,
+      // which exceeds the 10-ancestor cap and must not be found.
+      // The target is deliberately text-free so the blank assertion isolates
+      // the 10-level walk cap (the target's own text would otherwise
+      // legitimately resolve as text_content).
+      let html = `<div data-dash0-action-name="Too Far">`;
+      for (let i = 0; i < 12; i++) {
+        html += `<div>`;
+      }
+      html += `<span id="span"></span>`;
+      for (let i = 0; i < 12; i++) {
+        html += `</div>`;
+      }
+      html += `</div>`;
+      dom.body.innerHTML = html;
+      const target = dom.getElementById("span")!;
+
+      expect(deriveActionName(target, attributeName)).toEqual({
+        name: "",
+        nameSource: "blank",
+      });
+    });
+  });
+
+  describe("truncation", () => {
+    it("truncates names longer than 100 characters and appends a marker", () => {
+      const longText = "A".repeat(150);
+      dom.body.innerHTML = `<button id="btn">${longText}</button>`;
+      const target = dom.getElementById("btn")!;
+
+      const result = deriveActionName(target, attributeName);
+      expect(result.nameSource).toBe("text_content");
+      expect(result.name).toBe("A".repeat(100) + " [...]");
+      expect(result.name.length).toBe(106);
+    });
+
+    it("does not truncate names at exactly 100 characters", () => {
+      const exactText = "B".repeat(100);
+      dom.body.innerHTML = `<button id="btn">${exactText}</button>`;
+      const target = dom.getElementById("btn")!;
+
+      const result = deriveActionName(target, attributeName);
+      expect(result.name).toBe(exactText);
+    });
   });
 });

--- a/src/instrumentations/interactions/action-name_test.ts
+++ b/src/instrumentations/interactions/action-name_test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import {
+  EVENT_NAMES,
+  INTERACTION_TYPE,
+  INTERACTION_NAME,
+  INTERACTION_NAME_SOURCE,
+  INTERACTION_TARGET_SELECTOR,
+  INTERACTION_TARGET_TAG,
+  INTERACTION_TARGET_ID,
+} from "../../semantic-conventions";
+
+describe("interaction semantic conventions", () => {
+  it("defines the browser.interaction event name", () => {
+    expect(EVENT_NAMES.INTERACTION).toBe("browser.interaction");
+  });
+
+  it("defines interaction attribute keys", () => {
+    expect(INTERACTION_TYPE).toBe("type");
+    expect(INTERACTION_NAME).toBe("name");
+    expect(INTERACTION_NAME_SOURCE).toBe("name_source");
+    expect(INTERACTION_TARGET_SELECTOR).toBe("target.selector");
+    expect(INTERACTION_TARGET_TAG).toBe("target.tag");
+    expect(INTERACTION_TARGET_ID).toBe("target.id");
+  });
+});

--- a/src/instrumentations/interactions/action-name_test.ts
+++ b/src/instrumentations/interactions/action-name_test.ts
@@ -19,13 +19,13 @@ describe("interaction semantic conventions", () => {
     expect(EVENT_NAMES.INTERACTION).toBe("browser.interaction");
   });
 
-  it("defines interaction attribute keys", () => {
-    expect(INTERACTION_TYPE).toBe("type");
-    expect(INTERACTION_NAME).toBe("name");
-    expect(INTERACTION_NAME_SOURCE).toBe("name_source");
-    expect(INTERACTION_TARGET_SELECTOR).toBe("target.selector");
-    expect(INTERACTION_TARGET_TAG).toBe("target.tag");
-    expect(INTERACTION_TARGET_ID).toBe("target.id");
+  it("defines namespaced interaction attribute keys (log attributes, not body keys)", () => {
+    expect(INTERACTION_TYPE).toBe("interaction.type");
+    expect(INTERACTION_NAME).toBe("interaction.name");
+    expect(INTERACTION_NAME_SOURCE).toBe("interaction.name_source");
+    expect(INTERACTION_TARGET_SELECTOR).toBe("interaction.target.selector");
+    expect(INTERACTION_TARGET_TAG).toBe("interaction.target.tag");
+    expect(INTERACTION_TARGET_ID).toBe("interaction.target.id");
   });
 });
 
@@ -240,13 +240,26 @@ describe("deriveActionName", () => {
   });
 
   describe("priority 3: text content fallback", () => {
-    it("uses whitespace-normalized textContent when no attributes match", () => {
+    it("uses whitespace-normalized textContent of a clickable-tag element", () => {
+      dom.body.innerHTML = `<button id="btn">  Save\n\n  Part   Now  </button>`;
+      const target = dom.getElementById("btn")!;
+
+      expect(deriveActionName(target, attributeName)).toEqual({
+        name: "Save Part Now",
+        nameSource: "text_content",
+      });
+    });
+
+    it("does NOT harvest textContent from a non-interactive container", () => {
+      // Regression guard: a click on a layout <div> with no clickable-tag
+      // ancestor and no naming attribute must fall through to blank, not dump
+      // the container's entire visible text as the action name.
       dom.body.innerHTML = `<div id="div">  Some\n\n  Text   Here  </div>`;
       const target = dom.getElementById("div")!;
 
       expect(deriveActionName(target, attributeName)).toEqual({
-        name: "Some Text Here",
-        nameSource: "text_content",
+        name: "",
+        nameSource: "blank",
       });
     });
   });

--- a/src/instrumentations/interactions/action-name_test.ts
+++ b/src/instrumentations/interactions/action-name_test.ts
@@ -286,6 +286,22 @@ describe("deriveActionName", () => {
         nameSource: "blank",
       });
     });
+
+    it("never derives a name from an OPTION click target's visible text", () => {
+      // Pins the OPTION entry of TEXT_FALLBACK_EXCLUDED_TAGS: an option's
+      // visible text is the user's chosen value, so a direct click on it
+      // (no attribute sources anywhere in the walk) must stay blank.
+      dom.body.innerHTML = `
+        <select id="sel">
+          <option id="opt" value="secret-option" selected>Secret Option Label</option>
+        </select>`;
+      const target = dom.getElementById("opt")!;
+
+      expect(deriveActionName(target, attributeName)).toEqual({
+        name: "",
+        nameSource: "blank",
+      });
+    });
   });
 
   describe("ancestor walk boundaries", () => {
@@ -334,6 +350,49 @@ describe("deriveActionName", () => {
       }
       html += `<span id="span"></span>`;
       for (let i = 0; i < 12; i++) {
+        html += `</div>`;
+      }
+      html += `</div>`;
+      dom.body.innerHTML = html;
+      const target = dom.getElementById("span")!;
+
+      expect(deriveActionName(target, attributeName)).toEqual({
+        name: "",
+        nameSource: "blank",
+      });
+    });
+
+    it("finds a custom attribute on exactly the 10th ancestor", () => {
+      // Pins the exact MAX_ANCESTOR_WALK boundary: the attribute div plus 9
+      // plain divs puts the attribute exactly 10 ancestors above the target.
+      let html = `<div data-dash0-action-name="At The Cap">`;
+      for (let i = 0; i < 9; i++) {
+        html += `<div>`;
+      }
+      html += `<span id="span"></span>`;
+      for (let i = 0; i < 9; i++) {
+        html += `</div>`;
+      }
+      html += `</div>`;
+      dom.body.innerHTML = html;
+      const target = dom.getElementById("span")!;
+
+      expect(deriveActionName(target, attributeName)).toEqual({
+        name: "At The Cap",
+        nameSource: "custom_attribute",
+      });
+    });
+
+    it("does not find a custom attribute on the 11th ancestor", () => {
+      // Pins the exact MAX_ANCESTOR_WALK boundary from the other side: 10
+      // plain divs push the attribute to ancestor 11, one past the cap. The
+      // target is deliberately text-free so blank isolates the cap itself.
+      let html = `<div data-dash0-action-name="One Past The Cap">`;
+      for (let i = 0; i < 10; i++) {
+        html += `<div>`;
+      }
+      html += `<span id="span"></span>`;
+      for (let i = 0; i < 10; i++) {
         html += `</div>`;
       }
       html += `</div>`;

--- a/src/instrumentations/interactions/action-name_test.ts
+++ b/src/instrumentations/interactions/action-name_test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   EVENT_NAMES,
   INTERACTION_TYPE,
@@ -9,10 +9,12 @@ import {
   INTERACTION_TARGET_ID,
 } from "../../semantic-conventions";
 import { doc } from "../../utils/globals";
-import { deriveActionName } from "./action-name";
+import { vars } from "../../vars";
+import { deriveActionName, resolveActionName } from "./action-name";
 
 // Vitest runs these tests in jsdom, so the SSR-safe doc is always defined.
 const dom = doc!;
+const defaultInteractionSettings = { ...vars.interactionInstrumentation };
 
 describe("interaction semantic conventions", () => {
   it("defines the browser.interaction event name", () => {
@@ -438,6 +440,371 @@ describe("deriveActionName", () => {
 
       const result = deriveActionName(target, attributeName);
       expect(result.name).toBe(exactText);
+    });
+  });
+
+  // Regression coverage for the P1 leak: the exclusion list used to be checked
+  // against the CLICK TARGET's tag only, while the text itself was read with
+  // `Element.textContent` from an ANCESTOR -- and `textContent` concatenates the
+  // whole subtree, including the wrapped control's value. A <label> wrapping its
+  // control is the dominant form markup, so this was the default shape.
+  describe("privacy: text is never harvested from a nested control or editable region", () => {
+    it("does not read a wrapped textarea's value from the enclosing label's text", () => {
+      dom.body.innerHTML = `<label id="lbl">Notes <textarea>MY PRIVATE SAVED NOTE</textarea></label>`;
+      const target = dom.getElementById("lbl")!;
+
+      expect(deriveActionName(target, attributeName)).toEqual({
+        name: "Notes",
+        nameSource: "text_content",
+      });
+    });
+
+    it("does not read a wrapped select's option text from the enclosing button's text", () => {
+      dom.body.innerHTML = `<button id="btn">Filter <select><option>Acme Corp Invoice 4471</option></select></button>`;
+      const target = dom.getElementById("btn")!;
+
+      expect(deriveActionName(target, attributeName)).toEqual({
+        name: "Filter",
+        nameSource: "text_content",
+      });
+    });
+
+    it("names a control click from its enclosing label, without the control's own value", () => {
+      // The text phase now applies to form-control targets too: with the
+      // control's text excluded from collection, the enclosing label's text is
+      // the correct name and carries no user data.
+      dom.body.innerHTML = `<label id="lbl">Notes <textarea id="ta">MY PRIVATE SAVED NOTE</textarea></label>`;
+      const target = dom.getElementById("ta")!;
+
+      expect(deriveActionName(target, attributeName)).toEqual({
+        name: "Notes",
+        nameSource: "text_content",
+      });
+    });
+
+    it("excludes a control nested more than one level deep", () => {
+      dom.body.innerHTML = `<a id="lnk" href="#"><span><textarea>SECRET</textarea></span> Open</a>`;
+      const target = dom.getElementById("lnk")!;
+
+      expect(deriveActionName(target, attributeName)).toEqual({
+        name: "Open",
+        nameSource: "text_content",
+      });
+    });
+
+    it("separates the text around a removed control instead of gluing it together", () => {
+      dom.body.innerHTML = `<label id="lbl">Qty<input value="99" />units</label>`;
+      const target = dom.getElementById("lbl")!;
+
+      expect(deriveActionName(target, attributeName)).toEqual({
+        name: "Qty units",
+        nameSource: "text_content",
+      });
+    });
+
+    it("does not read an output element's computed value", () => {
+      dom.body.innerHTML = `<label id="lbl">Total <output>4,271.33</output></label>`;
+      const target = dom.getElementById("lbl")!;
+
+      expect(deriveActionName(target, attributeName)).toEqual({
+        name: "Total",
+        nameSource: "text_content",
+      });
+    });
+
+    it("does not read a contenteditable region's text", () => {
+      dom.body.innerHTML = `<div id="btn" role="button">Post <div contenteditable="true">USER TYPED DRAFT</div></div>`;
+      const target = dom.getElementById("btn")!;
+
+      expect(deriveActionName(target, attributeName)).toEqual({
+        name: "Post",
+        nameSource: "text_content",
+      });
+    });
+
+    it("skips a whole contenteditable region including a nested contenteditable=false chip", () => {
+      // Conservative on purpose: a `false` chip inside an editor is typically an
+      // app-inserted mention widget holding user data ("Jane Doe").
+      dom.body.innerHTML = `
+        <div id="btn" role="button">Post
+          <div contenteditable="true">Hi <span contenteditable="false">Jane Doe</span></div>
+        </div>`;
+      const target = dom.getElementById("btn")!;
+
+      expect(deriveActionName(target, attributeName)).toEqual({
+        name: "Post",
+        nameSource: "text_content",
+      });
+    });
+
+    it("treats an empty contenteditable attribute as editable", () => {
+      dom.body.innerHTML = `<button id="btn">Comment <span contenteditable="">USER TYPED DRAFT</span></button>`;
+      const target = dom.getElementById("btn")!;
+
+      expect(deriveActionName(target, attributeName)).toEqual({
+        name: "Comment",
+        nameSource: "text_content",
+      });
+    });
+
+    it("still reads the text of an element explicitly marked contenteditable=false", () => {
+      dom.body.innerHTML = `<label id="lbl" contenteditable="false">Notes</label>`;
+      const target = dom.getElementById("lbl")!;
+
+      expect(deriveActionName(target, attributeName)).toEqual({
+        name: "Notes",
+        nameSource: "text_content",
+      });
+    });
+
+    it("does not read datalist option text", () => {
+      dom.body.innerHTML = `
+        <label id="lbl">Search
+          <datalist id="dl"><option>ACME Invoice 992</option></datalist>
+          <input list="dl" />
+        </label>`;
+      const target = dom.getElementById("lbl")!;
+
+      expect(deriveActionName(target, attributeName)).toEqual({
+        name: "Search",
+        nameSource: "text_content",
+      });
+    });
+
+    it("does not read inline script source", () => {
+      dom.body.innerHTML = `<button id="btn">Save<script>var token = "tok_live_abc";</script></button>`;
+      const target = dom.getElementById("btn")!;
+
+      expect(deriveActionName(target, attributeName)).toEqual({
+        name: "Save",
+        nameSource: "text_content",
+      });
+    });
+
+    it("does not read inline style rules", () => {
+      dom.body.innerHTML = `<button id="btn">Save<style>.x{color:red}</style></button>`;
+      const target = dom.getElementById("btn")!;
+
+      expect(deriveActionName(target, attributeName)).toEqual({
+        name: "Save",
+        nameSource: "text_content",
+      });
+    });
+
+    it("does not cross a shadow boundary", () => {
+      // Documents a boundary the SDK deliberately does not cross: traversing
+      // into shadow roots would open a new leak surface, not close one.
+      dom.body.innerHTML = `<div id="host" role="button">Publish</div>`;
+      const target = dom.getElementById("host")!;
+      target.attachShadow({ mode: "open" }).innerHTML = `<textarea>SECRET DRAFT</textarea>`;
+
+      expect(deriveActionName(target, attributeName)).toEqual({
+        name: "Publish",
+        nameSource: "text_content",
+      });
+    });
+  });
+
+  describe("privacy: aria-labelledby resolution", () => {
+    it("does not read a control nested inside the referenced element", () => {
+      // The worse half of the P1 leak: this path had no exclusion at all, and
+      // reported `standard_attribute`, so consumers filtering out text-derived
+      // names were still exposed.
+      dom.body.innerHTML = `
+        <span id="lbl">Upload <textarea>SECRET DRAFT</textarea></span>
+        <button id="btn" aria-labelledby="lbl">&uarr;</button>`;
+      const target = dom.getElementById("btn")!;
+
+      expect(deriveActionName(target, attributeName)).toEqual({
+        name: "Upload",
+        nameSource: "standard_attribute",
+      });
+    });
+
+    it("ignores a reference to an element that is itself a form control, falling through to title", () => {
+      dom.body.innerHTML = `
+        <textarea id="lbl">SECRET DRAFT</textarea>
+        <button id="btn" aria-labelledby="lbl" title="Send">x</button>`;
+      const target = dom.getElementById("btn")!;
+
+      expect(deriveActionName(target, attributeName)).toEqual({
+        name: "Send",
+        nameSource: "standard_attribute",
+      });
+    });
+
+    it("falls through to blank when aria-labelledby only references a form control", () => {
+      dom.body.innerHTML = `
+        <textarea id="lbl">SECRET DRAFT</textarea>
+        <div id="btn" aria-labelledby="lbl"></div>`;
+      const target = dom.getElementById("btn")!;
+
+      expect(deriveActionName(target, attributeName)).toEqual({
+        name: "",
+        nameSource: "blank",
+      });
+    });
+  });
+
+  describe("text scan budget", () => {
+    it("stops the walk at MAX_TEXT_SCAN_NODES rather than scanning an unbounded subtree", () => {
+      // Characters only accumulate on text nodes, so a subtree of empty
+      // elements would never hit the character budget -- the node bound is what
+      // keeps a click inside a virtualized grid cheap.
+      dom.body.innerHTML = `<div id="btn" role="button">${"<span></span>".repeat(1200)}Save</div>`;
+      const target = dom.getElementById("btn")!;
+
+      expect(deriveActionName(target, attributeName)).toEqual({
+        name: "",
+        nameSource: "blank",
+      });
+    });
+
+    it("still reaches label text just inside the node budget", () => {
+      dom.body.innerHTML = `<div id="btn" role="button">${"<span></span>".repeat(900)}Save</div>`;
+      const target = dom.getElementById("btn")!;
+
+      expect(deriveActionName(target, attributeName)).toEqual({
+        name: "Save",
+        nameSource: "text_content",
+      });
+    });
+
+    it("still normalizes and truncates when the character budget is exhausted", () => {
+      dom.body.innerHTML = `<button id="btn">${"<span>word </span>".repeat(300)}</button>`;
+      const target = dom.getElementById("btn")!;
+
+      const result = deriveActionName(target, attributeName);
+      expect(result.nameSource).toBe("text_content");
+      expect(result.name).toBe("word ".repeat(20) + " [...]");
+    });
+  });
+
+  describe("actionNameScrubber", () => {
+    it("replaces the derived name", () => {
+      dom.body.innerHTML = `<button id="btn">Delete jane@acme.com</button>`;
+      const target = dom.getElementById("btn")!;
+
+      expect(deriveActionName(target, attributeName, () => "Delete User")).toEqual({
+        name: "Delete User",
+        nameSource: "text_content",
+      });
+    });
+
+    it("receives the derived name, its source and the interaction target", () => {
+      dom.body.innerHTML = `<button id="btn" aria-label="Close Dialog">x</button>`;
+      const target = dom.getElementById("btn")!;
+      const scrubber = vi.fn(() => "scrubbed");
+
+      deriveActionName(target, attributeName, scrubber);
+
+      expect(scrubber).toHaveBeenCalledTimes(1);
+      expect(scrubber).toHaveBeenCalledWith("Close Dialog", "standard_attribute", target);
+    });
+
+    it("is not called when no name was derived, so it cannot invent one", () => {
+      dom.body.innerHTML = `<div id="div"></div>`;
+      const target = dom.getElementById("div")!;
+      const scrubber = vi.fn(() => "invented");
+
+      expect(deriveActionName(target, attributeName, scrubber)).toEqual({
+        name: "",
+        nameSource: "blank",
+      });
+      expect(scrubber).not.toHaveBeenCalled();
+    });
+
+    it("drops the name when the scrubber returns an empty string", () => {
+      dom.body.innerHTML = `<button id="btn">Delete</button>`;
+      const target = dom.getElementById("btn")!;
+
+      expect(deriveActionName(target, attributeName, () => "")).toEqual({
+        name: "",
+        nameSource: "blank",
+      });
+    });
+
+    it("fails closed when the scrubber throws: drops the name, does not propagate", () => {
+      dom.body.innerHTML = `<button id="btn">Delete jane@acme.com</button>`;
+      const target = dom.getElementById("btn")!;
+      const scrubber = () => {
+        throw new Error("boom");
+      };
+
+      expect(() => deriveActionName(target, attributeName, scrubber)).not.toThrow();
+      expect(deriveActionName(target, attributeName, scrubber)).toEqual({
+        name: "",
+        nameSource: "blank",
+      });
+    });
+
+    it("fails closed when the scrubber returns a non-string", () => {
+      dom.body.innerHTML = `<button id="btn">Delete jane@acme.com</button>`;
+      const target = dom.getElementById("btn")!;
+
+      expect(deriveActionName(target, attributeName, () => undefined as unknown as string)).toEqual({
+        name: "",
+        nameSource: "blank",
+      });
+    });
+
+    it("normalizes and truncates the scrubber's return value", () => {
+      dom.body.innerHTML = `<button id="btn">Save</button>`;
+      const target = dom.getElementById("btn")!;
+
+      const result = deriveActionName(target, attributeName, () => `  ${"C".repeat(150)}  `);
+      expect(result.name).toBe("C".repeat(100) + " [...]");
+    });
+
+    it("also applies to a name that came from the custom attribute", () => {
+      dom.body.innerHTML = `<button id="btn" data-dash0-action-name="Save jane@acme.com">Save</button>`;
+      const target = dom.getElementById("btn")!;
+
+      expect(deriveActionName(target, attributeName, (name) => name.replace(/\S+@\S+/, "[email]"))).toEqual({
+        name: "Save [email]",
+        nameSource: "custom_attribute",
+      });
+    });
+  });
+
+  describe("resolveActionName (the configuration choke point)", () => {
+    afterEach(() => {
+      vars.interactionInstrumentation = { ...defaultInteractionSettings };
+    });
+
+    it("reads the configured action name attribute", () => {
+      vars.interactionInstrumentation = { ...defaultInteractionSettings, actionNameAttribute: "data-track-name" };
+      dom.body.innerHTML = `<button id="btn" data-track-name="Custom Attr">Save</button>`;
+
+      expect(resolveActionName(dom.getElementById("btn")!)).toEqual({
+        name: "Custom Attr",
+        nameSource: "custom_attribute",
+      });
+    });
+
+    it("falls back to the default attribute when the option is explicitly undefined", () => {
+      // merge() in init.ts spreads source over destination, so a consumer
+      // passing `{ actionNameAttribute: undefined }` overwrites the default.
+      vars.interactionInstrumentation = { ...defaultInteractionSettings, actionNameAttribute: undefined };
+      dom.body.innerHTML = `<button id="btn" data-dash0-action-name="Save Settings">Save</button>`;
+
+      expect(resolveActionName(dom.getElementById("btn")!)).toEqual({
+        name: "Save Settings",
+        nameSource: "custom_attribute",
+      });
+    });
+
+    it("applies the configured scrubber, so no interaction type can bypass it", () => {
+      vars.interactionInstrumentation = {
+        ...defaultInteractionSettings,
+        actionNameScrubber: (name) => name.replace(/\S+@\S+/, "[email]"),
+      };
+      dom.body.innerHTML = `<button id="btn">Delete jane@acme.com</button>`;
+
+      expect(resolveActionName(dom.getElementById("btn")!)).toEqual({
+        name: "Delete [email]",
+        nameSource: "text_content",
+      });
     });
   });
 });

--- a/src/instrumentations/interactions/action-name_test.ts
+++ b/src/instrumentations/interactions/action-name_test.ts
@@ -353,6 +353,45 @@ describe("deriveActionName", () => {
       });
     });
 
+    it("does not walk past a FORM whose tagName property is clobbered", () => {
+      // In a real browser `<input name="tagName">` shadows `form.tagName` into an
+      // element, so a naive `BOUNDARY_TAGS.has(form.tagName)` is silently false and
+      // the walk escapes the boundary it exists to enforce. jsdom does not
+      // implement the shadowing, so it is installed by hand -- see utils/dom.
+      dom.body.innerHTML = `
+        <div data-dash0-action-name="Outer Name">
+          <form>
+            <input name="tagName" />
+            <span id="span"></span>
+          </form>
+        </div>`;
+      const form = dom.querySelector("form")!;
+      Object.defineProperty(form, "tagName", { value: form.querySelector("input"), configurable: true });
+
+      expect(deriveActionName(dom.getElementById("span")!, attributeName)).toEqual({
+        name: "",
+        nameSource: "blank",
+      });
+    });
+
+    it("still reads attributes off a FORM whose getAttribute method is clobbered", () => {
+      // `<input name="getAttribute">` shadows the method itself, so calling
+      // `form.getAttribute(...)` throws -- and the throw is swallowed by the
+      // handler's try/catch, silently dropping the whole interaction.
+      dom.body.innerHTML = `
+        <form data-dash0-action-name="Checkout Form">
+          <input name="getAttribute" />
+          <span id="span"></span>
+        </form>`;
+      const form = dom.querySelector("form")!;
+      Object.defineProperty(form, "getAttribute", { value: form.querySelector("input"), configurable: true });
+
+      expect(deriveActionName(dom.getElementById("span")!, attributeName)).toEqual({
+        name: "Checkout Form",
+        nameSource: "custom_attribute",
+      });
+    });
+
     it("caps the ancestor walk at 10 levels", () => {
       // Build 12 nested divs; only the outermost (12 levels up) carries the attribute,
       // which exceeds the 10-ancestor cap and must not be found.

--- a/src/instrumentations/interactions/active-interaction.ts
+++ b/src/instrumentations/interactions/active-interaction.ts
@@ -1,0 +1,53 @@
+import { generateUniqueId, WEB_EVENT_ID_BYTES } from "../../utils";
+
+/**
+ * The most recent user interaction, kept around briefly so that HTTP requests
+ * fired in reaction to it (event handlers, framework change detection,
+ * microtask-deferred XHR/fetch calls) can be attributed back to the click that
+ * caused them — the same causality RUM products expose as "user actions".
+ *
+ * The click instrumentation registers interactions from a window-level
+ * capture-phase listener, which is guaranteed to run before the application's
+ * own handlers. Any span started while the interaction is active gets stamped
+ * with `user_interaction.id` (and `.name` when one was derived), and the
+ * `browser.interaction` event carries the same id, so the two sides can be
+ * joined downstream.
+ */
+export type ActiveInteraction = {
+  id: string;
+  /** The derived action name; empty string when the click had no derivable name. */
+  name: string;
+  epochMillis: number;
+};
+
+/**
+ * How long after a click HTTP requests are still attributed to it. Requests
+ * triggered by a click are typically issued within the same task or a few
+ * microtasks; the window is deliberately small so long-lived polling or timers
+ * are not misattributed to a stale click.
+ */
+const ACTIVE_INTERACTION_WINDOW_MILLIS = 2000;
+
+let active: ActiveInteraction | undefined;
+
+export function registerActiveInteraction(name: string): ActiveInteraction {
+  active = {
+    id: generateUniqueId(WEB_EVENT_ID_BYTES),
+    name,
+    epochMillis: Date.now(),
+  };
+  return active;
+}
+
+export function getActiveInteraction(): ActiveInteraction | undefined {
+  if (!active) return undefined;
+  if (Date.now() - active.epochMillis > ACTIVE_INTERACTION_WINDOW_MILLIS) {
+    active = undefined;
+    return undefined;
+  }
+  return active;
+}
+
+export function clearActiveInteractionForTests(): void {
+  active = undefined;
+}

--- a/src/instrumentations/interactions/active-interaction.ts
+++ b/src/instrumentations/interactions/active-interaction.ts
@@ -30,9 +30,17 @@ const ACTIVE_INTERACTION_WINDOW_MILLIS = 2000;
 
 let active: ActiveInteraction | undefined;
 
-export function registerActiveInteraction(name: string): ActiveInteraction {
+/**
+ * Registers the interaction HTTP requests are attributed to from now on.
+ *
+ * `id` lets a producer that coalesces a burst of DOM events into one telemetry
+ * event (keypress.ts, change.ts) keep the attribution window alive on the
+ * burst's own id. Without it every DOM event in the burst would mint an id
+ * whose log record never gets emitted, leaving spans pointing at nothing.
+ */
+export function registerActiveInteraction(name: string, id?: string): ActiveInteraction {
   active = {
-    id: generateUniqueId(WEB_EVENT_ID_BYTES),
+    id: id ?? generateUniqueId(WEB_EVENT_ID_BYTES),
     name,
     epochMillis: Date.now(),
   };

--- a/src/instrumentations/interactions/active-interaction_test.ts
+++ b/src/instrumentations/interactions/active-interaction_test.ts
@@ -1,0 +1,58 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { clearActiveInteractionForTests, getActiveInteraction, registerActiveInteraction } from "./active-interaction";
+
+describe("active interaction tracking", () => {
+  afterEach(() => {
+    clearActiveInteractionForTests();
+    vi.restoreAllMocks();
+  });
+
+  it("returns the registered interaction within the attribution window", () => {
+    const registered = registerActiveInteraction("Save Part");
+
+    const active = getActiveInteraction();
+    expect(active).toBeDefined();
+    expect(active!.id).toBe(registered.id);
+    expect(active!.name).toBe("Save Part");
+    expect(active!.id).toMatch(/^[0-9a-f]{16}$/);
+  });
+
+  it("expires the interaction after the attribution window", () => {
+    const now = vi.spyOn(Date, "now");
+
+    now.mockReturnValue(100_000);
+    registerActiveInteraction("Save Part");
+
+    now.mockReturnValue(101_999);
+    expect(getActiveInteraction()).toBeDefined();
+
+    now.mockReturnValue(102_001); // > 2000ms after registration
+    expect(getActiveInteraction()).toBeUndefined();
+
+    // and stays gone even if time goes on
+    now.mockReturnValue(103_000);
+    expect(getActiveInteraction()).toBeUndefined();
+  });
+
+  it("a new click replaces the previous interaction", () => {
+    const first = registerActiveInteraction("First");
+    const second = registerActiveInteraction("Second");
+
+    expect(second.id).not.toBe(first.id);
+    expect(getActiveInteraction()!.id).toBe(second.id);
+    expect(getActiveInteraction()!.name).toBe("Second");
+  });
+
+  it("keeps a blank name for unnamed interactions (id still joins the event to its requests)", () => {
+    registerActiveInteraction("");
+
+    const active = getActiveInteraction();
+    expect(active).toBeDefined();
+    expect(active!.name).toBe("");
+    expect(active!.id).toMatch(/^[0-9a-f]{16}$/);
+  });
+
+  it("returns undefined when no interaction was ever registered", () => {
+    expect(getActiveInteraction()).toBeUndefined();
+  });
+});

--- a/src/instrumentations/interactions/change.ts
+++ b/src/instrumentations/interactions/change.ts
@@ -1,0 +1,101 @@
+import { win } from "../../utils";
+import { debug } from "../../utils/debug";
+import { addAttribute } from "../../utils/otel";
+import { INTERACTION_SELECTED_COUNT, INTERACTION_VALUE_LENGTH } from "../../semantic-conventions";
+import { KeyValue } from "../../types/otlp";
+import { vars } from "../../vars";
+import { deriveActionName } from "./action-name";
+import { registerActiveInteraction } from "./active-interaction";
+import { emitInteractionEvent, pagePath } from "./emit";
+
+/**
+ * Form-change capture, privacy-first: the VALUE of a field is never read.
+ * What is emitted, per control kind:
+ *   - text-like inputs / textarea: the value's LENGTH only
+ *     ("Change "Email" to 17 characters")
+ *   - select: the number of selected options only
+ *     ("Change "Country" to 1 selected")
+ *   - checkbox / radio: the fact that it was toggled, nothing else
+ *   - password inputs: not even the length (length is itself a weak secret)
+ *   - file inputs: the fact that files were chosen; never a filename
+ * Field names come from deriveActionName, which for form controls only uses
+ * naming attributes (aria-label, placeholder, the custom attribute), never
+ * user-entered content.
+ */
+const CHANGE_TAGS = new Set(["INPUT", "SELECT", "TEXTAREA"]);
+const NO_LENGTH_INPUT_TYPES = new Set(["password", "hidden"]);
+const TOGGLE_INPUT_TYPES = new Set(["checkbox", "radio"]);
+
+let listenerAttached = false;
+
+function onWindowChange(event: Event) {
+  if (!event.isTrusted) return;
+  handleChange(event);
+}
+
+export function startChangeInstrumentation() {
+  if (listenerAttached) return;
+  if (!win) return;
+
+  win.addEventListener("change", onWindowChange, { capture: true });
+  listenerAttached = true;
+}
+
+export function stopChangeInstrumentationForTests() {
+  if (!listenerAttached || !win) return;
+  win.removeEventListener("change", onWindowChange, { capture: true } as EventListenerOptions);
+  listenerAttached = false;
+}
+
+/**
+ * Exported for tests (bypasses the isTrusted gate, same pattern as
+ * click.ts/handleClick).
+ */
+export function handleChange(event: Event): void {
+  try {
+    const target = event.target;
+    if (!target || (target as Node).nodeType !== 1) return;
+    const element = target as Element;
+    if (!CHANGE_TAGS.has(element.tagName)) return;
+
+    const { name, nameSource } = deriveActionName(element, vars.interactionInstrumentation.actionNameAttribute!);
+    const tag = element.tagName.toLowerCase();
+    const label = name ? `"${name}"` : tag;
+
+    // A change often triggers a request (dependent selects, autosave), so
+    // register it for HTTP span attribution just like a click.
+    const interaction = registerActiveInteraction(name);
+
+    const extraAttributes: KeyValue[] = [];
+    let title: string;
+
+    if (element.tagName === "SELECT") {
+      const selectedCount = (element as HTMLSelectElement).selectedOptions?.length ?? 0;
+      addAttribute(extraAttributes, INTERACTION_SELECTED_COUNT, selectedCount);
+      title = `Change ${label} to ${selectedCount} selected on ${pagePath()}`;
+    } else if (element.tagName === "INPUT" && TOGGLE_INPUT_TYPES.has((element as HTMLInputElement).type)) {
+      title = `Toggle ${label} on ${pagePath()}`;
+    } else if (element.tagName === "INPUT" && (element as HTMLInputElement).type === "file") {
+      title = `Change ${label} on ${pagePath()}`;
+    } else if (element.tagName === "INPUT" && NO_LENGTH_INPUT_TYPES.has((element as HTMLInputElement).type)) {
+      // password/hidden: even the length stays private
+      title = `Change ${label} on ${pagePath()}`;
+    } else {
+      const valueLength = (element as HTMLInputElement | HTMLTextAreaElement).value?.length ?? 0;
+      addAttribute(extraAttributes, INTERACTION_VALUE_LENGTH, valueLength);
+      title = `Change ${label} to ${valueLength} characters on ${pagePath()}`;
+    }
+
+    emitInteractionEvent({
+      type: "change",
+      title,
+      id: interaction.id,
+      name,
+      nameSource,
+      element,
+      extraAttributes,
+    });
+  } catch (err) {
+    debug("Dash0 interaction instrumentation failed to process a change event.", err);
+  }
+}

--- a/src/instrumentations/interactions/change.ts
+++ b/src/instrumentations/interactions/change.ts
@@ -1,9 +1,11 @@
-import { win } from "../../utils";
+import { nowNanos, win } from "../../utils";
 import { debug } from "../../utils/debug";
+import { onLastChance } from "../../utils/on-last-chance";
+import { setTimeout, clearTimeout } from "../../utils/timers";
 import { addAttribute } from "../../utils/otel";
 import { INTERACTION_SELECTED_COUNT, INTERACTION_VALUE_LENGTH } from "../../semantic-conventions";
 import { KeyValue } from "../../types/otlp";
-import { resolveActionName } from "./action-name";
+import { ActionNameSource, resolveActionName } from "./action-name";
 import { registerActiveInteraction } from "./active-interaction";
 import { emitInteractionEvent } from "./emit";
 
@@ -26,7 +28,35 @@ const CHANGE_TAGS = new Set(["INPUT", "SELECT", "TEXTAREA"]);
 const NO_LENGTH_INPUT_TYPES = new Set(["password", "hidden"]);
 const TOGGLE_INPUT_TYPES = new Set(["checkbox", "radio"]);
 
+/**
+ * Successive changes to the SAME control collapse into one telemetry event
+ * describing its latest state, emitted this long after the last change.
+ * Drag-driven controls (`input[type=range]` in browsers that fire `change`
+ * during the drag) and dependent-select cascades are otherwise the chattiest
+ * producers in this instrumentation.
+ *
+ * A change to a *different* control finalizes the pending one immediately, so
+ * emission order still follows the order the fields were edited in.
+ */
+export const CHANGE_SETTLE_MILLIS = 300;
+
+/** A run of changes to one control, pending emission. */
+type PendingChange = {
+  element: Element;
+  /** Correlation id, shared by every span attributed during the run. */
+  id: string;
+  name: string;
+  nameSource: ActionNameSource;
+  title: string;
+  extraAttributes: KeyValue[];
+  /** When the run started, so a delayed emission is not timestamped late. */
+  timeUnixNano: string;
+  settleTimeout: ReturnType<typeof setTimeout> | null;
+};
+
 let listenerAttached = false;
+let unloadHookRegistered = false;
+let pending: PendingChange | undefined;
 
 function onWindowChange(event: Event) {
   if (!event.isTrusted) return;
@@ -39,9 +69,26 @@ export function startChangeInstrumentation() {
 
   win.addEventListener("change", onWindowChange, { capture: true });
   listenerAttached = true;
+
+  // A coalesced change is otherwise only emitted once its settle timer fires, so
+  // committing a field and immediately navigating away would drop it -- and a
+  // change followed straight by a navigation (submit, dependent route change) is
+  // one of the more interesting ones. See the long form of this reasoning --
+  // including why the log still reaches the wire despite the transport
+  // registering its own onLastChance first -- in scroll.ts.
+  if (!unloadHookRegistered) {
+    unloadHookRegistered = true;
+    onLastChance(flushPending);
+  }
 }
 
 export function stopChangeInstrumentationForTests() {
+  // Before the guard below: a pending change and its settle timer must not leak
+  // into the next test case, even one that never attached a listener.
+  if (pending?.settleTimeout != null) clearTimeout(pending.settleTimeout);
+  pending = undefined;
+  // unloadHookRegistered is deliberately NOT reset: onLastChance listeners
+  // cannot be removed, so clearing the flag would only register a second set.
   if (!listenerAttached || !win) return;
   win.removeEventListener("change", onWindowChange, { capture: true } as EventListenerOptions);
   listenerAttached = false;
@@ -63,8 +110,11 @@ export function handleChange(event: Event): void {
     const label = name ? `"${name}"` : tag;
 
     // A change often triggers a request (dependent selects, autosave), so
-    // register it for HTTP span attribution just like a click.
-    const interaction = registerActiveInteraction(name);
+    // register it for HTTP span attribution just like a click. Re-registering on
+    // the pending run's own id keeps the attribution window alive across a run of
+    // changes without minting ids no log record will ever carry.
+    const extendingRun = pending?.element === element ? pending : undefined;
+    const interaction = registerActiveInteraction(name, extendingRun?.id);
 
     const extraAttributes: KeyValue[] = [];
     // Titles carry no page path -- emit appends the scrubbed one.
@@ -87,16 +137,67 @@ export function handleChange(event: Event): void {
       title = `Change ${label} to ${valueLength} characters`;
     }
 
-    emitInteractionEvent({
-      type: "change",
-      title,
-      id: interaction.id,
-      name,
-      nameSource,
-      element,
-      extraAttributes,
-    });
+    // Everything above is derived HERE, at event time, and only the derived
+    // values are held for emission: re-reading value/selectedOptions once the
+    // settle timer fires would report a field that has since been reset or
+    // detached (modal closed, route change) -- the same trap scroll.ts documents
+    // for its position reads.
+    if (extendingRun) {
+      extendingRun.name = name;
+      extendingRun.nameSource = nameSource;
+      extendingRun.title = title;
+      extendingRun.extraAttributes = extraAttributes;
+    } else {
+      flushPending(); // a change to a different control ends the previous run
+      pending = {
+        element,
+        id: interaction.id,
+        name,
+        nameSource,
+        title,
+        extraAttributes,
+        timeUnixNano: nowNanos(),
+        settleTimeout: null,
+      };
+    }
+
+    // Either branch above leaves `pending` as the pending run.
+    const run = pending!;
+    if (run.settleTimeout != null) clearTimeout(run.settleTimeout);
+    run.settleTimeout = setTimeout(() => finalizePending(), CHANGE_SETTLE_MILLIS);
   } catch (err) {
     debug("Dash0 interaction instrumentation failed to process a change event.", err);
   }
+}
+
+function finalizePending(): void {
+  const finished = pending;
+  pending = undefined;
+  if (!finished) return;
+
+  try {
+    emitInteractionEvent({
+      type: "change",
+      title: finished.title,
+      id: finished.id,
+      name: finished.name,
+      nameSource: finished.nameSource,
+      element: finished.element,
+      extraAttributes: finished.extraAttributes,
+      timeUnixNano: finished.timeUnixNano,
+    });
+  } catch (err) {
+    debug("Dash0 interaction instrumentation failed to finalize a change event.", err);
+  }
+}
+
+/** Emits the pending change now, without waiting for the settle timer. */
+function flushPending(): void {
+  if (pending?.settleTimeout != null) clearTimeout(pending.settleTimeout);
+  finalizePending();
+}
+
+/** Test-only: force-emit the pending change without waiting for the settle timer. */
+export function flushPendingChangeForTests(): void {
+  flushPending();
 }

--- a/src/instrumentations/interactions/change.ts
+++ b/src/instrumentations/interactions/change.ts
@@ -5,7 +5,7 @@ import { INTERACTION_SELECTED_COUNT, INTERACTION_VALUE_LENGTH } from "../../sema
 import { KeyValue } from "../../types/otlp";
 import { resolveActionName } from "./action-name";
 import { registerActiveInteraction } from "./active-interaction";
-import { emitInteractionEvent, pagePath } from "./emit";
+import { emitInteractionEvent } from "./emit";
 
 /**
  * Form-change capture, privacy-first: the VALUE of a field is never read.
@@ -67,23 +67,24 @@ export function handleChange(event: Event): void {
     const interaction = registerActiveInteraction(name);
 
     const extraAttributes: KeyValue[] = [];
+    // Titles carry no page path -- emit appends the scrubbed one.
     let title: string;
 
     if (element.tagName === "SELECT") {
       const selectedCount = (element as HTMLSelectElement).selectedOptions?.length ?? 0;
       addAttribute(extraAttributes, INTERACTION_SELECTED_COUNT, selectedCount);
-      title = `Change ${label} to ${selectedCount} selected on ${pagePath()}`;
+      title = `Change ${label} to ${selectedCount} selected`;
     } else if (element.tagName === "INPUT" && TOGGLE_INPUT_TYPES.has((element as HTMLInputElement).type)) {
-      title = `Toggle ${label} on ${pagePath()}`;
+      title = `Toggle ${label}`;
     } else if (element.tagName === "INPUT" && (element as HTMLInputElement).type === "file") {
-      title = `Change ${label} on ${pagePath()}`;
+      title = `Change ${label}`;
     } else if (element.tagName === "INPUT" && NO_LENGTH_INPUT_TYPES.has((element as HTMLInputElement).type)) {
       // password/hidden: even the length stays private
-      title = `Change ${label} on ${pagePath()}`;
+      title = `Change ${label}`;
     } else {
       const valueLength = (element as HTMLInputElement | HTMLTextAreaElement).value?.length ?? 0;
       addAttribute(extraAttributes, INTERACTION_VALUE_LENGTH, valueLength);
-      title = `Change ${label} to ${valueLength} characters on ${pagePath()}`;
+      title = `Change ${label} to ${valueLength} characters`;
     }
 
     emitInteractionEvent({

--- a/src/instrumentations/interactions/change.ts
+++ b/src/instrumentations/interactions/change.ts
@@ -3,8 +3,7 @@ import { debug } from "../../utils/debug";
 import { addAttribute } from "../../utils/otel";
 import { INTERACTION_SELECTED_COUNT, INTERACTION_VALUE_LENGTH } from "../../semantic-conventions";
 import { KeyValue } from "../../types/otlp";
-import { vars } from "../../vars";
-import { deriveActionName } from "./action-name";
+import { resolveActionName } from "./action-name";
 import { registerActiveInteraction } from "./active-interaction";
 import { emitInteractionEvent, pagePath } from "./emit";
 
@@ -18,9 +17,10 @@ import { emitInteractionEvent, pagePath } from "./emit";
  *   - checkbox / radio: the fact that it was toggled, nothing else
  *   - password inputs: not even the length (length is itself a weak secret)
  *   - file inputs: the fact that files were chosen; never a filename
- * Field names come from deriveActionName, which for form controls only uses
- * naming attributes (aria-label, placeholder, the custom attribute), never
- * user-entered content.
+ * Field names come from resolveActionName, which for form controls uses naming
+ * attributes (aria-label, placeholder, the custom attribute) or the enclosing
+ * label's text with the control's own text excluded -- never user-entered
+ * content.
  */
 const CHANGE_TAGS = new Set(["INPUT", "SELECT", "TEXTAREA"]);
 const NO_LENGTH_INPUT_TYPES = new Set(["password", "hidden"]);
@@ -58,7 +58,7 @@ export function handleChange(event: Event): void {
     const element = target as Element;
     if (!CHANGE_TAGS.has(element.tagName)) return;
 
-    const { name, nameSource } = deriveActionName(element, vars.interactionInstrumentation.actionNameAttribute!);
+    const { name, nameSource } = resolveActionName(element);
     const tag = element.tagName.toLowerCase();
     const label = name ? `"${name}"` : tag;
 

--- a/src/instrumentations/interactions/change_test.ts
+++ b/src/instrumentations/interactions/change_test.ts
@@ -1,0 +1,136 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { vars } from "../../vars";
+import { sendLog } from "../../transport";
+import { doc } from "../../utils/globals";
+import {
+  INTERACTION_NAME,
+  INTERACTION_NAME_SOURCE,
+  INTERACTION_SELECTED_COUNT,
+  INTERACTION_TYPE,
+  INTERACTION_VALUE_LENGTH,
+} from "../../semantic-conventions";
+import type { LogRecord } from "../../types/otlp";
+
+vi.mock("../../transport", () => ({
+  sendLog: vi.fn(),
+}));
+
+import { handleChange } from "./change";
+import { clearActiveInteractionForTests, getActiveInteraction } from "./active-interaction";
+
+const dom = doc!;
+
+function changeEventFor(el: Element): Event {
+  const event = new Event("change", { bubbles: true });
+  Object.defineProperty(event, "target", { value: el });
+  return event;
+}
+
+function lastLog(): LogRecord {
+  const calls = (sendLog as ReturnType<typeof vi.fn>).mock.calls;
+  expect(calls.length).toBeGreaterThan(0);
+  return calls[calls.length - 1]![0] as LogRecord;
+}
+
+function attr(log: LogRecord, key: string) {
+  return (log.attributes as { key: string; value: Record<string, unknown> }[]).find((kv) => kv.key === key)?.value;
+}
+
+describe("change instrumentation", () => {
+  beforeEach(() => {
+    dom.body.innerHTML = "";
+    vars.interactionInstrumentation = { enabled: true, actionNameAttribute: "data-dash0-action-name" };
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    clearActiveInteractionForTests();
+    vi.clearAllMocks();
+  });
+
+  it("reports only the value LENGTH for text inputs, never the value", () => {
+    dom.body.innerHTML = `<input id="email" type="text" aria-label="Email" />`;
+    const input = dom.getElementById("email") as HTMLInputElement;
+    input.value = "user@example.com"; // 16 characters of user data
+
+    handleChange(changeEventFor(input));
+
+    const log = lastLog();
+    expect(log.body).toEqual({ stringValue: 'Change "Email" to 16 characters on /' });
+    expect(attr(log, INTERACTION_VALUE_LENGTH)).toEqual({ doubleValue: 16 });
+    expect(attr(log, INTERACTION_TYPE)).toEqual({ stringValue: "change" });
+    // the raw value must not appear anywhere in the record
+    expect(JSON.stringify(log)).not.toContain("user@example.com");
+  });
+
+  it("reports neither value nor length for password inputs", () => {
+    dom.body.innerHTML = `<input id="pw" type="password" aria-label="Password" />`;
+    const input = dom.getElementById("pw") as HTMLInputElement;
+    input.value = "hunter2";
+
+    handleChange(changeEventFor(input));
+
+    const log = lastLog();
+    expect(log.body).toEqual({ stringValue: 'Change "Password" on /' });
+    expect(attr(log, INTERACTION_VALUE_LENGTH)).toBeUndefined();
+    expect(JSON.stringify(log)).not.toContain("hunter2");
+  });
+
+  it("reports the selected COUNT for selects, never the chosen option", () => {
+    dom.body.innerHTML = `
+      <select id="country" aria-label="Country">
+        <option value="secret-country" selected>Secret Country</option>
+        <option value="other">Other</option>
+      </select>`;
+    const select = dom.getElementById("country")!;
+
+    handleChange(changeEventFor(select));
+
+    const log = lastLog();
+    expect(log.body).toEqual({ stringValue: 'Change "Country" to 1 selected on /' });
+    expect(attr(log, INTERACTION_SELECTED_COUNT)).toEqual({ doubleValue: 1 });
+    expect(JSON.stringify(log)).not.toContain("Secret Country");
+    expect(JSON.stringify(log)).not.toContain("secret-country");
+  });
+
+  it("reports checkbox changes as a toggle with no value", () => {
+    dom.body.innerHTML = `<input id="sub" type="checkbox" aria-label="Subscribe" />`;
+    const box = dom.getElementById("sub") as HTMLInputElement;
+    box.checked = true;
+
+    handleChange(changeEventFor(box));
+
+    const log = lastLog();
+    expect(log.body).toEqual({ stringValue: 'Toggle "Subscribe" on /' });
+    expect(attr(log, INTERACTION_VALUE_LENGTH)).toBeUndefined();
+  });
+
+  it("ignores change events from non-form elements", () => {
+    dom.body.innerHTML = `<div id="d"></div>`;
+    handleChange(changeEventFor(dom.getElementById("d")!));
+
+    expect(sendLog).not.toHaveBeenCalled();
+  });
+
+  it("registers the change as the active interaction for span attribution", () => {
+    dom.body.innerHTML = `<select id="c" aria-label="Country"><option selected>A</option></select>`;
+    handleChange(changeEventFor(dom.getElementById("c")!));
+
+    const active = getActiveInteraction();
+    expect(active).toBeDefined();
+    expect(active!.name).toBe("Country");
+  });
+
+  it("names the field via naming attributes and records the source", () => {
+    dom.body.innerHTML = `<textarea id="notes" placeholder="Notes"></textarea>`;
+    const ta = dom.getElementById("notes") as HTMLTextAreaElement;
+    ta.value = "abc";
+
+    handleChange(changeEventFor(ta));
+
+    const log = lastLog();
+    expect(attr(log, INTERACTION_NAME)).toEqual({ stringValue: "Notes" });
+    expect(attr(log, INTERACTION_NAME_SOURCE)).toEqual({ stringValue: "standard_attribute" });
+    expect(attr(log, INTERACTION_VALUE_LENGTH)).toEqual({ doubleValue: 3 });
+  });
+});

--- a/src/instrumentations/interactions/change_test.ts
+++ b/src/instrumentations/interactions/change_test.ts
@@ -2,7 +2,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { vars } from "../../vars";
 import { sendLog } from "../../transport";
 import { doc, win } from "../../utils/globals";
+import { nowNanos } from "../../utils";
 import {
+  INTERACTION_ID,
   INTERACTION_NAME,
   INTERACTION_NAME_SOURCE,
   INTERACTION_SELECTED_COUNT,
@@ -15,7 +17,13 @@ vi.mock("../../transport", () => ({
   sendLog: vi.fn(),
 }));
 
-import { handleChange, startChangeInstrumentation, stopChangeInstrumentationForTests } from "./change";
+import {
+  CHANGE_SETTLE_MILLIS,
+  flushPendingChangeForTests,
+  handleChange,
+  startChangeInstrumentation,
+  stopChangeInstrumentationForTests,
+} from "./change";
 import { clearActiveInteractionForTests, getActiveInteraction } from "./active-interaction";
 
 // Vitest runs these tests in jsdom, so the SSR-safe doc/win are always defined.
@@ -26,6 +34,16 @@ function changeEventFor(el: Element): Event {
   const event = new Event("change", { bubbles: true });
   Object.defineProperty(event, "target", { value: el });
   return event;
+}
+
+/**
+ * Commits a change and closes the coalescing window, which is what the settle
+ * timer does 300 ms later. Tests about the coalescing itself call handleChange
+ * directly instead.
+ */
+function change(el: Element): void {
+  handleChange(changeEventFor(el));
+  flushPendingChangeForTests();
 }
 
 function lastLog(): LogRecord {
@@ -59,7 +77,7 @@ describe("change instrumentation", () => {
     const input = dom.getElementById("email") as HTMLInputElement;
     input.value = "user@example.com"; // 16 characters of user data
 
-    handleChange(changeEventFor(input));
+    change(input);
 
     const log = lastLog();
     expect(log.body).toEqual({ stringValue: 'Change "Email" to 16 characters on /' });
@@ -74,7 +92,7 @@ describe("change instrumentation", () => {
     const input = dom.getElementById("pw") as HTMLInputElement;
     input.value = "hunter2";
 
-    handleChange(changeEventFor(input));
+    change(input);
 
     const log = lastLog();
     expect(log.body).toEqual({ stringValue: 'Change "Password" on /' });
@@ -90,7 +108,7 @@ describe("change instrumentation", () => {
       </select>`;
     const select = dom.getElementById("country")!;
 
-    handleChange(changeEventFor(select));
+    change(select);
 
     const log = lastLog();
     expect(log.body).toEqual({ stringValue: 'Change "Country" to 1 selected on /' });
@@ -104,7 +122,7 @@ describe("change instrumentation", () => {
     const box = dom.getElementById("sub") as HTMLInputElement;
     box.checked = true;
 
-    handleChange(changeEventFor(box));
+    change(box);
 
     const log = lastLog();
     expect(log.body).toEqual({ stringValue: 'Toggle "Subscribe" on /' });
@@ -113,14 +131,14 @@ describe("change instrumentation", () => {
 
   it("ignores change events from non-form elements", () => {
     dom.body.innerHTML = `<div id="d"></div>`;
-    handleChange(changeEventFor(dom.getElementById("d")!));
+    change(dom.getElementById("d")!);
 
     expect(sendLog).not.toHaveBeenCalled();
   });
 
   it("registers the change as the active interaction for span attribution", () => {
     dom.body.innerHTML = `<select id="c" aria-label="Country"><option selected>A</option></select>`;
-    handleChange(changeEventFor(dom.getElementById("c")!));
+    change(dom.getElementById("c")!);
 
     const active = getActiveInteraction();
     expect(active).toBeDefined();
@@ -132,7 +150,7 @@ describe("change instrumentation", () => {
     const ta = dom.getElementById("notes") as HTMLTextAreaElement;
     ta.value = "abc";
 
-    handleChange(changeEventFor(ta));
+    change(ta);
 
     const log = lastLog();
     expect(attr(log, INTERACTION_NAME)).toEqual({ stringValue: "Notes" });
@@ -151,18 +169,135 @@ describe("change instrumentation", () => {
       },
     });
 
-    expect(() => handleChange(changeEventFor(input))).not.toThrow();
+    expect(() => change(input)).not.toThrow();
 
     expect(sendLog).not.toHaveBeenCalled();
   });
 
+  describe("coalescing", () => {
+    function textInput(id: string, label: string): HTMLInputElement {
+      dom.body.insertAdjacentHTML("beforeend", `<input id="${id}" type="text" aria-label="${label}" />`);
+      return dom.getElementById(id) as HTMLInputElement;
+    }
+
+    it("collapses successive changes to one control into a single event describing its latest state", () => {
+      const input = textInput("email", "Email");
+
+      for (const value of ["a", "ab", "abc"]) {
+        input.value = value;
+        handleChange(changeEventFor(input));
+      }
+      expect(sendLog).not.toHaveBeenCalled(); // settle timer still pending
+      flushPendingChangeForTests();
+
+      expect(sendLog).toHaveBeenCalledOnce();
+      expect(attr(lastLog(), INTERACTION_VALUE_LENGTH)).toEqual({ doubleValue: 3 });
+    });
+
+    it("emits the pending change immediately when a different control changes, preserving edit order", () => {
+      const email = textInput("email", "Email");
+      const notes = textInput("notes", "Notes");
+
+      email.value = "user@example.com";
+      handleChange(changeEventFor(email));
+      notes.value = "hi";
+      handleChange(changeEventFor(notes));
+
+      // The second control's change flushed the first one rather than replacing it.
+      expect(sendLog).toHaveBeenCalledOnce();
+      expect(lastLog().body).toEqual({ stringValue: 'Change "Email" to 16 characters on /' });
+
+      flushPendingChangeForTests();
+      expect(sendLog).toHaveBeenCalledTimes(2);
+      expect(lastLog().body).toEqual({ stringValue: 'Change "Notes" to 2 characters on /' });
+    });
+
+    it("keeps one correlation id across a coalesced run, so attributed spans join to the emitted event", () => {
+      const input = textInput("email", "Email");
+
+      input.value = "a";
+      handleChange(changeEventFor(input));
+      const firstId = getActiveInteraction()!.id;
+
+      input.value = "ab";
+      handleChange(changeEventFor(input));
+      const secondId = getActiveInteraction()!.id;
+
+      // Minting a fresh id per change would leave the spans attributed to the
+      // first one pointing at a log record that never gets emitted.
+      expect(secondId).toBe(firstId);
+
+      flushPendingChangeForTests();
+      expect(attr(lastLog(), INTERACTION_ID)).toEqual({ stringValue: firstId });
+    });
+
+    it("reports the value length read at event time, not at emission time", () => {
+      const input = textInput("email", "Email");
+      input.value = "user@example.com";
+
+      handleChange(changeEventFor(input));
+      // Whatever happens to the field afterwards -- reset, detached modal, route
+      // change -- must not change what the pending event reports.
+      input.value = "";
+
+      flushPendingChangeForTests();
+      expect(attr(lastLog(), INTERACTION_VALUE_LENGTH)).toEqual({ doubleValue: 16 });
+    });
+
+    /**
+     * The only test here that drives the production settle timer instead of
+     * calling flushPendingChangeForTests(); without it, deleting the setTimeout
+     * in handleChange would keep every other test in this file green.
+     *
+     * It really does wait: utils/timers captures win.setTimeout at module load,
+     * so vi.useFakeTimers() cannot intercept the timer this code schedules.
+     */
+    it("emits after the settle timer, with no test-only flush", async () => {
+      const input = textInput("email", "Email");
+      input.value = "abc";
+
+      handleChange(changeEventFor(input));
+      expect(sendLog).not.toHaveBeenCalled();
+
+      await new Promise((resolve) => globalThis.setTimeout(resolve, CHANGE_SETTLE_MILLIS + 50));
+
+      expect(sendLog).toHaveBeenCalledOnce();
+      expect(attr(lastLog(), INTERACTION_VALUE_LENGTH)).toEqual({ doubleValue: 3 });
+    });
+
+    it("timestamps the event when the run started, not when the settle timer fired", async () => {
+      const input = textInput("email", "Email");
+      input.value = "abc";
+
+      handleChange(changeEventFor(input));
+      await new Promise((resolve) => globalThis.setTimeout(resolve, CHANGE_SETTLE_MILLIS + 50));
+
+      // A coalesced change and a coalesced key press settle on independent
+      // timers, so only an event-time stamp keeps them orderable against each
+      // other downstream.
+      const elapsedNanos = BigInt(nowNanos()) - BigInt(lastLog().timeUnixNano!);
+      expect(elapsedNanos).toBeGreaterThan(BigInt(CHANGE_SETTLE_MILLIS) * 1_000_000n);
+    });
+  });
+
   describe("startChangeInstrumentation (real capture-phase listener + isTrusted gate)", () => {
+    /**
+     * Filtered by event type rather than asserting a total call count: the
+     * unload hook also registers window-level pagehide/beforeunload listeners,
+     * and it registers only on the *first* start* in this file, so any count
+     * over all registrations would depend on test order. Same shape as
+     * scroll_test.ts.
+     */
+    function changeRegistrations(addSpy: ReturnType<typeof vi.spyOn>) {
+      return addSpy.mock.calls.filter((call) => call[0] === "change");
+    }
+
     it("registers exactly one window-level capture-phase change listener", () => {
       const addSpy = vi.spyOn(globalWindow, "addEventListener");
 
       startChangeInstrumentation();
 
-      expect(addSpy).toHaveBeenCalledOnce();
+      expect(changeRegistrations(addSpy)).toHaveLength(1);
       expect(addSpy).toHaveBeenCalledWith("change", expect.any(Function), { capture: true });
 
       addSpy.mockRestore();
@@ -174,7 +309,7 @@ describe("change instrumentation", () => {
       startChangeInstrumentation();
       startChangeInstrumentation();
 
-      expect(addSpy).toHaveBeenCalledOnce();
+      expect(changeRegistrations(addSpy)).toHaveLength(1);
       addSpy.mockRestore();
     });
 
@@ -202,6 +337,7 @@ describe("change instrumentation", () => {
 
       const listener = addSpy.mock.calls.find((call) => call[0] === "change")![1] as EventListener;
       listener({ isTrusted: true, target: input } as unknown as Event);
+      flushPendingChangeForTests();
 
       addSpy.mockRestore();
       expect(sendLog).toHaveBeenCalledOnce();

--- a/src/instrumentations/interactions/change_test.ts
+++ b/src/instrumentations/interactions/change_test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { vars } from "../../vars";
 import { sendLog } from "../../transport";
-import { doc } from "../../utils/globals";
+import { doc, win } from "../../utils/globals";
 import {
   INTERACTION_NAME,
   INTERACTION_NAME_SOURCE,
@@ -15,10 +15,12 @@ vi.mock("../../transport", () => ({
   sendLog: vi.fn(),
 }));
 
-import { handleChange } from "./change";
+import { handleChange, startChangeInstrumentation, stopChangeInstrumentationForTests } from "./change";
 import { clearActiveInteractionForTests, getActiveInteraction } from "./active-interaction";
 
+// Vitest runs these tests in jsdom, so the SSR-safe doc/win are always defined.
 const dom = doc!;
+const globalWindow = win!;
 
 function changeEventFor(el: Element): Event {
   const event = new Event("change", { bubbles: true });
@@ -44,7 +46,11 @@ describe("change instrumentation", () => {
   });
 
   afterEach(() => {
+    stopChangeInstrumentationForTests();
     clearActiveInteractionForTests();
+    // Restores any addEventListener spy even when an assertion failed before the
+    // test reached its own mockRestore, so the spy cannot leak into the next case.
+    vi.restoreAllMocks();
     vi.clearAllMocks();
   });
 
@@ -132,5 +138,74 @@ describe("change instrumentation", () => {
     expect(attr(log, INTERACTION_NAME)).toEqual({ stringValue: "Notes" });
     expect(attr(log, INTERACTION_NAME_SOURCE)).toEqual({ stringValue: "standard_attribute" });
     expect(attr(log, INTERACTION_VALUE_LENGTH)).toEqual({ doubleValue: 3 });
+  });
+
+  it("swallows errors from a throwing scenario and does not propagate", () => {
+    dom.body.innerHTML = `<input id="email" type="text" aria-label="Email" />`;
+    const input = dom.getElementById("email")!;
+    // The length read is the last DOM access in the handler, so a throwing value
+    // getter exercises the catch without short-circuiting anything before it.
+    Object.defineProperty(input, "value", {
+      get() {
+        throw new Error("boom");
+      },
+    });
+
+    expect(() => handleChange(changeEventFor(input))).not.toThrow();
+
+    expect(sendLog).not.toHaveBeenCalled();
+  });
+
+  describe("startChangeInstrumentation (real capture-phase listener + isTrusted gate)", () => {
+    it("registers exactly one window-level capture-phase change listener", () => {
+      const addSpy = vi.spyOn(globalWindow, "addEventListener");
+
+      startChangeInstrumentation();
+
+      expect(addSpy).toHaveBeenCalledOnce();
+      expect(addSpy).toHaveBeenCalledWith("change", expect.any(Function), { capture: true });
+
+      addSpy.mockRestore();
+    });
+
+    it("does not register a second listener if called twice (idempotent start)", () => {
+      const addSpy = vi.spyOn(globalWindow, "addEventListener");
+
+      startChangeInstrumentation();
+      startChangeInstrumentation();
+
+      expect(addSpy).toHaveBeenCalledOnce();
+      addSpy.mockRestore();
+    });
+
+    it("ignores untrusted (synthetic) changes -- jsdom's dispatchEvent always yields isTrusted: false", () => {
+      dom.body.innerHTML = `<input id="email" type="text" aria-label="Email" />`;
+      startChangeInstrumentation();
+
+      const event = new Event("change", { bubbles: true });
+      dom.getElementById("email")!.dispatchEvent(event);
+
+      expect(event.isTrusted).toBe(false);
+      expect(sendLog).not.toHaveBeenCalled();
+    });
+
+    it("processes a change when isTrusted is stubbed true, proving the gate is the only thing blocking synthetic changes", () => {
+      // jsdom defines `isTrusted` as a non-configurable accessor on its Event
+      // prototype, so there is no way to construct a pre-trusted event -- see the
+      // long-form explanation in click_test.ts. Capture the real listener
+      // registered by startChangeInstrumentation and invoke it directly instead.
+      dom.body.innerHTML = `<input id="email" type="text" aria-label="Email" />`;
+      const input = dom.getElementById("email") as HTMLInputElement;
+      input.value = "abc";
+      const addSpy = vi.spyOn(globalWindow, "addEventListener");
+      startChangeInstrumentation();
+
+      const listener = addSpy.mock.calls.find((call) => call[0] === "change")![1] as EventListener;
+      listener({ isTrusted: true, target: input } as unknown as Event);
+
+      addSpy.mockRestore();
+      expect(sendLog).toHaveBeenCalledOnce();
+      expect(attr(lastLog(), INTERACTION_VALUE_LENGTH)).toEqual({ doubleValue: 3 });
+    });
   });
 });

--- a/src/instrumentations/interactions/click.ts
+++ b/src/instrumentations/interactions/click.ts
@@ -106,10 +106,14 @@ export function handleClick(event: Event): void {
  *   The walk never crosses a BODY/HTML boundary -- those document-structure
  *   elements are not meaningful click-target context.
  * Result is capped at MAX_SELECTOR_LENGTH characters.
+ *
+ * The selector is best-effort display telemetry, NOT guaranteed valid CSS for
+ * querySelector: ids/class names are not escaped and truncation may cut
+ * mid-token.
  */
 function buildSelector(element: Element): string {
   if (element.id) {
-    return describeElement(element);
+    return truncateSelector(describeElement(element));
   }
 
   const parts: string[] = [describeElement(element)];
@@ -121,7 +125,10 @@ function buildSelector(element: Element): string {
     if (current.id) break;
   }
 
-  const selector = parts.join(" > ");
+  return truncateSelector(parts.join(" > "));
+}
+
+function truncateSelector(selector: string): string {
   return selector.length > MAX_SELECTOR_LENGTH ? selector.substring(0, MAX_SELECTOR_LENGTH) : selector;
 }
 

--- a/src/instrumentations/interactions/click.ts
+++ b/src/instrumentations/interactions/click.ts
@@ -1,26 +1,9 @@
-import { nowNanos, win } from "../../utils";
+import { win } from "../../utils";
 import { debug } from "../../utils/debug";
-import { sendLog } from "../../transport";
-import {
-  EVENT_NAME,
-  EVENT_NAMES,
-  INTERACTION_NAME,
-  INTERACTION_NAME_SOURCE,
-  INTERACTION_TARGET_ID,
-  INTERACTION_TARGET_SELECTOR,
-  INTERACTION_TARGET_TAG,
-  INTERACTION_TYPE,
-  LOG_SEVERITIES,
-} from "../../semantic-conventions";
-import { addAttribute } from "../../utils/otel";
-import { addCommonAttributes } from "../../attributes";
-import { KeyValue, LogRecord } from "../../types/otlp";
 import { vars } from "../../vars";
 import { deriveActionName } from "./action-name";
-
-const MAX_SELECTOR_LENGTH = 128;
-const MAX_SELECTOR_ANCESTORS = 3;
-const SELECTOR_BOUNDARY_TAGS = new Set(["BODY", "HTML"]);
+import { registerActiveInteraction } from "./active-interaction";
+import { emitInteractionEvent, pagePath } from "./emit";
 
 let listenerAttached = false;
 
@@ -65,78 +48,24 @@ export function handleClick(event: Event): void {
 
     const element = target as Element;
     const { name, nameSource } = deriveActionName(element, vars.interactionInstrumentation.actionNameAttribute!);
-    const selector = buildSelector(element);
+    const tag = element.tagName.toLowerCase();
 
-    const attributes: KeyValue[] = [];
-    addCommonAttributes(attributes);
-    addAttribute(attributes, EVENT_NAME, EVENT_NAMES.INTERACTION);
+    // Register this click as the active interaction BEFORE the application's
+    // own handlers run (we are in the capture phase), so any HTTP request the
+    // click triggers gets stamped with this interaction's id/name.
+    const interaction = registerActiveInteraction(name);
 
-    const bodyValues: KeyValue[] = [];
-    addAttribute(bodyValues, INTERACTION_TYPE, "click");
-    addAttribute(bodyValues, INTERACTION_NAME, name);
-    addAttribute(bodyValues, INTERACTION_NAME_SOURCE, nameSource);
-    addAttribute(bodyValues, INTERACTION_TARGET_SELECTOR, selector);
-    addAttribute(bodyValues, INTERACTION_TARGET_TAG, element.tagName.toLowerCase());
-    if (element.id) {
-      addAttribute(bodyValues, INTERACTION_TARGET_ID, element.id);
-    }
-
-    const log: LogRecord = {
-      timeUnixNano: nowNanos(),
-      attributes,
-      severityNumber: LOG_SEVERITIES.INFO,
-      severityText: "INFO",
-      body: {
-        kvlistValue: { values: bodyValues },
-      },
-    };
-
-    sendLog(log);
+    emitInteractionEvent({
+      type: "click",
+      // Click "Save Part" on /inventory/parts
+      // Click button on /playground          (no derivable name)
+      title: name ? `Click "${name}" on ${pagePath()}` : `Click ${tag} on ${pagePath()}`,
+      id: interaction.id,
+      name,
+      nameSource,
+      element,
+    });
   } catch (err) {
     debug("Dash0 interaction instrumentation failed to process a click event.", err);
   }
-}
-
-/**
- * Builds a compact CSS-like selector describing the click target:
- * - `tag#id` when the target has an id.
- * - `tag.firstClass` when it has classes but no id.
- * - Otherwise, walks up to MAX_SELECTOR_ANCESTORS ancestors (each rendered the
- *   same way) joined with " > ", since there is no id anywhere to anchor on.
- *   The walk never crosses a BODY/HTML boundary -- those document-structure
- *   elements are not meaningful click-target context.
- * Result is capped at MAX_SELECTOR_LENGTH characters.
- *
- * The selector is best-effort display telemetry, NOT guaranteed valid CSS for
- * querySelector: ids/class names are not escaped and truncation may cut
- * mid-token.
- */
-function buildSelector(element: Element): string {
-  if (element.id) {
-    return truncateSelector(describeElement(element));
-  }
-
-  const parts: string[] = [describeElement(element)];
-  let current: Element | null = element;
-  for (let i = 0; i < MAX_SELECTOR_ANCESTORS; i++) {
-    current = current.parentElement;
-    if (!current || SELECTOR_BOUNDARY_TAGS.has(current.tagName)) break;
-    parts.unshift(describeElement(current));
-    if (current.id) break;
-  }
-
-  return truncateSelector(parts.join(" > "));
-}
-
-function truncateSelector(selector: string): string {
-  return selector.length > MAX_SELECTOR_LENGTH ? selector.substring(0, MAX_SELECTOR_LENGTH) : selector;
-}
-
-function describeElement(element: Element): string {
-  const tag = element.tagName.toLowerCase();
-  if (element.id) {
-    return `${tag}#${element.id}`;
-  }
-  const firstClass = element.classList.item(0);
-  return firstClass ? `${tag}.${firstClass}` : tag;
 }

--- a/src/instrumentations/interactions/click.ts
+++ b/src/instrumentations/interactions/click.ts
@@ -1,0 +1,135 @@
+import { nowNanos, win } from "../../utils";
+import { debug } from "../../utils/debug";
+import { sendLog } from "../../transport";
+import {
+  EVENT_NAME,
+  EVENT_NAMES,
+  INTERACTION_NAME,
+  INTERACTION_NAME_SOURCE,
+  INTERACTION_TARGET_ID,
+  INTERACTION_TARGET_SELECTOR,
+  INTERACTION_TARGET_TAG,
+  INTERACTION_TYPE,
+  LOG_SEVERITIES,
+} from "../../semantic-conventions";
+import { addAttribute } from "../../utils/otel";
+import { addCommonAttributes } from "../../attributes";
+import { KeyValue, LogRecord } from "../../types/otlp";
+import { vars } from "../../vars";
+import { deriveActionName } from "./action-name";
+
+const MAX_SELECTOR_LENGTH = 128;
+const MAX_SELECTOR_ANCESTORS = 3;
+const SELECTOR_BOUNDARY_TAGS = new Set(["BODY", "HTML"]);
+
+let listenerAttached = false;
+
+function onWindowClick(event: Event) {
+  if (!event.isTrusted) return;
+  handleClick(event);
+}
+
+export function startClickInstrumentation() {
+  if (listenerAttached) return;
+  if (!win) return;
+
+  win.addEventListener("click", onWindowClick, { capture: true });
+  listenerAttached = true;
+}
+
+/**
+ * Test-only teardown. Production code has no need to stop this listener --
+ * matching the errors/index.ts precedent of start-only lifecycle -- but unit
+ * tests need to avoid leaking a real window listener across test cases.
+ */
+export function stopClickInstrumentationForTests() {
+  if (!listenerAttached || !win) return;
+  win.removeEventListener("click", onWindowClick, { capture: true } as EventListenerOptions);
+  listenerAttached = false;
+}
+
+/**
+ * Handles a click event and, if the target is a valid Element, builds and
+ * transmits a `browser.interaction` log. Exported separately from the
+ * `isTrusted` gate in the real listener (see `onWindowClick`) so unit tests
+ * can exercise the full event-building path directly: jsdom's
+ * `dispatchEvent`, like real browsers, always produces `isTrusted: false`,
+ * so a trust-gated entry point cannot be driven by synthetic test events.
+ */
+export function handleClick(event: Event): void {
+  try {
+    const target = event.target;
+    if (!target || (target as Node).nodeType !== 1) {
+      return;
+    }
+
+    const element = target as Element;
+    const { name, nameSource } = deriveActionName(element, vars.interactionInstrumentation.actionNameAttribute!);
+    const selector = buildSelector(element);
+
+    const attributes: KeyValue[] = [];
+    addCommonAttributes(attributes);
+    addAttribute(attributes, EVENT_NAME, EVENT_NAMES.INTERACTION);
+
+    const bodyValues: KeyValue[] = [];
+    addAttribute(bodyValues, INTERACTION_TYPE, "click");
+    addAttribute(bodyValues, INTERACTION_NAME, name);
+    addAttribute(bodyValues, INTERACTION_NAME_SOURCE, nameSource);
+    addAttribute(bodyValues, INTERACTION_TARGET_SELECTOR, selector);
+    addAttribute(bodyValues, INTERACTION_TARGET_TAG, element.tagName.toLowerCase());
+    if (element.id) {
+      addAttribute(bodyValues, INTERACTION_TARGET_ID, element.id);
+    }
+
+    const log: LogRecord = {
+      timeUnixNano: nowNanos(),
+      attributes,
+      severityNumber: LOG_SEVERITIES.INFO,
+      severityText: "INFO",
+      body: {
+        kvlistValue: { values: bodyValues },
+      },
+    };
+
+    sendLog(log);
+  } catch (err) {
+    debug("Dash0 interaction instrumentation failed to process a click event.", err);
+  }
+}
+
+/**
+ * Builds a compact CSS-like selector describing the click target:
+ * - `tag#id` when the target has an id.
+ * - `tag.firstClass` when it has classes but no id.
+ * - Otherwise, walks up to MAX_SELECTOR_ANCESTORS ancestors (each rendered the
+ *   same way) joined with " > ", since there is no id anywhere to anchor on.
+ *   The walk never crosses a BODY/HTML boundary -- those document-structure
+ *   elements are not meaningful click-target context.
+ * Result is capped at MAX_SELECTOR_LENGTH characters.
+ */
+function buildSelector(element: Element): string {
+  if (element.id) {
+    return describeElement(element);
+  }
+
+  const parts: string[] = [describeElement(element)];
+  let current: Element | null = element;
+  for (let i = 0; i < MAX_SELECTOR_ANCESTORS; i++) {
+    current = current.parentElement;
+    if (!current || SELECTOR_BOUNDARY_TAGS.has(current.tagName)) break;
+    parts.unshift(describeElement(current));
+    if (current.id) break;
+  }
+
+  const selector = parts.join(" > ");
+  return selector.length > MAX_SELECTOR_LENGTH ? selector.substring(0, MAX_SELECTOR_LENGTH) : selector;
+}
+
+function describeElement(element: Element): string {
+  const tag = element.tagName.toLowerCase();
+  if (element.id) {
+    return `${tag}#${element.id}`;
+  }
+  const firstClass = element.classList.item(0);
+  return firstClass ? `${tag}.${firstClass}` : tag;
+}

--- a/src/instrumentations/interactions/click.ts
+++ b/src/instrumentations/interactions/click.ts
@@ -1,4 +1,4 @@
-import { win } from "../../utils";
+import { elementTag, win } from "../../utils";
 import { debug } from "../../utils/debug";
 import { resolveActionName } from "./action-name";
 import { registerActiveInteraction } from "./active-interaction";
@@ -110,7 +110,9 @@ export function handleClick(event: Event): void {
     rememberLabelForward(element);
 
     const { name, nameSource } = resolveActionName(element);
-    const tag = element.tagName.toLowerCase();
+    // Clobber-safe: a click can land on a <form> itself, whose own named controls
+    // can shadow `tagName` into an element -- see utils/dom.
+    const tag = elementTag(element).toLowerCase();
 
     // Register this click as the active interaction BEFORE the application's
     // own handlers run (we are in the capture phase), so any HTTP request the

--- a/src/instrumentations/interactions/click.ts
+++ b/src/instrumentations/interactions/click.ts
@@ -1,7 +1,6 @@
 import { win } from "../../utils";
 import { debug } from "../../utils/debug";
-import { vars } from "../../vars";
-import { deriveActionName } from "./action-name";
+import { resolveActionName } from "./action-name";
 import { registerActiveInteraction } from "./active-interaction";
 import { emitInteractionEvent, pagePath } from "./emit";
 
@@ -47,7 +46,7 @@ export function handleClick(event: Event): void {
     }
 
     const element = target as Element;
-    const { name, nameSource } = deriveActionName(element, vars.interactionInstrumentation.actionNameAttribute!);
+    const { name, nameSource } = resolveActionName(element);
     const tag = element.tagName.toLowerCase();
 
     // Register this click as the active interaction BEFORE the application's

--- a/src/instrumentations/interactions/click.ts
+++ b/src/instrumentations/interactions/click.ts
@@ -2,7 +2,7 @@ import { win } from "../../utils";
 import { debug } from "../../utils/debug";
 import { resolveActionName } from "./action-name";
 import { registerActiveInteraction } from "./active-interaction";
-import { emitInteractionEvent, pagePath } from "./emit";
+import { emitInteractionEvent } from "./emit";
 
 let listenerAttached = false;
 
@@ -56,9 +56,9 @@ export function handleClick(event: Event): void {
 
     emitInteractionEvent({
       type: "click",
-      // Click "Save Part" on /inventory/parts
-      // Click button on /playground          (no derivable name)
-      title: name ? `Click "${name}" on ${pagePath()}` : `Click ${tag} on ${pagePath()}`,
+      // Click "Save Part"   (emit appends ` on <scrubbed page path>`)
+      // Click button        (no derivable name)
+      title: name ? `Click "${name}"` : `Click ${tag}`,
       id: interaction.id,
       name,
       nameSource,

--- a/src/instrumentations/interactions/click.ts
+++ b/src/instrumentations/interactions/click.ts
@@ -4,11 +4,62 @@ import { resolveActionName } from "./action-name";
 import { registerActiveInteraction } from "./active-interaction";
 import { emitInteractionEvent } from "./emit";
 
+/**
+ * How long a label-forward marker stays valid. The window only has to span one
+ * dispatch task: a label's activation behavior fires the forwarded click
+ * synchronously while the label's own click is still being dispatched, so a
+ * genuine second click is always a later task.
+ */
+const LABEL_FORWARD_WINDOW_MILLIS = 50;
+
 let listenerAttached = false;
+
+/**
+ * The control a `<label>` activation is about to forward a click to, set by the
+ * label's own click and consumed by the very next one. Holds a DOM reference
+ * only for that gap, and only for clicks that landed inside a label with a
+ * control -- every other click clears it.
+ */
+let pendingLabelForward: { control: Element; epochMillis: number } | undefined;
 
 function onWindowClick(event: Event) {
   if (!event.isTrusted) return;
   handleClick(event);
+}
+
+/**
+ * Consumes the one-shot marker left by the preceding click. True when `element`
+ * is the control that label activation forwarded to, i.e. this event is the
+ * browser's duplicate of a gesture already reported.
+ */
+function consumePendingLabelForward(element: Element): boolean {
+  const pending = pendingLabelForward;
+  pendingLabelForward = undefined; // one-shot: never outlives the next click
+  return (
+    pending !== undefined &&
+    pending.control === element &&
+    Date.now() - pending.epochMillis <= LABEL_FORWARD_WINDOW_MILLIS
+  );
+}
+
+/**
+ * Records that this click is about to be duplicated, if it landed inside a
+ * `<label>` that has a labeled control.
+ *
+ * `closest` rather than a parent walk: the click target is routinely a
+ * `<span>`/`<svg>` inside the label, and activation forwards regardless of
+ * depth. `label.control` rather than a containment check: with
+ * `<label for="x">` the control is not a descendant of the label at all.
+ */
+function rememberLabelForward(element: Element): void {
+  const label = element.closest("label") as HTMLLabelElement | null;
+  const control = label?.control;
+  // A click that already landed on the control is not forwarded again -- a
+  // label's activation behavior does nothing for events targeted at its
+  // interactive content descendants -- so there is nothing to suppress.
+  if (control && control !== element) {
+    pendingLabelForward = { control, epochMillis: Date.now() };
+  }
 }
 
 export function startClickInstrumentation() {
@@ -25,6 +76,9 @@ export function startClickInstrumentation() {
  * tests need to avoid leaking a real window listener across test cases.
  */
 export function stopClickInstrumentationForTests() {
+  // Before the guard below: module state has to be reset even for test cases
+  // that never attached the real listener.
+  pendingLabelForward = undefined;
   if (!listenerAttached || !win) return;
   win.removeEventListener("click", onWindowClick, { capture: true } as EventListenerOptions);
   listenerAttached = false;
@@ -37,6 +91,12 @@ export function stopClickInstrumentationForTests() {
  * can exercise the full event-building path directly: jsdom's
  * `dispatchEvent`, like real browsers, always produces `isTrusted: false`,
  * so a trust-gated entry point cannot be driven by synthetic test events.
+ *
+ * Not every click handed in produces an event: clicking a `<label>` makes the
+ * browser forward a second, also trusted, click to the labeled control, and
+ * that duplicate is dropped so one gesture yields one interaction. The click
+ * the user actually made is the one that survives, which also keeps the
+ * registered active interaction and the emitted log carrying the same id.
  */
 export function handleClick(event: Event): void {
   try {
@@ -46,6 +106,9 @@ export function handleClick(event: Event): void {
     }
 
     const element = target as Element;
+    if (consumePendingLabelForward(element)) return;
+    rememberLabelForward(element);
+
     const { name, nameSource } = resolveActionName(element);
     const tag = element.tagName.toLowerCase();
 

--- a/src/instrumentations/interactions/click_test.ts
+++ b/src/instrumentations/interactions/click_test.ts
@@ -1,0 +1,230 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { vars } from "../../vars";
+import { sendLog } from "../../transport";
+import { doc, win } from "../../utils/globals";
+import {
+  EVENT_NAME,
+  EVENT_NAMES,
+  INTERACTION_NAME,
+  INTERACTION_NAME_SOURCE,
+  INTERACTION_TARGET_ID,
+  INTERACTION_TARGET_SELECTOR,
+  INTERACTION_TARGET_TAG,
+  INTERACTION_TYPE,
+  LOG_SEVERITIES,
+} from "../../semantic-conventions";
+import { WEB_EVENT_ID } from "../../semantic-conventions";
+import type { LogRecord } from "../../types/otlp";
+
+vi.mock("../../transport", () => ({
+  sendLog: vi.fn(),
+}));
+
+import { handleClick, startClickInstrumentation, stopClickInstrumentationForTests } from "./click";
+
+// Vitest runs these tests in jsdom, so the SSR-safe doc/win are always defined.
+const dom = doc!;
+const globalWindow = win!;
+
+function dispatchClick(target: Element) {
+  const event = new MouseEvent("click", { bubbles: true, cancelable: true });
+  target.dispatchEvent(event);
+  return event;
+}
+
+describe("click instrumentation", () => {
+  beforeEach(() => {
+    dom.body.innerHTML = "";
+    vars.interactionInstrumentation = { enabled: true, actionNameAttribute: "data-dash0-action-name" };
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    stopClickInstrumentationForTests();
+    vi.clearAllMocks();
+  });
+
+  function lastLog(): LogRecord {
+    const calls = (sendLog as ReturnType<typeof vi.fn>).mock.calls;
+    expect(calls.length).toBeGreaterThan(0);
+    return calls[calls.length - 1]![0] as LogRecord;
+  }
+
+  describe("handleClick (direct, bypasses isTrusted gate)", () => {
+    it("emits exactly one log per click with the full expected attribute set", () => {
+      dom.body.innerHTML = `<button id="btn" data-dash0-action-name="Save Settings">Save</button>`;
+      const target = dom.getElementById("btn")!;
+
+      handleClick(dispatchClick(target));
+
+      expect(sendLog).toHaveBeenCalledOnce();
+      const log = lastLog();
+
+      expect(log.severityNumber).toBe(LOG_SEVERITIES.INFO);
+      expect(log.severityText).toBe("INFO");
+      expect(typeof log.timeUnixNano).toBe("string");
+
+      expect(log.attributes).toEqual(
+        expect.arrayContaining([
+          { key: WEB_EVENT_ID, value: { stringValue: expect.any(String) } },
+          { key: EVENT_NAME, value: { stringValue: EVENT_NAMES.INTERACTION } },
+        ])
+      );
+
+      expect(log.body).toEqual({
+        kvlistValue: {
+          values: expect.arrayContaining([
+            { key: INTERACTION_TYPE, value: { stringValue: "click" } },
+            { key: INTERACTION_NAME, value: { stringValue: "Save Settings" } },
+            { key: INTERACTION_NAME_SOURCE, value: { stringValue: "custom_attribute" } },
+            { key: INTERACTION_TARGET_SELECTOR, value: { stringValue: "button#btn" } },
+            { key: INTERACTION_TARGET_TAG, value: { stringValue: "button" } },
+            { key: INTERACTION_TARGET_ID, value: { stringValue: "btn" } },
+          ]),
+        },
+      });
+    });
+
+    it("addCommonAttributes attributes come before EVENT_NAME, matching the errors/index.ts structural template", () => {
+      dom.body.innerHTML = `<button id="btn">Click</button>`;
+      handleClick(dispatchClick(dom.getElementById("btn")!));
+
+      const log = lastLog();
+      const eventNameIndex = log.attributes.findIndex((a) => a.key === EVENT_NAME);
+      const webEventIdIndex = log.attributes.findIndex((a) => a.key === WEB_EVENT_ID);
+
+      expect(webEventIdIndex).toBeGreaterThanOrEqual(0);
+      expect(eventNameIndex).toBeGreaterThan(webEventIdIndex);
+    });
+
+    it("omits target.id when the element has no id", () => {
+      dom.body.innerHTML = `<button class="cta">Click</button>`;
+      handleClick(dispatchClick(dom.querySelector(".cta")!));
+
+      const log = lastLog();
+      const values = (log.body!.kvlistValue!.values as { key: string }[]).map((kv) => kv.key);
+      expect(values).not.toContain(INTERACTION_TARGET_ID);
+    });
+
+    it("derives a compact selector: tag + #id when id is present", () => {
+      dom.body.innerHTML = `<div id="card" class="card highlighted"><span id="inner">x</span></div>`;
+      handleClick(dispatchClick(dom.getElementById("inner")!));
+
+      const log = lastLog();
+      const selector = (log.body!.kvlistValue!.values as { key: string; value: { stringValue: string } }[]).find(
+        (kv) => kv.key === INTERACTION_TARGET_SELECTOR
+      );
+      expect(selector?.value.stringValue).toBe("span#inner");
+    });
+
+    it("derives a compact selector: tag + first class when no id is present", () => {
+      dom.body.innerHTML = `<button class="btn-primary large">Click</button>`;
+      handleClick(dispatchClick(dom.querySelector(".btn-primary")!));
+
+      const log = lastLog();
+      const selector = (log.body!.kvlistValue!.values as { key: string; value: { stringValue: string } }[]).find(
+        (kv) => kv.key === INTERACTION_TARGET_SELECTOR
+      );
+      expect(selector?.value.stringValue).toBe("button.btn-primary");
+    });
+
+    it("walks up to 3 ancestors joined with ' > ' when no id is present anywhere in the path", () => {
+      dom.body.innerHTML = `
+        <div class="outer">
+          <div class="middle">
+            <span class="inner">x</span>
+          </div>
+        </div>`;
+      handleClick(dispatchClick(dom.querySelector(".inner")!));
+
+      const log = lastLog();
+      const selector = (log.body!.kvlistValue!.values as { key: string; value: { stringValue: string } }[]).find(
+        (kv) => kv.key === INTERACTION_TARGET_SELECTOR
+      );
+      expect(selector?.value.stringValue).toBe("div.outer > div.middle > span.inner");
+    });
+
+    it("does not emit a log when target is not an Element (e.g. a text node)", () => {
+      dom.body.innerHTML = `<div id="wrap">text</div>`;
+      const textNode = dom.getElementById("wrap")!.firstChild!;
+
+      const event = new MouseEvent("click", { bubbles: true });
+      Object.defineProperty(event, "target", { value: textNode });
+
+      handleClick(event);
+
+      expect(sendLog).not.toHaveBeenCalled();
+    });
+
+    it("swallows errors from a throwing scenario and does not propagate", () => {
+      dom.body.innerHTML = `<button id="btn">Click</button>`;
+      const target = dom.getElementById("btn")!;
+      // Force an internal error by making textContent throw.
+      Object.defineProperty(target, "textContent", {
+        get() {
+          throw new Error("boom");
+        },
+      });
+
+      expect(() => handleClick(dispatchClick(target))).not.toThrow();
+      expect(sendLog).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("startClickInstrumentation (real capture-phase listener + isTrusted gate)", () => {
+    it("registers exactly one window-level capture-phase click listener", () => {
+      const addSpy = vi.spyOn(globalWindow, "addEventListener");
+
+      startClickInstrumentation();
+
+      expect(addSpy).toHaveBeenCalledOnce();
+      expect(addSpy).toHaveBeenCalledWith("click", expect.any(Function), { capture: true });
+
+      addSpy.mockRestore();
+    });
+
+    it("ignores untrusted (synthetic) clicks -- jsdom's dispatchEvent always yields isTrusted: false", () => {
+      dom.body.innerHTML = `<button id="btn">Click</button>`;
+      startClickInstrumentation();
+
+      const target = dom.getElementById("btn")!;
+      const event = dispatchClick(target);
+
+      // jsdom, like real browsers, never sets isTrusted: true for dispatchEvent --
+      // this assertion documents and locks in that guard behavior.
+      expect(event.isTrusted).toBe(false);
+      expect(sendLog).not.toHaveBeenCalled();
+    });
+
+    it("processes a click when isTrusted is stubbed true, proving the gate is the only thing blocking synthetic clicks", () => {
+      // jsdom (v26, pinned in this repo) defines `isTrusted` as a non-configurable
+      // accessor on its Event prototype, so `Object.defineProperty` on a real
+      // dispatched event throws "Cannot redefine property: isTrusted" -- there is
+      // no public jsdom API to construct a pre-trusted event. Instead, capture the
+      // real capture-phase listener registered by `startClickInstrumentation` and
+      // invoke it directly with a minimal object shaped like a trusted click
+      // event. This still exercises the real production listener function (not a
+      // reimplementation of it), only substituting jsdom's event construction.
+      dom.body.innerHTML = `<button id="btn">Click</button>`;
+      const addSpy = vi.spyOn(globalWindow, "addEventListener");
+      startClickInstrumentation();
+
+      const target = dom.getElementById("btn")!;
+      const listener = addSpy.mock.calls.find((call) => call[0] === "click")![1] as EventListener;
+      listener({ isTrusted: true, target } as unknown as Event);
+
+      addSpy.mockRestore();
+      expect(sendLog).toHaveBeenCalledOnce();
+    });
+
+    it("does not register a second listener if called twice (idempotent start)", () => {
+      const addSpy = vi.spyOn(globalWindow, "addEventListener");
+
+      startClickInstrumentation();
+      startClickInstrumentation();
+
+      expect(addSpy).toHaveBeenCalledOnce();
+      addSpy.mockRestore();
+    });
+  });
+});

--- a/src/instrumentations/interactions/click_test.ts
+++ b/src/instrumentations/interactions/click_test.ts
@@ -128,6 +128,34 @@ describe("click instrumentation", () => {
       expect(selector?.value.stringValue).toBe("button.btn-primary");
     });
 
+    it("caps the selector length on the id-anchored path, same as the ancestor-walk path", () => {
+      // Regression: the tag#id fast path must go through the same
+      // MAX_SELECTOR_LENGTH (128) truncation as the ancestor-walk branch.
+      const longId = "x".repeat(200);
+      dom.body.innerHTML = `<button id="${longId}">Click</button>`;
+      handleClick(dispatchClick(dom.getElementById(longId)!));
+
+      const log = lastLog();
+      const selector = (log.body!.kvlistValue!.values as { key: string; value: { stringValue: string } }[]).find(
+        (kv) => kv.key === INTERACTION_TARGET_SELECTOR
+      );
+      expect(selector?.value.stringValue).toBe(`button#${longId}`.substring(0, 128));
+      expect(selector?.value.stringValue.length).toBe(128);
+    });
+
+    it("never includes body/html segments in the selector for a shallow element with no id", () => {
+      // Locks in SELECTOR_BOUNDARY_TAGS: the ancestor walk stops before
+      // crossing into document-structure elements.
+      dom.body.innerHTML = `<span class="lonely">x</span>`;
+      handleClick(dispatchClick(dom.querySelector(".lonely")!));
+
+      const log = lastLog();
+      const selector = (log.body!.kvlistValue!.values as { key: string; value: { stringValue: string } }[]).find(
+        (kv) => kv.key === INTERACTION_TARGET_SELECTOR
+      );
+      expect(selector?.value.stringValue).toBe("span.lonely");
+    });
+
     it("walks up to 3 ancestors joined with ' > ' when no id is present anywhere in the path", () => {
       dom.body.innerHTML = `
         <div class="outer">

--- a/src/instrumentations/interactions/click_test.ts
+++ b/src/instrumentations/interactions/click_test.ts
@@ -5,6 +5,7 @@ import { doc, win } from "../../utils/globals";
 import {
   EVENT_NAME,
   EVENT_NAMES,
+  INTERACTION_ID,
   INTERACTION_NAME,
   INTERACTION_NAME_SOURCE,
   INTERACTION_TARGET_ID,
@@ -21,6 +22,7 @@ vi.mock("../../transport", () => ({
 }));
 
 import { handleClick, startClickInstrumentation, stopClickInstrumentationForTests } from "./click";
+import { clearActiveInteractionForTests, getActiveInteraction } from "./active-interaction";
 
 // Vitest runs these tests in jsdom, so the SSR-safe doc/win are always defined.
 const dom = doc!;
@@ -41,6 +43,7 @@ describe("click instrumentation", () => {
 
   afterEach(() => {
     stopClickInstrumentationForTests();
+    clearActiveInteractionForTests();
     vi.clearAllMocks();
   });
 
@@ -68,21 +71,51 @@ describe("click instrumentation", () => {
         expect.arrayContaining([
           { key: WEB_EVENT_ID, value: { stringValue: expect.any(String) } },
           { key: EVENT_NAME, value: { stringValue: EVENT_NAMES.INTERACTION } },
+          { key: INTERACTION_ID, value: { stringValue: expect.stringMatching(/^[0-9a-f]{16}$/) } },
+          { key: INTERACTION_TYPE, value: { stringValue: "click" } },
+          { key: INTERACTION_NAME, value: { stringValue: "Save Settings" } },
+          { key: INTERACTION_NAME_SOURCE, value: { stringValue: "custom_attribute" } },
+          { key: INTERACTION_TARGET_SELECTOR, value: { stringValue: "button#btn" } },
+          { key: INTERACTION_TARGET_TAG, value: { stringValue: "button" } },
+          { key: INTERACTION_TARGET_ID, value: { stringValue: "btn" } },
         ])
       );
 
-      expect(log.body).toEqual({
-        kvlistValue: {
-          values: expect.arrayContaining([
-            { key: INTERACTION_TYPE, value: { stringValue: "click" } },
-            { key: INTERACTION_NAME, value: { stringValue: "Save Settings" } },
-            { key: INTERACTION_NAME_SOURCE, value: { stringValue: "custom_attribute" } },
-            { key: INTERACTION_TARGET_SELECTOR, value: { stringValue: "button#btn" } },
-            { key: INTERACTION_TARGET_TAG, value: { stringValue: "button" } },
-            { key: INTERACTION_TARGET_ID, value: { stringValue: "btn" } },
-          ]),
-        },
-      });
+      // The body is the plain human-readable summary -- UIs without a
+      // dedicated browser.interaction renderer display it as-is.
+      expect(log.body).toEqual({ stringValue: 'Click "Save Settings" on /' });
+    });
+
+    it("titles an unnamed click with the target tag instead of dumping its text content", () => {
+      dom.body.innerHTML = `<div id="page" class="page">Lots of page prose that must not become the title</div>`;
+      handleClick(dispatchClick(dom.getElementById("page")!));
+
+      const log = lastLog();
+      expect(log.body).toEqual({ stringValue: "Click div on /" });
+      expect(log.attributes).toEqual(
+        expect.arrayContaining([
+          { key: INTERACTION_NAME, value: { stringValue: "" } },
+          { key: INTERACTION_NAME_SOURCE, value: { stringValue: "blank" } },
+        ])
+      );
+    });
+
+    it("registers the click as the active interaction so HTTP spans can be attributed to it", () => {
+      dom.body.innerHTML = `<button id="btn" data-dash0-action-name="Fire Requests">Go</button>`;
+      handleClick(dispatchClick(dom.getElementById("btn")!));
+
+      const log = lastLog();
+      const eventId = (log.attributes as { key: string; value: { stringValue: string } }[]).find(
+        (kv) => kv.key === INTERACTION_ID
+      )!.value.stringValue;
+
+      const active = getActiveInteraction();
+      expect(active).toBeDefined();
+      expect(active!.name).toBe("Fire Requests");
+      // The event's interaction.id and the id stamped onto spans are the same
+      // value -- that shared id is what joins a click to the requests it
+      // triggered.
+      expect(active!.id).toBe(eventId);
     });
 
     it("addCommonAttributes attributes come before EVENT_NAME, matching the errors/index.ts structural template", () => {
@@ -102,8 +135,8 @@ describe("click instrumentation", () => {
       handleClick(dispatchClick(dom.querySelector(".cta")!));
 
       const log = lastLog();
-      const values = (log.body!.kvlistValue!.values as { key: string }[]).map((kv) => kv.key);
-      expect(values).not.toContain(INTERACTION_TARGET_ID);
+      const keys = (log.attributes as { key: string }[]).map((kv) => kv.key);
+      expect(keys).not.toContain(INTERACTION_TARGET_ID);
     });
 
     it("derives a compact selector: tag + #id when id is present", () => {
@@ -111,7 +144,7 @@ describe("click instrumentation", () => {
       handleClick(dispatchClick(dom.getElementById("inner")!));
 
       const log = lastLog();
-      const selector = (log.body!.kvlistValue!.values as { key: string; value: { stringValue: string } }[]).find(
+      const selector = (log.attributes as { key: string; value: { stringValue: string } }[]).find(
         (kv) => kv.key === INTERACTION_TARGET_SELECTOR
       );
       expect(selector?.value.stringValue).toBe("span#inner");
@@ -122,7 +155,7 @@ describe("click instrumentation", () => {
       handleClick(dispatchClick(dom.querySelector(".btn-primary")!));
 
       const log = lastLog();
-      const selector = (log.body!.kvlistValue!.values as { key: string; value: { stringValue: string } }[]).find(
+      const selector = (log.attributes as { key: string; value: { stringValue: string } }[]).find(
         (kv) => kv.key === INTERACTION_TARGET_SELECTOR
       );
       expect(selector?.value.stringValue).toBe("button.btn-primary");
@@ -136,7 +169,7 @@ describe("click instrumentation", () => {
       handleClick(dispatchClick(dom.getElementById(longId)!));
 
       const log = lastLog();
-      const selector = (log.body!.kvlistValue!.values as { key: string; value: { stringValue: string } }[]).find(
+      const selector = (log.attributes as { key: string; value: { stringValue: string } }[]).find(
         (kv) => kv.key === INTERACTION_TARGET_SELECTOR
       );
       expect(selector?.value.stringValue).toBe(`button#${longId}`.substring(0, 128));
@@ -150,7 +183,7 @@ describe("click instrumentation", () => {
       handleClick(dispatchClick(dom.querySelector(".lonely")!));
 
       const log = lastLog();
-      const selector = (log.body!.kvlistValue!.values as { key: string; value: { stringValue: string } }[]).find(
+      const selector = (log.attributes as { key: string; value: { stringValue: string } }[]).find(
         (kv) => kv.key === INTERACTION_TARGET_SELECTOR
       );
       expect(selector?.value.stringValue).toBe("span.lonely");
@@ -166,7 +199,7 @@ describe("click instrumentation", () => {
       handleClick(dispatchClick(dom.querySelector(".inner")!));
 
       const log = lastLog();
-      const selector = (log.body!.kvlistValue!.values as { key: string; value: { stringValue: string } }[]).find(
+      const selector = (log.attributes as { key: string; value: { stringValue: string } }[]).find(
         (kv) => kv.key === INTERACTION_TARGET_SELECTOR
       );
       expect(selector?.value.stringValue).toBe("div.outer > div.middle > span.inner");

--- a/src/instrumentations/interactions/click_test.ts
+++ b/src/instrumentations/interactions/click_test.ts
@@ -13,9 +13,17 @@ import {
   INTERACTION_TARGET_TAG,
   INTERACTION_TYPE,
   LOG_SEVERITIES,
+  PAGE_URL_ATTR_PREFIX,
+  URL_FULL,
+  URL_PATH,
   WEB_EVENT_ID,
 } from "../../semantic-conventions";
 import type { LogRecord } from "../../types/otlp";
+import type { UrlAttributeScrubber } from "../../attributes/url";
+import { identity } from "../../utils";
+import { withPrefix } from "../../utils/otel";
+
+const PAGE_URL_PATH = withPrefix(PAGE_URL_ATTR_PREFIX)(URL_PATH);
 
 vi.mock("../../transport", () => ({
   sendLog: vi.fn(),
@@ -288,6 +296,77 @@ describe("click instrumentation", () => {
 
       expect(addSpy).toHaveBeenCalledOnce();
       addSpy.mockRestore();
+    });
+  });
+
+  // The page path in the body must come from the scrubbed `page.url.path`
+  // attribute, never from a raw `location.pathname` read -- otherwise a
+  // consumer's urlAttributeScrubber redacts the attribute while the free-text
+  // body still leaks the segment, and free text cannot be scrubbed downstream.
+  describe("page path in the body", () => {
+    const RAW_PATH = "/invoices/acme-corp/4471";
+
+    beforeEach(() => {
+      globalWindow.history.pushState({}, "", RAW_PATH);
+    });
+
+    afterEach(() => {
+      globalWindow.history.pushState({}, "", "/");
+      vars.urlAttributeScrubber = identity;
+      vars.signalAttributes = [];
+    });
+
+    function clickAndGetBody(): string {
+      dom.body.innerHTML = `<button id="btn" data-dash0-action-name="Save">Save</button>`;
+      handleClick(dispatchClick(dom.getElementById("btn")!));
+      return (lastLog().body as { stringValue: string }).stringValue;
+    }
+
+    it("renders the scrubbed path rather than the raw location.pathname", () => {
+      vars.urlAttributeScrubber = ((attrs) => ({
+        ...attrs,
+        [URL_PATH]: "/invoices/REDACTED/4471",
+      })) satisfies UrlAttributeScrubber;
+
+      // Sanity check: the raw path really is present on `location`, so the
+      // assertions below prove the body did not read it.
+      expect(globalWindow.location.pathname).toBe(RAW_PATH);
+
+      const body = clickAndGetBody();
+
+      expect(body).toBe('Click "Save" on /invoices/REDACTED/4471');
+      expect(body).not.toContain("acme-corp");
+      // The body and the attribute must agree -- both come from one scrub.
+      expect(lastLog().attributes).toEqual(
+        expect.arrayContaining([{ key: PAGE_URL_PATH, value: { stringValue: "/invoices/REDACTED/4471" } }])
+      );
+    });
+
+    it("omits the path suffix entirely when the scrubber drops url.path", () => {
+      vars.urlAttributeScrubber = ((attrs) => ({ [URL_FULL]: attrs[URL_FULL] })) satisfies UrlAttributeScrubber;
+
+      // A scrubber that dropped the path asked for it gone; there is no
+      // fallback to location.pathname.
+      expect(clickAndGetBody()).toBe('Click "Save"');
+    });
+
+    it("omits the path suffix when the scrubber throws", () => {
+      vars.urlAttributeScrubber = (() => {
+        throw new Error("scrubber boom");
+      }) satisfies UrlAttributeScrubber;
+
+      const body = clickAndGetBody();
+
+      expect(body).toBe('Click "Save"');
+      expect(body).not.toContain("acme-corp");
+    });
+
+    it("prefers the derived page.url.path over a same-keyed signal attribute", () => {
+      // signalAttributes are spliced in *before* the url block, so a forward
+      // scan would pick this up instead of the real, scrubbed value.
+      vars.signalAttributes = [{ key: PAGE_URL_PATH, value: { stringValue: "/spoofed" } }];
+
+      expect(clickAndGetBody()).toBe(`Click "Save" on ${RAW_PATH}`);
     });
   });
 });

--- a/src/instrumentations/interactions/click_test.ts
+++ b/src/instrumentations/interactions/click_test.ts
@@ -253,11 +253,12 @@ describe("click instrumentation", () => {
     it("swallows errors from a throwing scenario and does not propagate", () => {
       dom.body.innerHTML = `<button id="btn">Click</button>`;
       const target = dom.getElementById("btn")!;
-      // Force an internal error by making the first DOM read of the derivation
-      // throw (name derivation no longer touches textContent -- see labelText
-      // in action-name.ts).
-      Object.defineProperty(target, "getAttribute", {
-        value() {
+      // Force an internal error by making the first DOM read of the derivation --
+      // the ancestor walk -- throw. Shadowing `getAttribute` no longer works as a
+      // lever: attributes are read through Element.prototype so a shadowed method
+      // on the element is bypassed by design (see utils/dom).
+      Object.defineProperty(target, "parentElement", {
+        get() {
           throw new Error("boom");
         },
       });

--- a/src/instrumentations/interactions/click_test.ts
+++ b/src/instrumentations/interactions/click_test.ts
@@ -13,8 +13,8 @@ import {
   INTERACTION_TARGET_TAG,
   INTERACTION_TYPE,
   LOG_SEVERITIES,
+  WEB_EVENT_ID,
 } from "../../semantic-conventions";
-import { WEB_EVENT_ID } from "../../semantic-conventions";
 import type { LogRecord } from "../../types/otlp";
 
 vi.mock("../../transport", () => ({

--- a/src/instrumentations/interactions/click_test.ts
+++ b/src/instrumentations/interactions/click_test.ts
@@ -220,9 +220,11 @@ describe("click instrumentation", () => {
     it("swallows errors from a throwing scenario and does not propagate", () => {
       dom.body.innerHTML = `<button id="btn">Click</button>`;
       const target = dom.getElementById("btn")!;
-      // Force an internal error by making textContent throw.
-      Object.defineProperty(target, "textContent", {
-        get() {
+      // Force an internal error by making the first DOM read of the derivation
+      // throw (name derivation no longer touches textContent -- see labelText
+      // in action-name.ts).
+      Object.defineProperty(target, "getAttribute", {
+        value() {
           throw new Error("boom");
         },
       });

--- a/src/instrumentations/interactions/click_test.ts
+++ b/src/instrumentations/interactions/click_test.ts
@@ -42,6 +42,31 @@ function dispatchClick(target: Element) {
   return event;
 }
 
+/**
+ * Dispatches one click and feeds every click event it produces to `handleClick`,
+ * in dispatch order -- exactly what the production listener does, minus the
+ * `isTrusted` gate. jsdom implements a `<label>`'s activation behavior, so a
+ * click inside a label really does produce a second event at the labeled
+ * control here, the same duplicate every browser emits. Returns the events seen
+ * so a test can assert the duplication happened at all.
+ */
+function dispatchClickThroughListener(target: Element): Event[] {
+  const seen: Event[] = [];
+  const collect = (event: Event) => {
+    seen.push(event);
+    handleClick(event);
+  };
+
+  globalWindow.addEventListener("click", collect, { capture: true });
+  try {
+    target.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+  } finally {
+    globalWindow.removeEventListener("click", collect, { capture: true } as EventListenerOptions);
+  }
+
+  return seen;
+}
+
 describe("click instrumentation", () => {
   beforeEach(() => {
     dom.body.innerHTML = "";
@@ -239,6 +264,144 @@ describe("click instrumentation", () => {
 
       expect(() => handleClick(dispatchClick(target))).not.toThrow();
       expect(sendLog).not.toHaveBeenCalled();
+    });
+  });
+
+  // Clicking a <label> makes the browser fire a second, also trusted, click at
+  // the labeled control: one gesture, two events reaching a window-level
+  // capture listener. Both the wrapping shape and <label for="..."> are covered
+  // because the control is a descendant of the label in the first and not in
+  // the second -- a containment test would only ever see the first, and only
+  // when the click landed on the label element itself rather than on something
+  // inside it.
+  describe("label-forwarded duplicate clicks", () => {
+    function logCount(): number {
+      return (sendLog as ReturnType<typeof vi.fn>).mock.calls.length;
+    }
+
+    function attribute(log: LogRecord, key: string): string | undefined {
+      return (log.attributes as { key: string; value: { stringValue: string } }[]).find((kv) => kv.key === key)?.value
+        .stringValue;
+    }
+
+    it("emits one event for a click on a span inside a label wrapping its control", () => {
+      // The shape of the e2e fixture: the click target is an inner span, so the
+      // forwarded target (the textarea) is its sibling, not its descendant.
+      dom.body.innerHTML = `
+        <label id="notes-label"
+          ><span id="notes-label-text">Notes</span>
+          <textarea id="notes"></textarea>
+        </label>`;
+
+      const seen = dispatchClickThroughListener(dom.getElementById("notes-label-text")!);
+
+      // Guards the premise: without two events there is nothing to coalesce and
+      // the rest of this test would pass for the wrong reason.
+      expect(seen.map((event) => (event.target as Element).id)).toEqual(["notes-label-text", "notes"]);
+      expect(sendLog).toHaveBeenCalledOnce();
+      expect(attribute(lastLog(), INTERACTION_TARGET_ID)).toBe("notes-label-text");
+    });
+
+    it("emits one event for a label whose control lives outside it (label for=)", () => {
+      dom.body.innerHTML = `
+        <label id="terms-label" for="terms">Accept terms</label>
+        <div><input id="terms" type="checkbox" /></div>`;
+
+      const seen = dispatchClickThroughListener(dom.getElementById("terms-label")!);
+
+      expect(seen.map((event) => (event.target as Element).id)).toEqual(["terms-label", "terms"]);
+      expect(sendLog).toHaveBeenCalledOnce();
+      expect(attribute(lastLog(), INTERACTION_TARGET_ID)).toBe("terms-label");
+    });
+
+    it("keeps the surviving event's id as the active interaction, so spans join to a log that exists", () => {
+      dom.body.innerHTML = `
+        <label id="terms-label" for="terms">Accept terms</label>
+        <div><input id="terms" type="checkbox" /></div>`;
+
+      dispatchClickThroughListener(dom.getElementById("terms-label")!);
+
+      // The suppressed click must not have overwritten the registration: the
+      // forwarded control click never calls registerActiveInteraction.
+      expect(getActiveInteraction()!.id).toBe(attribute(lastLog(), INTERACTION_ID));
+      expect(getActiveInteraction()!.name).toBe("Accept terms");
+    });
+
+    it("emits for a click that lands on the control itself, which is never forwarded again", () => {
+      dom.body.innerHTML = `
+        <label id="terms-label"><input id="terms" type="checkbox" /> Accept terms</label>`;
+
+      const seen = dispatchClickThroughListener(dom.getElementById("terms")!);
+
+      // A label's activation behavior does nothing for events targeted at its
+      // interactive content descendants, so there is no duplicate to drop here.
+      expect(seen).toHaveLength(1);
+      expect(sendLog).toHaveBeenCalledOnce();
+      expect(attribute(lastLog(), INTERACTION_TARGET_ID)).toBe("terms");
+    });
+
+    it("does not latch: each successive gesture on the same label emits its own event", () => {
+      dom.body.innerHTML = `
+        <label id="terms-label" for="terms">Accept terms</label>
+        <div><input id="terms" type="checkbox" /></div>`;
+      const label = dom.getElementById("terms-label")!;
+
+      dispatchClickThroughListener(label);
+      const firstId = attribute(lastLog(), INTERACTION_ID);
+      dispatchClickThroughListener(label);
+
+      expect(logCount()).toBe(2);
+      expect(attribute(lastLog(), INTERACTION_ID)).not.toBe(firstId);
+    });
+
+    it("emits a genuine click on the control once the forward window has elapsed", () => {
+      dom.body.innerHTML = `
+        <label id="terms-label" for="terms">Accept terms</label>
+        <div><input id="terms" type="checkbox" /></div>`;
+      const nowSpy = vi.spyOn(Date, "now").mockReturnValue(1_000);
+
+      try {
+        // dispatchClick (not the listener helper) so only the label's own click
+        // is handled -- the forwarded one is dropped by the browser here, as it
+        // would be for a disabled control.
+        handleClick(dispatchClick(dom.getElementById("terms-label")!));
+        // Later than any same-task forward could be: a deliberate second click.
+        nowSpy.mockReturnValue(1_051);
+        handleClick(dispatchClick(dom.getElementById("terms")!));
+      } finally {
+        nowSpy.mockRestore();
+      }
+
+      expect(logCount()).toBe(2);
+      expect(attribute(lastLog(), INTERACTION_TARGET_ID)).toBe("terms");
+    });
+
+    it("leaves no marker behind for a label with no labeled control", () => {
+      dom.body.innerHTML = `
+        <label id="orphan-label" for="missing">Nothing to activate</label>
+        <button id="btn">Go</button>`;
+
+      dispatchClickThroughListener(dom.getElementById("orphan-label")!);
+      dispatchClickThroughListener(dom.getElementById("btn")!);
+
+      expect(logCount()).toBe(2);
+      expect(attribute(lastLog(), INTERACTION_TARGET_ID)).toBe("btn");
+    });
+
+    it("emits a keyboard-activated click on a labeled control, which carries no preceding label click", () => {
+      // Keyboard activation of a button produces a click with detail 0, the same
+      // marker a label-forwarded click carries in some browsers -- which is why
+      // the suppression keys off the preceding label click rather than `detail`.
+      dom.body.innerHTML = `
+        <label id="submit-label" for="submit-button">Submit</label>
+        <button id="submit-button">Go</button>`;
+      const event = new MouseEvent("click", { bubbles: true, cancelable: true, detail: 0 });
+      dom.getElementById("submit-button")!.dispatchEvent(event);
+
+      handleClick(event);
+
+      expect(sendLog).toHaveBeenCalledOnce();
+      expect(attribute(lastLog(), INTERACTION_TARGET_ID)).toBe("submit-button");
     });
   });
 

--- a/src/instrumentations/interactions/emit.ts
+++ b/src/instrumentations/interactions/emit.ts
@@ -1,0 +1,125 @@
+import { loc, nowNanos } from "../../utils";
+import { sendLog } from "../../transport";
+import {
+  EVENT_NAME,
+  EVENT_NAMES,
+  INTERACTION_ID,
+  INTERACTION_NAME,
+  INTERACTION_NAME_SOURCE,
+  INTERACTION_TARGET_ID,
+  INTERACTION_TARGET_SELECTOR,
+  INTERACTION_TARGET_TAG,
+  INTERACTION_TYPE,
+  LOG_SEVERITIES,
+} from "../../semantic-conventions";
+import { addAttribute } from "../../utils/otel";
+import { addCommonAttributes } from "../../attributes";
+import { KeyValue, LogRecord } from "../../types/otlp";
+
+const MAX_SELECTOR_LENGTH = 128;
+const MAX_SELECTOR_ANCESTORS = 3;
+const SELECTOR_BOUNDARY_TAGS = new Set(["BODY", "HTML"]);
+
+export type InteractionType = "click" | "scroll" | "key_press" | "change";
+
+export type InteractionEvent = {
+  /** Discriminator emitted as `interaction.type`. */
+  type: InteractionType;
+  /** Human-readable one-line summary; becomes the log body. */
+  title: string;
+  /** Correlation id (shared with `user_interaction.id` on attributed spans). */
+  id: string;
+  /** Derived action name; may be blank. */
+  name: string;
+  /** How the name was derived. */
+  nameSource: string;
+  /** The DOM element the interaction targeted. */
+  element: Element;
+  /** Type-specific extra attributes (e.g. key, direction, value_length). */
+  extraAttributes?: KeyValue[];
+};
+
+/** The current page path, used in every interaction title. */
+export function pagePath(): string {
+  return loc?.pathname || "/";
+}
+
+/**
+ * Shared emit path for every interaction type: identical envelope
+ * (browser.interaction event, INFO severity), a plain-string human-readable
+ * body, and the structured fields as namespaced `interaction.*` log
+ * attributes.
+ */
+export function emitInteractionEvent(evt: InteractionEvent): void {
+  const attributes: KeyValue[] = [];
+  addCommonAttributes(attributes);
+  addAttribute(attributes, EVENT_NAME, EVENT_NAMES.INTERACTION);
+  addAttribute(attributes, INTERACTION_ID, evt.id);
+  addAttribute(attributes, INTERACTION_TYPE, evt.type);
+  addAttribute(attributes, INTERACTION_NAME, evt.name);
+  addAttribute(attributes, INTERACTION_NAME_SOURCE, evt.nameSource);
+  addAttribute(attributes, INTERACTION_TARGET_SELECTOR, buildSelector(evt.element));
+  addAttribute(attributes, INTERACTION_TARGET_TAG, evt.element.tagName.toLowerCase());
+  if (evt.element.id) {
+    addAttribute(attributes, INTERACTION_TARGET_ID, evt.element.id);
+  }
+  for (const extra of evt.extraAttributes ?? []) {
+    attributes.push(extra);
+  }
+
+  const log: LogRecord = {
+    timeUnixNano: nowNanos(),
+    attributes,
+    severityNumber: LOG_SEVERITIES.INFO,
+    severityText: "INFO",
+    body: {
+      stringValue: evt.title,
+    },
+  };
+
+  sendLog(log);
+}
+
+/**
+ * Builds a compact CSS-like selector describing the interaction target:
+ * - `tag#id` when the target has an id.
+ * - `tag.firstClass` when it has classes but no id.
+ * - Otherwise, walks up to MAX_SELECTOR_ANCESTORS ancestors (each rendered the
+ *   same way) joined with " > ", since there is no id anywhere to anchor on.
+ *   The walk never crosses a BODY/HTML boundary -- those document-structure
+ *   elements are not meaningful target context.
+ * Result is capped at MAX_SELECTOR_LENGTH characters.
+ *
+ * The selector is best-effort display telemetry, NOT guaranteed valid CSS for
+ * querySelector: ids/class names are not escaped and truncation may cut
+ * mid-token.
+ */
+export function buildSelector(element: Element): string {
+  if (element.id) {
+    return truncateSelector(describeElement(element));
+  }
+
+  const parts: string[] = [describeElement(element)];
+  let current: Element | null = element;
+  for (let i = 0; i < MAX_SELECTOR_ANCESTORS; i++) {
+    current = current.parentElement;
+    if (!current || SELECTOR_BOUNDARY_TAGS.has(current.tagName)) break;
+    parts.unshift(describeElement(current));
+    if (current.id) break;
+  }
+
+  return truncateSelector(parts.join(" > "));
+}
+
+function truncateSelector(selector: string): string {
+  return selector.length > MAX_SELECTOR_LENGTH ? selector.substring(0, MAX_SELECTOR_LENGTH) : selector;
+}
+
+function describeElement(element: Element): string {
+  const tag = element.tagName.toLowerCase();
+  if (element.id) {
+    return `${tag}#${element.id}`;
+  }
+  const firstClass = element.classList.item(0);
+  return firstClass ? `${tag}.${firstClass}` : tag;
+}

--- a/src/instrumentations/interactions/emit.ts
+++ b/src/instrumentations/interactions/emit.ts
@@ -1,4 +1,4 @@
-import { loc, nowNanos } from "../../utils";
+import { nowNanos } from "../../utils";
 import { sendLog } from "../../transport";
 import {
   EVENT_NAME,
@@ -11,8 +11,10 @@ import {
   INTERACTION_TARGET_TAG,
   INTERACTION_TYPE,
   LOG_SEVERITIES,
+  PAGE_URL_ATTR_PREFIX,
+  URL_PATH,
 } from "../../semantic-conventions";
-import { addAttribute } from "../../utils/otel";
+import { addAttribute, findLastAttribute, withPrefix } from "../../utils/otel";
 import { addCommonAttributes } from "../../attributes";
 import { KeyValue, LogRecord } from "../../types/otlp";
 
@@ -20,12 +22,19 @@ const MAX_SELECTOR_LENGTH = 128;
 const MAX_SELECTOR_ANCESTORS = 3;
 const SELECTOR_BOUNDARY_TAGS = new Set(["BODY", "HTML"]);
 
+/** The attribute key `addCommonAttributes` emits the scrubbed page path under. */
+const PAGE_URL_PATH = withPrefix(PAGE_URL_ATTR_PREFIX)(URL_PATH);
+
 export type InteractionType = "click" | "scroll" | "key_press" | "change";
 
 export type InteractionEvent = {
   /** Discriminator emitted as `interaction.type`. */
   type: InteractionType;
-  /** Human-readable one-line summary; becomes the log body. */
+  /**
+   * Human-readable one-line summary *without* the page path; becomes the log
+   * body once `emitInteractionEvent` has appended ` on <path>`, using the
+   * scrubbed `page.url.path` rather than a raw `location.pathname` read.
+   */
   title: string;
   /** Correlation id (shared with `user_interaction.id` on attributed spans). */
   id: string;
@@ -39,11 +48,6 @@ export type InteractionEvent = {
   extraAttributes?: KeyValue[];
 };
 
-/** The current page path, used in every interaction title. */
-export function pagePath(): string {
-  return loc?.pathname || "/";
-}
-
 /**
  * Shared emit path for every interaction type: identical envelope
  * (browser.interaction event, INFO severity), a plain-string human-readable
@@ -53,6 +57,15 @@ export function pagePath(): string {
 export function emitInteractionEvent(evt: InteractionEvent): void {
   const attributes: KeyValue[] = [];
   addCommonAttributes(attributes);
+
+  // Read the page path back out of the attributes we just derived rather than
+  // re-reading location.pathname: addCommonAttributes has already run it
+  // through vars.urlAttributeScrubber, so the body cannot leak a segment the
+  // consumer redacted. Missing key means the scrubber dropped url.path, threw,
+  // or the url failed to parse -- in every one of those cases the path is meant
+  // to stay out of the telemetry, so the suffix is omitted entirely.
+  const scrubbedPath = findLastAttribute(attributes, PAGE_URL_PATH)?.value?.stringValue;
+
   addAttribute(attributes, EVENT_NAME, EVENT_NAMES.INTERACTION);
   addAttribute(attributes, INTERACTION_ID, evt.id);
   addAttribute(attributes, INTERACTION_TYPE, evt.type);
@@ -73,7 +86,7 @@ export function emitInteractionEvent(evt: InteractionEvent): void {
     severityNumber: LOG_SEVERITIES.INFO,
     severityText: "INFO",
     body: {
-      stringValue: evt.title,
+      stringValue: scrubbedPath ? `${evt.title} on ${scrubbedPath}` : evt.title,
     },
   };
 

--- a/src/instrumentations/interactions/emit.ts
+++ b/src/instrumentations/interactions/emit.ts
@@ -1,5 +1,8 @@
-import { elementFirstClass, elementId, elementTag, nowNanos } from "../../utils";
+import { createRateLimiter, elementFirstClass, elementId, elementTag, nowNanos } from "../../utils";
+import { debug } from "../../utils/debug";
 import { sendLog } from "../../transport";
+import { MAX_TRANSPORT_CALLS_PER_TEN_SECONDS } from "../../transport/limits";
+import { DEFAULT_MAX_INTERACTION_EVENTS_PER_TEN_SECONDS, vars } from "../../vars";
 import {
   EVENT_NAME,
   EVENT_NAMES,
@@ -25,6 +28,51 @@ const SELECTOR_BOUNDARY_TAGS = new Set(["BODY", "HTML"]);
 
 /** The attribute key `addCommonAttributes` emits the scrubbed page path under. */
 const PAGE_URL_PATH = withPrefix(PAGE_URL_ATTR_PREFIX)(URL_PATH);
+
+/**
+ * How much of a ten-minute window interactions may use, relative to their
+ * ten-second allowance. Keeps their share of the transport budget identical in
+ * both windows: the default 32/10s maps to 512/10min, which is 1/8 of the
+ * transport's 4096 -- the same ratio as 32 out of 128.
+ */
+const TEN_MINUTE_BUDGET_MULTIPLIER = 16;
+
+let rateLimiter: (() => boolean) | undefined;
+
+/**
+ * Interaction events are the highest-frequency signal the SDK produces, so they
+ * get their own budget instead of drawing on the transport-wide one in
+ * transport/index.ts. Without it a burst of interactions evicts spans, errors,
+ * page views and web vitals -- the telemetry people actually alert on -- leaving
+ * only an invisible `debug()` trace behind.
+ *
+ * Created lazily, like the transport's own limiter: createRateLimiter registers
+ * two intervals, interaction capture is opt-in, and the configured budget is
+ * only known once init() has populated vars.
+ */
+function isRateLimited(): boolean {
+  if (!rateLimiter) {
+    // Clamped explicitly rather than leaning on createRateLimiter's `|| 32`
+    // fallback, which would silently turn a configured 0 into the default.
+    const configured = vars.interactionInstrumentation.maxEventsPerTenSeconds;
+    const perTenSeconds =
+      typeof configured === "number" && isFinite(configured)
+        ? Math.max(1, Math.min(MAX_TRANSPORT_CALLS_PER_TEN_SECONDS, Math.floor(configured)))
+        : DEFAULT_MAX_INTERACTION_EVENTS_PER_TEN_SECONDS;
+
+    rateLimiter = createRateLimiter({
+      maxCallsPerTenSeconds: perTenSeconds,
+      maxCallsPerTenMinutes: perTenSeconds * TEN_MINUTE_BUDGET_MULTIPLIER,
+    });
+  }
+
+  return rateLimiter();
+}
+
+/** Test-only: forget the limiter so the next emit starts from a full budget. */
+export function resetInteractionRateLimiterForTests(): void {
+  rateLimiter = undefined;
+}
 
 export type InteractionType = "click" | "scroll" | "key_press" | "change";
 
@@ -60,8 +108,22 @@ export type InteractionEvent = {
  * cannot send unbounded strings on every interaction -- and is read through the
  * clobber-safe accessors in utils/dom, since a `<form>` target's `id`/`tagName`
  * can be shadowed by its own named controls.
+ *
+ * Interactions over their own rate-limit budget are dropped here, ahead of any
+ * attribute derivation, so a spent budget also takes the selector and text
+ * reads off the input-delay path. Note that the callers register their active
+ * interaction *before* calling this, deliberately: a dropped log may leave a
+ * span carrying a `user_interaction.id` with no matching log record, but the
+ * span still carries `user_interaction.name`, whereas rate-limiting the
+ * registration itself would silently break click-to-request correlation under
+ * exactly the load where it is most interesting.
  */
 export function emitInteractionEvent(evt: InteractionEvent): void {
+  if (isRateLimited()) {
+    debug("Dash0 interaction rate limit reached. Will not send interaction event.", evt.type);
+    return;
+  }
+
   const attributes: KeyValue[] = [];
   addCommonAttributes(attributes);
 

--- a/src/instrumentations/interactions/emit.ts
+++ b/src/instrumentations/interactions/emit.ts
@@ -1,4 +1,4 @@
-import { nowNanos } from "../../utils";
+import { elementFirstClass, elementId, elementTag, nowNanos } from "../../utils";
 import { sendLog } from "../../transport";
 import {
   EVENT_NAME,
@@ -18,7 +18,8 @@ import { addAttribute, findLastAttribute, withPrefix } from "../../utils/otel";
 import { addCommonAttributes } from "../../attributes";
 import { KeyValue, LogRecord } from "../../types/otlp";
 
-const MAX_SELECTOR_LENGTH = 128;
+/** Shared cap for the two target descriptors: `target.selector` and `target.id`. */
+const MAX_TARGET_VALUE_LENGTH = 128;
 const MAX_SELECTOR_ANCESTORS = 3;
 const SELECTOR_BOUNDARY_TAGS = new Set(["BODY", "HTML"]);
 
@@ -53,6 +54,12 @@ export type InteractionEvent = {
  * (browser.interaction event, INFO severity), a plain-string human-readable
  * body, and the structured fields as namespaced `interaction.*` log
  * attributes.
+ *
+ * Every target descriptor is bounded -- `target.id` shares the selector's
+ * MAX_TARGET_VALUE_LENGTH cap so a page with generated or state-carrying ids
+ * cannot send unbounded strings on every interaction -- and is read through the
+ * clobber-safe accessors in utils/dom, since a `<form>` target's `id`/`tagName`
+ * can be shadowed by its own named controls.
  */
 export function emitInteractionEvent(evt: InteractionEvent): void {
   const attributes: KeyValue[] = [];
@@ -72,9 +79,10 @@ export function emitInteractionEvent(evt: InteractionEvent): void {
   addAttribute(attributes, INTERACTION_NAME, evt.name);
   addAttribute(attributes, INTERACTION_NAME_SOURCE, evt.nameSource);
   addAttribute(attributes, INTERACTION_TARGET_SELECTOR, buildSelector(evt.element));
-  addAttribute(attributes, INTERACTION_TARGET_TAG, evt.element.tagName.toLowerCase());
-  if (evt.element.id) {
-    addAttribute(attributes, INTERACTION_TARGET_ID, evt.element.id);
+  addAttribute(attributes, INTERACTION_TARGET_TAG, elementTag(evt.element).toLowerCase());
+  const targetId = elementId(evt.element);
+  if (targetId) {
+    addAttribute(attributes, INTERACTION_TARGET_ID, capTargetValue(targetId));
   }
   for (const extra of evt.extraAttributes ?? []) {
     attributes.push(extra);
@@ -101,38 +109,39 @@ export function emitInteractionEvent(evt: InteractionEvent): void {
  *   same way) joined with " > ", since there is no id anywhere to anchor on.
  *   The walk never crosses a BODY/HTML boundary -- those document-structure
  *   elements are not meaningful target context.
- * Result is capped at MAX_SELECTOR_LENGTH characters.
+ * Result is capped at MAX_TARGET_VALUE_LENGTH characters.
  *
  * The selector is best-effort display telemetry, NOT guaranteed valid CSS for
  * querySelector: ids/class names are not escaped and truncation may cut
  * mid-token.
  */
 export function buildSelector(element: Element): string {
-  if (element.id) {
-    return truncateSelector(describeElement(element));
+  if (elementId(element)) {
+    return capTargetValue(describeElement(element));
   }
 
   const parts: string[] = [describeElement(element)];
   let current: Element | null = element;
   for (let i = 0; i < MAX_SELECTOR_ANCESTORS; i++) {
     current = current.parentElement;
-    if (!current || SELECTOR_BOUNDARY_TAGS.has(current.tagName)) break;
+    if (!current || SELECTOR_BOUNDARY_TAGS.has(elementTag(current))) break;
     parts.unshift(describeElement(current));
-    if (current.id) break;
+    if (elementId(current)) break;
   }
 
-  return truncateSelector(parts.join(" > "));
+  return capTargetValue(parts.join(" > "));
 }
 
-function truncateSelector(selector: string): string {
-  return selector.length > MAX_SELECTOR_LENGTH ? selector.substring(0, MAX_SELECTOR_LENGTH) : selector;
+function capTargetValue(value: string): string {
+  return value.length > MAX_TARGET_VALUE_LENGTH ? value.substring(0, MAX_TARGET_VALUE_LENGTH) : value;
 }
 
 function describeElement(element: Element): string {
-  const tag = element.tagName.toLowerCase();
-  if (element.id) {
-    return `${tag}#${element.id}`;
+  const tag = elementTag(element).toLowerCase();
+  const id = elementId(element);
+  if (id) {
+    return `${tag}#${id}`;
   }
-  const firstClass = element.classList.item(0);
+  const firstClass = elementFirstClass(element);
   return firstClass ? `${tag}.${firstClass}` : tag;
 }

--- a/src/instrumentations/interactions/emit.ts
+++ b/src/instrumentations/interactions/emit.ts
@@ -95,6 +95,14 @@ export type InteractionEvent = {
   element: Element;
   /** Type-specific extra attributes (e.g. key, direction, value_length). */
   extraAttributes?: KeyValue[];
+  /**
+   * Event time in epoch nanoseconds; defaults to now. Producers that coalesce a
+   * burst of DOM events pass the time the burst *started*, so an event emitted
+   * once the settle timer fires is still ordered by when the user acted -- which
+   * is what keeps a coalesced key press and a coalesced change orderable against
+   * each other, since they settle on independent timers.
+   */
+  timeUnixNano?: string;
 };
 
 /**
@@ -151,7 +159,7 @@ export function emitInteractionEvent(evt: InteractionEvent): void {
   }
 
   const log: LogRecord = {
-    timeUnixNano: nowNanos(),
+    timeUnixNano: evt.timeUnixNano ?? nowNanos(),
     attributes,
     severityNumber: LOG_SEVERITIES.INFO,
     severityText: "INFO",

--- a/src/instrumentations/interactions/emit_test.ts
+++ b/src/instrumentations/interactions/emit_test.ts
@@ -1,0 +1,150 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { vars } from "../../vars";
+import { sendLog } from "../../transport";
+import { doc } from "../../utils/globals";
+import { INTERACTION_TARGET_ID, INTERACTION_TARGET_SELECTOR, INTERACTION_TARGET_TAG } from "../../semantic-conventions";
+import type { LogRecord } from "../../types/otlp";
+
+vi.mock("../../transport", () => ({
+  sendLog: vi.fn(),
+}));
+
+import { buildSelector, emitInteractionEvent } from "./emit";
+
+// Vitest runs these tests in jsdom, so the SSR-safe doc is always defined.
+const dom = doc!;
+
+const MAX_TARGET_VALUE_LENGTH = 128;
+
+/**
+ * Simulates DOM clobbering. In a real browser `<form><input name="id"></form>`
+ * makes `form.id` return the input element: HTMLFormElement is
+ * `[LegacyOverrideBuiltIns]`, so its named getter installs own properties that
+ * shadow the `Element.prototype` accessors. jsdom does not implement that
+ * shadowing (verified: `form.id` stays a string), so the own property is installed
+ * by hand here. The markup that triggers it for real is covered by the e2e fixture
+ * in test/e2e/spec/10-interactions.
+ */
+function clobber(element: Element, property: string, value: unknown): void {
+  Object.defineProperty(element, property, { value, configurable: true, writable: true });
+}
+
+function emit(element: Element): void {
+  emitInteractionEvent({
+    type: "click",
+    title: "Click test",
+    id: "0123456789abcdef",
+    name: "test",
+    nameSource: "custom_attribute",
+    element,
+  });
+}
+
+describe("interaction event emission", () => {
+  beforeEach(() => {
+    dom.body.innerHTML = "";
+    vars.interactionInstrumentation = { enabled: true, actionNameAttribute: "data-dash0-action-name" };
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function lastLog(): LogRecord {
+    const calls = (sendLog as ReturnType<typeof vi.fn>).mock.calls;
+    expect(calls.length).toBeGreaterThan(0);
+    return calls[calls.length - 1]![0] as LogRecord;
+  }
+
+  function attribute(key: string): unknown {
+    return lastLog().attributes?.find((kv) => kv.key === key)?.value;
+  }
+
+  describe("interaction.target.id", () => {
+    it("emits the id as a string", () => {
+      dom.body.innerHTML = `<button id="btn">Save</button>`;
+      emit(dom.getElementById("btn")!);
+
+      expect(attribute(INTERACTION_TARGET_ID)).toEqual({ stringValue: "btn" });
+    });
+
+    it("omits the attribute entirely when the element has no id", () => {
+      dom.body.innerHTML = `<button class="btn">Save</button>`;
+      emit(dom.querySelector("button")!);
+
+      expect(lastLog().attributes?.map((kv) => kv.key)).not.toContain(INTERACTION_TARGET_ID);
+    });
+
+    it("caps a long id at the same length as the selector", () => {
+      // Generated ids and ids carrying encoded state are unbounded in the wild, and
+      // this attribute ships on every single interaction.
+      const longId = "x".repeat(500);
+      dom.body.innerHTML = `<button id="${longId}">Save</button>`;
+      emit(dom.getElementById(longId)!);
+
+      expect(attribute(INTERACTION_TARGET_ID)).toEqual({
+        stringValue: "x".repeat(MAX_TARGET_VALUE_LENGTH),
+      });
+    });
+
+    it("caps at exactly the boundary, leaving a MAX_TARGET_VALUE_LENGTH id untouched", () => {
+      const exactId = "y".repeat(MAX_TARGET_VALUE_LENGTH);
+      dom.body.innerHTML = `<button id="${exactId}">Save</button>`;
+      emit(dom.getElementById(exactId)!);
+
+      expect(attribute(INTERACTION_TARGET_ID)).toEqual({ stringValue: exactId });
+    });
+  });
+
+  describe("DOM-clobbered targets", () => {
+    it("reports the real id of a form whose id property is shadowed by a named control", () => {
+      dom.body.innerHTML = `<form id="checkout"><input name="id" value="42" /></form>`;
+      const form = dom.getElementById("checkout")!;
+      clobber(form, "id", form.querySelector("input"));
+
+      emit(form);
+
+      // Without the clobber-safe read this ships as an empty kvlistValue, because
+      // toAnyValue falls through to its object branch for an Element.
+      expect(attribute(INTERACTION_TARGET_ID)).toEqual({ stringValue: "checkout" });
+      expect(attribute(INTERACTION_TARGET_SELECTOR)).toEqual({ stringValue: "form#checkout" });
+    });
+
+    it("reports the real tag of a form whose tagName property is shadowed", () => {
+      dom.body.innerHTML = `<form id="checkout"><input name="tagName" /></form>`;
+      const form = dom.getElementById("checkout")!;
+      clobber(form, "tagName", form.querySelector("input"));
+
+      emit(form);
+
+      expect(attribute(INTERACTION_TARGET_TAG)).toEqual({ stringValue: "form" });
+      expect(attribute(INTERACTION_TARGET_SELECTOR)).toEqual({ stringValue: "form#checkout" });
+    });
+
+    it("derives the class-based selector of a form whose classList is shadowed", () => {
+      dom.body.innerHTML = `<form class="checkout-form wide"><input name="classList" /></form>`;
+      const form = dom.querySelector("form")!;
+      clobber(form, "classList", form.querySelector("input"));
+
+      emit(form);
+
+      expect(attribute(INTERACTION_TARGET_SELECTOR)).toEqual({ stringValue: "form.checkout-form" });
+    });
+
+    it("anchors the ancestor walk on a clobbered form's real id", () => {
+      dom.body.innerHTML = `
+        <form id="checkout" class="form">
+          <input name="id" value="42" />
+          <div class="row"><span class="cell">Total</span></div>
+        </form>`;
+      const form = dom.getElementById("checkout")!;
+      clobber(form, "id", form.querySelector("input"));
+
+      // The walk must stop at the form because it has an id, and render that id --
+      // reading `.id` naively both breaks the anchor rendering and, being truthy,
+      // still ends the walk, so only the rendering is visibly wrong.
+      expect(buildSelector(dom.querySelector(".cell")!)).toBe("form#checkout > div.row > span.cell");
+    });
+  });
+});

--- a/src/instrumentations/interactions/emit_test.ts
+++ b/src/instrumentations/interactions/emit_test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { vars } from "../../vars";
+import { DEFAULT_MAX_INTERACTION_EVENTS_PER_TEN_SECONDS, vars } from "../../vars";
+import { MAX_TRANSPORT_CALLS_PER_TEN_SECONDS } from "../../transport/limits";
 import { sendLog } from "../../transport";
 import { doc } from "../../utils/globals";
 import { INTERACTION_TARGET_ID, INTERACTION_TARGET_SELECTOR, INTERACTION_TARGET_TAG } from "../../semantic-conventions";
@@ -9,7 +10,7 @@ vi.mock("../../transport", () => ({
   sendLog: vi.fn(),
 }));
 
-import { buildSelector, emitInteractionEvent } from "./emit";
+import { buildSelector, emitInteractionEvent, resetInteractionRateLimiterForTests } from "./emit";
 
 // Vitest runs these tests in jsdom, so the SSR-safe doc is always defined.
 const dom = doc!;
@@ -44,6 +45,9 @@ describe("interaction event emission", () => {
   beforeEach(() => {
     dom.body.innerHTML = "";
     vars.interactionInstrumentation = { enabled: true, actionNameAttribute: "data-dash0-action-name" };
+    // The limiter is module state built on first emit, so without this the
+    // budget spent by one test case is missing from the next one.
+    resetInteractionRateLimiterForTests();
     vi.clearAllMocks();
   });
 
@@ -145,6 +149,62 @@ describe("interaction event emission", () => {
       // reading `.id` naively both breaks the anchor rendering and, being truthy,
       // still ends the walk, so only the rendering is visibly wrong.
       expect(buildSelector(dom.querySelector(".cell")!)).toBe("form#checkout > div.row > span.cell");
+    });
+  });
+
+  describe("rate limiting", () => {
+    function sentCount(): number {
+      return (sendLog as ReturnType<typeof vi.fn>).mock.calls.length;
+    }
+
+    function emitTimes(count: number): void {
+      dom.body.innerHTML = `<button id="btn">Save</button>`;
+      const button = dom.getElementById("btn")!;
+      for (let i = 0; i < count; i++) {
+        emit(button);
+      }
+    }
+
+    it("emits up to the default per-ten-second budget and silently drops the rest", () => {
+      // The budget exists so a burst of interactions cannot evict spans, errors
+      // and web vitals from the shared transport budget.
+      emitTimes(DEFAULT_MAX_INTERACTION_EVENTS_PER_TEN_SECONDS + 20);
+
+      expect(sentCount()).toBe(DEFAULT_MAX_INTERACTION_EVENTS_PER_TEN_SECONDS);
+    });
+
+    it("honours a configured budget", () => {
+      vars.interactionInstrumentation.maxEventsPerTenSeconds = 4;
+
+      emitTimes(10);
+
+      expect(sentCount()).toBe(4);
+    });
+
+    it("clamps a budget above the transport ceiling, so interactions can never exceed it", () => {
+      vars.interactionInstrumentation.maxEventsPerTenSeconds = 100_000;
+
+      emitTimes(MAX_TRANSPORT_CALLS_PER_TEN_SECONDS + 5);
+
+      expect(sentCount()).toBe(MAX_TRANSPORT_CALLS_PER_TEN_SECONDS);
+    });
+
+    it("clamps a zero budget up to one event instead of falling back to the default", () => {
+      // createRateLimiter treats a falsy limit as "unset" and substitutes 32, so
+      // 0 has to be clamped before it gets there.
+      vars.interactionInstrumentation.maxEventsPerTenSeconds = 0;
+
+      emitTimes(5);
+
+      expect(sentCount()).toBe(1);
+    });
+
+    it("falls back to the default when the configured budget is not a usable number", () => {
+      vars.interactionInstrumentation.maxEventsPerTenSeconds = NaN;
+
+      emitTimes(DEFAULT_MAX_INTERACTION_EVENTS_PER_TEN_SECONDS + 5);
+
+      expect(sentCount()).toBe(DEFAULT_MAX_INTERACTION_EVENTS_PER_TEN_SECONDS);
     });
   });
 });

--- a/src/instrumentations/interactions/index.ts
+++ b/src/instrumentations/interactions/index.ts
@@ -6,13 +6,15 @@ import { startChangeInstrumentation } from "./change";
 
 export function startInteractionInstrumentation() {
   startClickInstrumentation();
-  if (vars.interactionInstrumentation.captureScrolls !== false) {
+  // Scroll/key-press/change capture are individually opt-in: enabling
+  // interaction instrumentation alone only captures clicks.
+  if (vars.interactionInstrumentation.captureScrolls === true) {
     startScrollInstrumentation();
   }
-  if (vars.interactionInstrumentation.captureKeyPresses !== false) {
+  if (vars.interactionInstrumentation.captureKeyPresses === true) {
     startKeyPressInstrumentation();
   }
-  if (vars.interactionInstrumentation.captureChanges !== false) {
+  if (vars.interactionInstrumentation.captureChanges === true) {
     startChangeInstrumentation();
   }
 }

--- a/src/instrumentations/interactions/index.ts
+++ b/src/instrumentations/interactions/index.ts
@@ -1,0 +1,3 @@
+export function startInteractionInstrumentation() {
+  // Implemented in Task 5 (click.ts composition).
+}

--- a/src/instrumentations/interactions/index.ts
+++ b/src/instrumentations/interactions/index.ts
@@ -1,3 +1,5 @@
+import { startClickInstrumentation } from "./click";
+
 export function startInteractionInstrumentation() {
-  // Implemented in Task 5 (click.ts composition).
+  startClickInstrumentation();
 }

--- a/src/instrumentations/interactions/index.ts
+++ b/src/instrumentations/interactions/index.ts
@@ -1,5 +1,18 @@
+import { vars } from "../../vars";
 import { startClickInstrumentation } from "./click";
+import { startScrollInstrumentation } from "./scroll";
+import { startKeyPressInstrumentation } from "./keypress";
+import { startChangeInstrumentation } from "./change";
 
 export function startInteractionInstrumentation() {
   startClickInstrumentation();
+  if (vars.interactionInstrumentation.captureScrolls !== false) {
+    startScrollInstrumentation();
+  }
+  if (vars.interactionInstrumentation.captureKeyPresses !== false) {
+    startKeyPressInstrumentation();
+  }
+  if (vars.interactionInstrumentation.captureChanges !== false) {
+    startChangeInstrumentation();
+  }
 }

--- a/src/instrumentations/interactions/index_test.ts
+++ b/src/instrumentations/interactions/index_test.ts
@@ -1,16 +1,56 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { vars } from "../../vars";
 
 vi.mock("./click", () => ({
   startClickInstrumentation: vi.fn(),
 }));
+vi.mock("./scroll", () => ({
+  startScrollInstrumentation: vi.fn(),
+}));
+vi.mock("./keypress", () => ({
+  startKeyPressInstrumentation: vi.fn(),
+}));
+vi.mock("./change", () => ({
+  startChangeInstrumentation: vi.fn(),
+}));
 
 import { startInteractionInstrumentation } from "./index";
 import { startClickInstrumentation } from "./click";
+import { startScrollInstrumentation } from "./scroll";
+import { startKeyPressInstrumentation } from "./keypress";
+import { startChangeInstrumentation } from "./change";
 
 describe("startInteractionInstrumentation", () => {
-  it("starts click instrumentation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vars.interactionInstrumentation = {
+      enabled: true,
+      actionNameAttribute: "data-dash0-action-name",
+      captureScrolls: true,
+      captureKeyPresses: true,
+      captureChanges: true,
+    };
+  });
+
+  it("starts all four interaction instrumentations by default", () => {
     startInteractionInstrumentation();
 
     expect(startClickInstrumentation).toHaveBeenCalledOnce();
+    expect(startScrollInstrumentation).toHaveBeenCalledOnce();
+    expect(startKeyPressInstrumentation).toHaveBeenCalledOnce();
+    expect(startChangeInstrumentation).toHaveBeenCalledOnce();
+  });
+
+  it("honors the capture* opt-outs while clicks stay on", () => {
+    vars.interactionInstrumentation.captureScrolls = false;
+    vars.interactionInstrumentation.captureKeyPresses = false;
+    vars.interactionInstrumentation.captureChanges = false;
+
+    startInteractionInstrumentation();
+
+    expect(startClickInstrumentation).toHaveBeenCalledOnce();
+    expect(startScrollInstrumentation).not.toHaveBeenCalled();
+    expect(startKeyPressInstrumentation).not.toHaveBeenCalled();
+    expect(startChangeInstrumentation).not.toHaveBeenCalled();
   });
 });

--- a/src/instrumentations/interactions/index_test.ts
+++ b/src/instrumentations/interactions/index_test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("./click", () => ({
+  startClickInstrumentation: vi.fn(),
+}));
+
+import { startInteractionInstrumentation } from "./index";
+import { startClickInstrumentation } from "./click";
+
+describe("startInteractionInstrumentation", () => {
+  it("starts click instrumentation", () => {
+    startInteractionInstrumentation();
+
+    expect(startClickInstrumentation).toHaveBeenCalledOnce();
+  });
+});

--- a/src/instrumentations/interactions/index_test.ts
+++ b/src/instrumentations/interactions/index_test.ts
@@ -26,13 +26,26 @@ describe("startInteractionInstrumentation", () => {
     vars.interactionInstrumentation = {
       enabled: true,
       actionNameAttribute: "data-dash0-action-name",
-      captureScrolls: true,
-      captureKeyPresses: true,
-      captureChanges: true,
+      captureScrolls: false,
+      captureKeyPresses: false,
+      captureChanges: false,
     };
   });
 
-  it("starts all four interaction instrumentations by default", () => {
+  it("starts only click instrumentation by default", () => {
+    startInteractionInstrumentation();
+
+    expect(startClickInstrumentation).toHaveBeenCalledOnce();
+    expect(startScrollInstrumentation).not.toHaveBeenCalled();
+    expect(startKeyPressInstrumentation).not.toHaveBeenCalled();
+    expect(startChangeInstrumentation).not.toHaveBeenCalled();
+  });
+
+  it("starts scroll/key-press/change capture when opted in", () => {
+    vars.interactionInstrumentation.captureScrolls = true;
+    vars.interactionInstrumentation.captureKeyPresses = true;
+    vars.interactionInstrumentation.captureChanges = true;
+
     startInteractionInstrumentation();
 
     expect(startClickInstrumentation).toHaveBeenCalledOnce();
@@ -41,10 +54,11 @@ describe("startInteractionInstrumentation", () => {
     expect(startChangeInstrumentation).toHaveBeenCalledOnce();
   });
 
-  it("honors the capture* opt-outs while clicks stay on", () => {
-    vars.interactionInstrumentation.captureScrolls = false;
-    vars.interactionInstrumentation.captureKeyPresses = false;
-    vars.interactionInstrumentation.captureChanges = false;
+  it("does not start the extra capture types when the flags are absent", () => {
+    vars.interactionInstrumentation = {
+      enabled: true,
+      actionNameAttribute: "data-dash0-action-name",
+    };
 
     startInteractionInstrumentation();
 

--- a/src/instrumentations/interactions/keypress.ts
+++ b/src/instrumentations/interactions/keypress.ts
@@ -1,4 +1,4 @@
-import { win } from "../../utils";
+import { generateUniqueId, win, WEB_EVENT_ID_BYTES } from "../../utils";
 import { debug } from "../../utils/debug";
 import { addAttribute } from "../../utils/otel";
 import { INTERACTION_KEY } from "../../semantic-conventions";
@@ -30,6 +30,16 @@ const CAPTURED_KEYS = new Set([
   "Home",
   "End",
 ]);
+
+/**
+ * Only these keys register for HTTP span attribution: Enter and Space are the
+ * keys that activate a control or submit a form, so a request that follows is
+ * plausibly caused by them. Navigation keys (arrows, Tab, PageUp/Down, ...)
+ * still emit an interaction event but must not claim the active-interaction
+ * slot -- arrowing through a list would steal attribution from a real click
+ * or stamp unrelated background requests.
+ */
+const ACTIVATION_KEYS = new Set(["Enter", " "]);
 
 let listenerAttached = false;
 
@@ -68,9 +78,12 @@ export function handleKeydown(event: KeyboardEvent): void {
     const key = event.key === " " ? "Space" : event.key;
     const { name, nameSource } = deriveActionName(element, vars.interactionInstrumentation.actionNameAttribute!);
 
-    // Enter/Space frequently activate a control or submit a form, so register
-    // the interaction for HTTP span attribution just like a click.
-    const interaction = registerActiveInteraction(name);
+    // Enter/Space activate a control or submit a form, so they register for
+    // HTTP span attribution just like a click; navigation keys only get an
+    // event id of their own (see ACTIVATION_KEYS).
+    const id = ACTIVATION_KEYS.has(event.key)
+      ? registerActiveInteraction(name).id
+      : generateUniqueId(WEB_EVENT_ID_BYTES);
 
     const extraAttributes: KeyValue[] = [];
     addAttribute(extraAttributes, INTERACTION_KEY, key);
@@ -80,7 +93,7 @@ export function handleKeydown(event: KeyboardEvent): void {
       // Press Enter in "Search parts" on /inventory/parts
       // Press Escape on /playground              (no derivable target name)
       title: name ? `Press ${key} in "${name}" on ${pagePath()}` : `Press ${key} on ${pagePath()}`,
-      id: interaction.id,
+      id,
       name,
       nameSource,
       element,

--- a/src/instrumentations/interactions/keypress.ts
+++ b/src/instrumentations/interactions/keypress.ts
@@ -1,0 +1,92 @@
+import { win } from "../../utils";
+import { debug } from "../../utils/debug";
+import { addAttribute } from "../../utils/otel";
+import { INTERACTION_KEY } from "../../semantic-conventions";
+import { KeyValue } from "../../types/otlp";
+import { vars } from "../../vars";
+import { deriveActionName } from "./action-name";
+import { registerActiveInteraction } from "./active-interaction";
+import { emitInteractionEvent, pagePath } from "./emit";
+
+/**
+ * Only these navigation/activation keys are ever captured. Printable
+ * characters (letters, digits, punctuation) are deliberately excluded --
+ * capturing them would amount to keylogging. This is an allow-list, not a
+ * block-list, so anything unknown is dropped by default.
+ */
+const CAPTURED_KEYS = new Set([
+  "Enter",
+  "Tab",
+  "Escape",
+  " ", // reported as "Space"
+  "ArrowUp",
+  "ArrowDown",
+  "ArrowLeft",
+  "ArrowRight",
+  "Backspace",
+  "Delete",
+  "PageUp",
+  "PageDown",
+  "Home",
+  "End",
+]);
+
+let listenerAttached = false;
+
+function onWindowKeydown(event: KeyboardEvent) {
+  if (!event.isTrusted) return;
+  handleKeydown(event);
+}
+
+export function startKeyPressInstrumentation() {
+  if (listenerAttached) return;
+  if (!win) return;
+
+  win.addEventListener("keydown", onWindowKeydown as EventListener, { capture: true });
+  listenerAttached = true;
+}
+
+export function stopKeyPressInstrumentationForTests() {
+  if (!listenerAttached || !win) return;
+  win.removeEventListener("keydown", onWindowKeydown as EventListener, { capture: true } as EventListenerOptions);
+  listenerAttached = false;
+}
+
+/**
+ * Exported for tests (bypasses the isTrusted gate, same pattern as
+ * click.ts/handleClick).
+ */
+export function handleKeydown(event: KeyboardEvent): void {
+  try {
+    if (event.repeat) return; // holding a key down is one interaction, not many
+    if (!CAPTURED_KEYS.has(event.key)) return;
+
+    const target = event.target;
+    if (!target || (target as Node).nodeType !== 1) return;
+    const element = target as Element;
+
+    const key = event.key === " " ? "Space" : event.key;
+    const { name, nameSource } = deriveActionName(element, vars.interactionInstrumentation.actionNameAttribute!);
+
+    // Enter/Space frequently activate a control or submit a form, so register
+    // the interaction for HTTP span attribution just like a click.
+    const interaction = registerActiveInteraction(name);
+
+    const extraAttributes: KeyValue[] = [];
+    addAttribute(extraAttributes, INTERACTION_KEY, key);
+
+    emitInteractionEvent({
+      type: "key_press",
+      // Press Enter in "Search parts" on /inventory/parts
+      // Press Escape on /playground              (no derivable target name)
+      title: name ? `Press ${key} in "${name}" on ${pagePath()}` : `Press ${key} on ${pagePath()}`,
+      id: interaction.id,
+      name,
+      nameSource,
+      element,
+      extraAttributes,
+    });
+  } catch (err) {
+    debug("Dash0 interaction instrumentation failed to process a keydown event.", err);
+  }
+}

--- a/src/instrumentations/interactions/keypress.ts
+++ b/src/instrumentations/interactions/keypress.ts
@@ -1,9 +1,11 @@
-import { generateUniqueId, win, WEB_EVENT_ID_BYTES } from "../../utils";
+import { generateUniqueId, nowNanos, win, WEB_EVENT_ID_BYTES } from "../../utils";
 import { debug } from "../../utils/debug";
+import { onLastChance } from "../../utils/on-last-chance";
+import { setTimeout, clearTimeout } from "../../utils/timers";
 import { addAttribute } from "../../utils/otel";
-import { INTERACTION_KEY } from "../../semantic-conventions";
+import { INTERACTION_KEY, INTERACTION_REPEAT_COUNT } from "../../semantic-conventions";
 import { KeyValue } from "../../types/otlp";
-import { resolveActionName } from "./action-name";
+import { ActionNameSource, resolveActionName } from "./action-name";
 import { registerActiveInteraction } from "./active-interaction";
 import { emitInteractionEvent } from "./emit";
 
@@ -40,7 +42,41 @@ const CAPTURED_KEYS = new Set([
  */
 const ACTIVATION_KEYS = new Set(["Enter", " "]);
 
+/**
+ * Repeated presses of the SAME key on the SAME element collapse into one
+ * telemetry event carrying a repeat count, finalized this long after the last
+ * press. Ordinary prose typing produces a press per word boundary and per
+ * correction, so without this the space bar and Backspace alone can dominate the
+ * interaction budget: a twelve-word sentence becomes one event instead of
+ * twelve.
+ *
+ * Pressing a *different* key, or the same key on a different element, finalizes
+ * the pending burst immediately, so emission order still follows press order.
+ *
+ * Enter is deliberately exempt (see handleKeydown): it is low-frequency, and it
+ * is the key most likely to have caused a request, so its event should not wait
+ * on a settle timer.
+ */
+export const KEYPRESS_SETTLE_MILLIS = 300;
+
+/** A run of presses of one key on one element, pending emission. */
+type KeyPressBurst = {
+  element: Element;
+  /** Display form of the key, e.g. "Space" rather than " ". */
+  key: string;
+  /** Correlation id, shared by every span attributed during the burst. */
+  id: string;
+  name: string;
+  nameSource: ActionNameSource;
+  count: number;
+  /** When the burst started, so a delayed emission is not timestamped late. */
+  timeUnixNano: string;
+  settleTimeout: ReturnType<typeof setTimeout> | null;
+};
+
 let listenerAttached = false;
+let unloadHookRegistered = false;
+let burst: KeyPressBurst | undefined;
 
 function onWindowKeydown(event: KeyboardEvent) {
   if (!event.isTrusted) return;
@@ -53,9 +89,24 @@ export function startKeyPressInstrumentation() {
 
   win.addEventListener("keydown", onWindowKeydown as EventListener, { capture: true });
   listenerAttached = true;
+
+  // A coalesced burst is otherwise only emitted once its settle timer fires, so
+  // pressing a key and immediately navigating away would drop it. See the long
+  // form of this reasoning -- including why the log still reaches the wire
+  // despite the transport registering its own onLastChance first -- in scroll.ts.
+  if (!unloadHookRegistered) {
+    unloadHookRegistered = true;
+    onLastChance(flushBurst);
+  }
 }
 
 export function stopKeyPressInstrumentationForTests() {
+  // Before the guard below: an in-flight burst and its pending settle timer must
+  // not leak into the next test case, even one that never attached a listener.
+  if (burst?.settleTimeout != null) clearTimeout(burst.settleTimeout);
+  burst = undefined;
+  // unloadHookRegistered is deliberately NOT reset: onLastChance listeners
+  // cannot be removed, so clearing the flag would only register a second set.
   if (!listenerAttached || !win) return;
   win.removeEventListener("keydown", onWindowKeydown as EventListener, { capture: true } as EventListenerOptions);
   listenerAttached = false;
@@ -77,28 +128,99 @@ export function handleKeydown(event: KeyboardEvent): void {
     const key = event.key === " " ? "Space" : event.key;
     const { name, nameSource } = resolveActionName(element);
 
+    if (event.key === "Enter") {
+      // Emitted straight away, so anything still pending has to go out first to
+      // keep emission order aligned with press order.
+      flushBurst();
+      emitKeyPress({
+        element,
+        key,
+        id: registerActiveInteraction(name).id,
+        name,
+        nameSource,
+        count: 1,
+        timeUnixNano: nowNanos(),
+      });
+      return;
+    }
+
     // Enter/Space activate a control or submit a form, so they register for
     // HTTP span attribution just like a click; navigation keys only get an
     // event id of their own (see ACTIVATION_KEYS).
-    const id = ACTIVATION_KEYS.has(event.key)
-      ? registerActiveInteraction(name).id
-      : generateUniqueId(WEB_EVENT_ID_BYTES);
+    const isActivation = ACTIVATION_KEYS.has(event.key);
 
-    const extraAttributes: KeyValue[] = [];
-    addAttribute(extraAttributes, INTERACTION_KEY, key);
+    const extending = burst?.element === element && burst?.key === key ? burst : undefined;
+    if (extending) {
+      extending.count++;
+      // Re-registering on the burst's own id keeps the attribution window alive
+      // across the burst without minting ids no log record will ever carry.
+      if (isActivation) registerActiveInteraction(name, extending.id);
+    } else {
+      flushBurst(); // a different key or target ends the previous burst
+      burst = {
+        element,
+        key,
+        id: isActivation ? registerActiveInteraction(name).id : generateUniqueId(WEB_EVENT_ID_BYTES),
+        name,
+        nameSource,
+        count: 1,
+        timeUnixNano: nowNanos(),
+        settleTimeout: null,
+      };
+    }
 
-    emitInteractionEvent({
-      type: "key_press",
-      // Press Enter in "Search parts"   (emit appends ` on <scrubbed page path>`)
-      // Press Escape                     (no derivable target name)
-      title: name ? `Press ${key} in "${name}"` : `Press ${key}`,
-      id,
-      name,
-      nameSource,
-      element,
-      extraAttributes,
-    });
+    // Either branch above leaves `burst` as the pending one.
+    const pending = burst!;
+    if (pending.settleTimeout != null) clearTimeout(pending.settleTimeout);
+    pending.settleTimeout = setTimeout(() => finalizeBurst(), KEYPRESS_SETTLE_MILLIS);
   } catch (err) {
     debug("Dash0 interaction instrumentation failed to process a keydown event.", err);
   }
+}
+
+function finalizeBurst(): void {
+  const finished = burst;
+  burst = undefined;
+  if (!finished) return;
+
+  try {
+    emitKeyPress(finished);
+  } catch (err) {
+    debug("Dash0 interaction instrumentation failed to finalize a key press burst.", err);
+  }
+}
+
+/** Finalizes the pending burst now, without waiting for the settle timer. */
+function flushBurst(): void {
+  if (burst?.settleTimeout != null) clearTimeout(burst.settleTimeout);
+  finalizeBurst();
+}
+
+/** Test-only: force-finalize the pending burst without waiting for the settle timer. */
+export function flushKeyPressBurstForTests(): void {
+  flushBurst();
+}
+
+function emitKeyPress(press: Omit<KeyPressBurst, "settleTimeout">): void {
+  const extraAttributes: KeyValue[] = [];
+  addAttribute(extraAttributes, INTERACTION_KEY, press.key);
+  if (press.count > 1) {
+    addAttribute(extraAttributes, INTERACTION_REPEAT_COUNT, press.count);
+  }
+
+  const repetition = press.count > 1 ? ` ${press.count} times` : "";
+
+  emitInteractionEvent({
+    type: "key_press",
+    // Press Enter in "Search parts"        (emit appends ` on <scrubbed page path>`)
+    // Press Backspace 7 times in "Notes"   (a coalesced burst)
+    // Press Escape                         (no derivable target name)
+    title: press.name ? `Press ${press.key}${repetition} in "${press.name}"` : `Press ${press.key}${repetition}`,
+    id: press.id,
+    name: press.name,
+    nameSource: press.nameSource,
+    element: press.element,
+    extraAttributes,
+    timeUnixNano: press.timeUnixNano,
+  });
 }

--- a/src/instrumentations/interactions/keypress.ts
+++ b/src/instrumentations/interactions/keypress.ts
@@ -3,8 +3,7 @@ import { debug } from "../../utils/debug";
 import { addAttribute } from "../../utils/otel";
 import { INTERACTION_KEY } from "../../semantic-conventions";
 import { KeyValue } from "../../types/otlp";
-import { vars } from "../../vars";
-import { deriveActionName } from "./action-name";
+import { resolveActionName } from "./action-name";
 import { registerActiveInteraction } from "./active-interaction";
 import { emitInteractionEvent, pagePath } from "./emit";
 
@@ -76,7 +75,7 @@ export function handleKeydown(event: KeyboardEvent): void {
     const element = target as Element;
 
     const key = event.key === " " ? "Space" : event.key;
-    const { name, nameSource } = deriveActionName(element, vars.interactionInstrumentation.actionNameAttribute!);
+    const { name, nameSource } = resolveActionName(element);
 
     // Enter/Space activate a control or submit a form, so they register for
     // HTTP span attribution just like a click; navigation keys only get an

--- a/src/instrumentations/interactions/keypress.ts
+++ b/src/instrumentations/interactions/keypress.ts
@@ -5,7 +5,7 @@ import { INTERACTION_KEY } from "../../semantic-conventions";
 import { KeyValue } from "../../types/otlp";
 import { resolveActionName } from "./action-name";
 import { registerActiveInteraction } from "./active-interaction";
-import { emitInteractionEvent, pagePath } from "./emit";
+import { emitInteractionEvent } from "./emit";
 
 /**
  * Only these navigation/activation keys are ever captured. Printable
@@ -89,9 +89,9 @@ export function handleKeydown(event: KeyboardEvent): void {
 
     emitInteractionEvent({
       type: "key_press",
-      // Press Enter in "Search parts" on /inventory/parts
-      // Press Escape on /playground              (no derivable target name)
-      title: name ? `Press ${key} in "${name}" on ${pagePath()}` : `Press ${key} on ${pagePath()}`,
+      // Press Enter in "Search parts"   (emit appends ` on <scrubbed page path>`)
+      // Press Escape                     (no derivable target name)
+      title: name ? `Press ${key} in "${name}"` : `Press ${key}`,
       id,
       name,
       nameSource,

--- a/src/instrumentations/interactions/keypress_test.ts
+++ b/src/instrumentations/interactions/keypress_test.ts
@@ -85,13 +85,50 @@ describe("key press instrumentation", () => {
     expect(sendLog).toHaveBeenCalledOnce();
   });
 
-  it("registers the key press as the active interaction for span attribution", () => {
+  it("registers Enter as the active interaction for span attribution", () => {
     dom.body.innerHTML = `<input id="q" aria-label="Search parts" />`;
 
     handleKeydown(keydownOn(dom.getElementById("q")!, "Enter"));
 
     const active = getActiveInteraction();
     expect(active).toBeDefined();
+    expect(active!.name).toBe("Search parts");
+  });
+
+  it("registers Space as the active interaction for span attribution", () => {
+    dom.body.innerHTML = `<button id="b" aria-label="Play"></button>`;
+
+    handleKeydown(keydownOn(dom.getElementById("b")!, " "));
+
+    const active = getActiveInteraction();
+    expect(active).toBeDefined();
+    expect(active!.name).toBe("Play");
+  });
+
+  it("does NOT register navigation keys for span attribution (but still emits their events)", () => {
+    dom.body.innerHTML = `<div id="list" tabindex="0" aria-label="Results"></div>`;
+    const list = dom.getElementById("list")!;
+
+    for (const key of ["ArrowDown", "Tab", "Escape", "PageDown", "Home", "Backspace"]) {
+      handleKeydown(keydownOn(list, key));
+      expect(getActiveInteraction()).toBeUndefined();
+    }
+
+    expect(sendLog).toHaveBeenCalledTimes(6);
+  });
+
+  it("a navigation key does not steal attribution from a preceding activation", () => {
+    dom.body.innerHTML = `<input id="q" aria-label="Search parts" />`;
+    const input = dom.getElementById("q")!;
+
+    handleKeydown(keydownOn(input, "Enter"));
+    const registered = getActiveInteraction()!;
+
+    handleKeydown(keydownOn(input, "ArrowDown"));
+
+    const active = getActiveInteraction();
+    expect(active).toBeDefined();
+    expect(active!.id).toBe(registered.id);
     expect(active!.name).toBe("Search parts");
   });
 });

--- a/src/instrumentations/interactions/keypress_test.ts
+++ b/src/instrumentations/interactions/keypress_test.ts
@@ -1,0 +1,97 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { vars } from "../../vars";
+import { sendLog } from "../../transport";
+import { doc } from "../../utils/globals";
+import { INTERACTION_KEY, INTERACTION_TYPE } from "../../semantic-conventions";
+import type { LogRecord } from "../../types/otlp";
+
+vi.mock("../../transport", () => ({
+  sendLog: vi.fn(),
+}));
+
+import { handleKeydown } from "./keypress";
+import { clearActiveInteractionForTests, getActiveInteraction } from "./active-interaction";
+
+const dom = doc!;
+
+function keydownOn(el: Element, key: string, repeat = false): KeyboardEvent {
+  const event = new KeyboardEvent("keydown", { key, repeat, bubbles: true });
+  Object.defineProperty(event, "target", { value: el });
+  return event;
+}
+
+function lastLog(): LogRecord {
+  const calls = (sendLog as ReturnType<typeof vi.fn>).mock.calls;
+  expect(calls.length).toBeGreaterThan(0);
+  return calls[calls.length - 1]![0] as LogRecord;
+}
+
+function attr(log: LogRecord, key: string) {
+  return (log.attributes as { key: string; value: Record<string, unknown> }[]).find((kv) => kv.key === key)?.value;
+}
+
+describe("key press instrumentation", () => {
+  beforeEach(() => {
+    dom.body.innerHTML = "";
+    vars.interactionInstrumentation = { enabled: true, actionNameAttribute: "data-dash0-action-name" };
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    clearActiveInteractionForTests();
+    vi.clearAllMocks();
+  });
+
+  it("captures Enter with the target's derived name", () => {
+    dom.body.innerHTML = `<input id="search" type="text" aria-label="Search parts" />`;
+
+    handleKeydown(keydownOn(dom.getElementById("search")!, "Enter"));
+
+    const log = lastLog();
+    expect(log.body).toEqual({ stringValue: 'Press Enter in "Search parts" on /' });
+    expect(attr(log, INTERACTION_KEY)).toEqual({ stringValue: "Enter" });
+    expect(attr(log, INTERACTION_TYPE)).toEqual({ stringValue: "key_press" });
+  });
+
+  it("normalizes the space key to a readable name", () => {
+    dom.body.innerHTML = `<button id="b">Play</button>`;
+
+    handleKeydown(keydownOn(dom.getElementById("b")!, " "));
+
+    const log = lastLog();
+    expect(attr(log, INTERACTION_KEY)).toEqual({ stringValue: "Space" });
+    expect(log.body).toEqual({ stringValue: 'Press Space in "Play" on /' });
+  });
+
+  it("NEVER captures printable characters (no keylogging)", () => {
+    dom.body.innerHTML = `<input id="pw" type="password" aria-label="Password" />`;
+    const input = dom.getElementById("pw")!;
+
+    for (const key of ["a", "Z", "1", "!", "ü", "€"]) {
+      handleKeydown(keydownOn(input, key));
+    }
+
+    expect(sendLog).not.toHaveBeenCalled();
+  });
+
+  it("ignores auto-repeat from a held-down key", () => {
+    dom.body.innerHTML = `<div id="list" tabindex="0"></div>`;
+    const list = dom.getElementById("list")!;
+
+    handleKeydown(keydownOn(list, "ArrowDown", false));
+    handleKeydown(keydownOn(list, "ArrowDown", true));
+    handleKeydown(keydownOn(list, "ArrowDown", true));
+
+    expect(sendLog).toHaveBeenCalledOnce();
+  });
+
+  it("registers the key press as the active interaction for span attribution", () => {
+    dom.body.innerHTML = `<input id="q" aria-label="Search parts" />`;
+
+    handleKeydown(keydownOn(dom.getElementById("q")!, "Enter"));
+
+    const active = getActiveInteraction();
+    expect(active).toBeDefined();
+    expect(active!.name).toBe("Search parts");
+  });
+});

--- a/src/instrumentations/interactions/keypress_test.ts
+++ b/src/instrumentations/interactions/keypress_test.ts
@@ -142,9 +142,10 @@ describe("key press instrumentation", () => {
     dom.body.innerHTML = `<input id="q" aria-label="Search parts" />`;
     const input = dom.getElementById("q")!;
     // Force an internal error in the name derivation, the deepest DOM surface
-    // the handler touches (same lever as click_test.ts).
-    Object.defineProperty(input, "getAttribute", {
-      value() {
+    // the handler touches (same lever as click_test.ts -- a shadowed
+    // `getAttribute` is bypassed by design, see utils/dom).
+    Object.defineProperty(input, "parentElement", {
+      get() {
         throw new Error("boom");
       },
     });

--- a/src/instrumentations/interactions/keypress_test.ts
+++ b/src/instrumentations/interactions/keypress_test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { vars } from "../../vars";
 import { sendLog } from "../../transport";
-import { doc } from "../../utils/globals";
+import { doc, win } from "../../utils/globals";
 import { INTERACTION_KEY, INTERACTION_TYPE } from "../../semantic-conventions";
 import type { LogRecord } from "../../types/otlp";
 
@@ -9,10 +9,12 @@ vi.mock("../../transport", () => ({
   sendLog: vi.fn(),
 }));
 
-import { handleKeydown } from "./keypress";
+import { handleKeydown, startKeyPressInstrumentation, stopKeyPressInstrumentationForTests } from "./keypress";
 import { clearActiveInteractionForTests, getActiveInteraction } from "./active-interaction";
 
+// Vitest runs these tests in jsdom, so the SSR-safe doc/win are always defined.
 const dom = doc!;
+const globalWindow = win!;
 
 function keydownOn(el: Element, key: string, repeat = false): KeyboardEvent {
   const event = new KeyboardEvent("keydown", { key, repeat, bubbles: true });
@@ -38,7 +40,11 @@ describe("key press instrumentation", () => {
   });
 
   afterEach(() => {
+    stopKeyPressInstrumentationForTests();
     clearActiveInteractionForTests();
+    // Restores any addEventListener spy even when an assertion failed before the
+    // test reached its own mockRestore, so the spy cannot leak into the next case.
+    vi.restoreAllMocks();
     vi.clearAllMocks();
   });
 
@@ -130,5 +136,76 @@ describe("key press instrumentation", () => {
     expect(active).toBeDefined();
     expect(active!.id).toBe(registered.id);
     expect(active!.name).toBe("Search parts");
+  });
+
+  it("swallows errors from a throwing scenario and does not propagate", () => {
+    dom.body.innerHTML = `<input id="q" aria-label="Search parts" />`;
+    const input = dom.getElementById("q")!;
+    // Force an internal error in the name derivation, the deepest DOM surface
+    // the handler touches (same lever as click_test.ts).
+    Object.defineProperty(input, "getAttribute", {
+      value() {
+        throw new Error("boom");
+      },
+    });
+
+    expect(() => handleKeydown(keydownOn(input, "Enter"))).not.toThrow();
+
+    expect(sendLog).not.toHaveBeenCalled();
+    // Name derivation runs before registerActiveInteraction, so a throw must not
+    // leave an interaction id behind for HTTP spans to join to.
+    expect(getActiveInteraction()).toBeUndefined();
+  });
+
+  describe("startKeyPressInstrumentation (real capture-phase listener + isTrusted gate)", () => {
+    it("registers exactly one window-level capture-phase keydown listener", () => {
+      const addSpy = vi.spyOn(globalWindow, "addEventListener");
+
+      startKeyPressInstrumentation();
+
+      expect(addSpy).toHaveBeenCalledOnce();
+      expect(addSpy).toHaveBeenCalledWith("keydown", expect.any(Function), { capture: true });
+
+      addSpy.mockRestore();
+    });
+
+    it("does not register a second listener if called twice (idempotent start)", () => {
+      const addSpy = vi.spyOn(globalWindow, "addEventListener");
+
+      startKeyPressInstrumentation();
+      startKeyPressInstrumentation();
+
+      expect(addSpy).toHaveBeenCalledOnce();
+      addSpy.mockRestore();
+    });
+
+    it("ignores untrusted (synthetic) key presses -- jsdom's dispatchEvent always yields isTrusted: false", () => {
+      dom.body.innerHTML = `<input id="q" aria-label="Search parts" />`;
+      startKeyPressInstrumentation();
+
+      const event = new KeyboardEvent("keydown", { key: "Enter", bubbles: true });
+      dom.getElementById("q")!.dispatchEvent(event);
+
+      expect(event.isTrusted).toBe(false);
+      expect(sendLog).not.toHaveBeenCalled();
+    });
+
+    it("processes a key press when isTrusted is stubbed true, proving the gate is the only thing blocking synthetic key presses", () => {
+      // jsdom defines `isTrusted` as a non-configurable accessor on its Event
+      // prototype, so there is no way to construct a pre-trusted event -- see the
+      // long-form explanation in click_test.ts. Capture the real listener
+      // registered by startKeyPressInstrumentation and invoke it directly instead.
+      dom.body.innerHTML = `<input id="q" aria-label="Search parts" />`;
+      const addSpy = vi.spyOn(globalWindow, "addEventListener");
+      startKeyPressInstrumentation();
+
+      const target = dom.getElementById("q")!;
+      const listener = addSpy.mock.calls.find((call) => call[0] === "keydown")![1] as EventListener;
+      listener({ isTrusted: true, target, key: "Enter", repeat: false } as unknown as Event);
+
+      addSpy.mockRestore();
+      expect(sendLog).toHaveBeenCalledOnce();
+      expect(attr(lastLog(), INTERACTION_KEY)).toEqual({ stringValue: "Enter" });
+    });
   });
 });

--- a/src/instrumentations/interactions/keypress_test.ts
+++ b/src/instrumentations/interactions/keypress_test.ts
@@ -2,14 +2,25 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { vars } from "../../vars";
 import { sendLog } from "../../transport";
 import { doc, win } from "../../utils/globals";
-import { INTERACTION_KEY, INTERACTION_TYPE } from "../../semantic-conventions";
+import {
+  INTERACTION_ID,
+  INTERACTION_KEY,
+  INTERACTION_REPEAT_COUNT,
+  INTERACTION_TYPE,
+} from "../../semantic-conventions";
 import type { LogRecord } from "../../types/otlp";
 
 vi.mock("../../transport", () => ({
   sendLog: vi.fn(),
 }));
 
-import { handleKeydown, startKeyPressInstrumentation, stopKeyPressInstrumentationForTests } from "./keypress";
+import {
+  flushKeyPressBurstForTests,
+  handleKeydown,
+  KEYPRESS_SETTLE_MILLIS,
+  startKeyPressInstrumentation,
+  stopKeyPressInstrumentationForTests,
+} from "./keypress";
 import { clearActiveInteractionForTests, getActiveInteraction } from "./active-interaction";
 
 // Vitest runs these tests in jsdom, so the SSR-safe doc/win are always defined.
@@ -63,6 +74,7 @@ describe("key press instrumentation", () => {
     dom.body.innerHTML = `<button id="b">Play</button>`;
 
     handleKeydown(keydownOn(dom.getElementById("b")!, " "));
+    flushKeyPressBurstForTests();
 
     const log = lastLog();
     expect(attr(log, INTERACTION_KEY)).toEqual({ stringValue: "Space" });
@@ -87,8 +99,12 @@ describe("key press instrumentation", () => {
     handleKeydown(keydownOn(list, "ArrowDown", false));
     handleKeydown(keydownOn(list, "ArrowDown", true));
     handleKeydown(keydownOn(list, "ArrowDown", true));
+    flushKeyPressBurstForTests();
 
+    // One event, and no repeat count: auto-repeat is filtered before it can be
+    // mistaken for the user pressing the key again.
     expect(sendLog).toHaveBeenCalledOnce();
+    expect(attr(lastLog(), INTERACTION_REPEAT_COUNT)).toBeUndefined();
   });
 
   it("registers Enter as the active interaction for span attribution", () => {
@@ -119,6 +135,8 @@ describe("key press instrumentation", () => {
       handleKeydown(keydownOn(list, key));
       expect(getActiveInteraction()).toBeUndefined();
     }
+    // Each key finalizes the previous key's burst, leaving only the last pending.
+    flushKeyPressBurstForTests();
 
     expect(sendLog).toHaveBeenCalledTimes(6);
   });
@@ -158,13 +176,135 @@ describe("key press instrumentation", () => {
     expect(getActiveInteraction()).toBeUndefined();
   });
 
+  describe("coalescing", () => {
+    it("collapses repeated presses of the same key into one event carrying the repeat count", () => {
+      // Prose typing produces a press per word boundary and per correction, which
+      // is what would otherwise dominate the interaction budget.
+      dom.body.innerHTML = `<textarea id="notes" placeholder="Notes"></textarea>`;
+      const notes = dom.getElementById("notes")!;
+
+      for (let i = 0; i < 7; i++) {
+        handleKeydown(keydownOn(notes, "Backspace"));
+      }
+      expect(sendLog).not.toHaveBeenCalled(); // settle timer still pending
+      flushKeyPressBurstForTests();
+
+      expect(sendLog).toHaveBeenCalledOnce();
+      const log = lastLog();
+      expect(log.body).toEqual({ stringValue: 'Press Backspace 7 times in "Notes" on /' });
+      expect(attr(log, INTERACTION_REPEAT_COUNT)).toEqual({ doubleValue: 7 });
+    });
+
+    it("omits the repeat count for a single press", () => {
+      dom.body.innerHTML = `<div id="list" tabindex="0" aria-label="Results"></div>`;
+
+      handleKeydown(keydownOn(dom.getElementById("list")!, "ArrowDown"));
+      flushKeyPressBurstForTests();
+
+      const log = lastLog();
+      expect(log.body).toEqual({ stringValue: 'Press ArrowDown in "Results" on /' });
+      expect(attr(log, INTERACTION_REPEAT_COUNT)).toBeUndefined();
+    });
+
+    it("emits Enter immediately, and flushes a pending burst ahead of it to keep press order", () => {
+      dom.body.innerHTML = `<input id="q" aria-label="Search parts" />`;
+      const input = dom.getElementById("q")!;
+
+      handleKeydown(keydownOn(input, "Backspace"));
+      handleKeydown(keydownOn(input, "Enter"));
+
+      // Enter must not wait on a settle timer: it is the key most likely to have
+      // caused the request that follows.
+      const [first, second] = (sendLog as ReturnType<typeof vi.fn>).mock.calls.map((call) => call[0] as LogRecord);
+      expect(sendLog).toHaveBeenCalledTimes(2);
+      expect(attr(first!, INTERACTION_KEY)).toEqual({ stringValue: "Backspace" });
+      expect(attr(second!, INTERACTION_KEY)).toEqual({ stringValue: "Enter" });
+    });
+
+    it("finalizes the pending burst when a different key is pressed", () => {
+      dom.body.innerHTML = `<textarea id="notes" placeholder="Notes"></textarea>`;
+      const notes = dom.getElementById("notes")!;
+
+      handleKeydown(keydownOn(notes, "Backspace"));
+      handleKeydown(keydownOn(notes, "Backspace"));
+      handleKeydown(keydownOn(notes, "Delete"));
+
+      expect(sendLog).toHaveBeenCalledOnce();
+      expect(attr(lastLog(), INTERACTION_REPEAT_COUNT)).toEqual({ doubleValue: 2 });
+
+      flushKeyPressBurstForTests();
+      expect(attr(lastLog(), INTERACTION_KEY)).toEqual({ stringValue: "Delete" });
+    });
+
+    it("finalizes the pending burst when the same key is pressed on a different element", () => {
+      dom.body.innerHTML = `
+        <input id="first" aria-label="First" />
+        <input id="second" aria-label="Second" />`;
+
+      handleKeydown(keydownOn(dom.getElementById("first")!, "Tab"));
+      handleKeydown(keydownOn(dom.getElementById("second")!, "Tab"));
+
+      expect(sendLog).toHaveBeenCalledOnce();
+      expect(lastLog().body).toEqual({ stringValue: 'Press Tab in "First" on /' });
+    });
+
+    it("keeps one correlation id across a coalesced activation burst, so attributed spans join to the emitted event", () => {
+      dom.body.innerHTML = `<button id="b" aria-label="Play"></button>`;
+      const button = dom.getElementById("b")!;
+
+      handleKeydown(keydownOn(button, " "));
+      const firstId = getActiveInteraction()!.id;
+
+      handleKeydown(keydownOn(button, " "));
+      const secondId = getActiveInteraction()!.id;
+
+      // Minting a fresh id per press would leave the spans attributed to the
+      // first one pointing at a log record that never gets emitted.
+      expect(secondId).toBe(firstId);
+
+      flushKeyPressBurstForTests();
+      expect(attr(lastLog(), INTERACTION_ID)).toEqual({ stringValue: firstId });
+    });
+
+    /**
+     * The only test here that drives the production settle timer instead of
+     * calling flushKeyPressBurstForTests(); without it, deleting the setTimeout
+     * in handleKeydown would keep every other test in this file green.
+     *
+     * It really does wait: utils/timers captures win.setTimeout at module load,
+     * so vi.useFakeTimers() cannot intercept the timer this code schedules.
+     */
+    it("emits after the settle timer, with no test-only flush", async () => {
+      dom.body.innerHTML = `<div id="list" tabindex="0" aria-label="Results"></div>`;
+
+      handleKeydown(keydownOn(dom.getElementById("list")!, "ArrowDown"));
+      expect(sendLog).not.toHaveBeenCalled();
+
+      await new Promise((resolve) => globalThis.setTimeout(resolve, KEYPRESS_SETTLE_MILLIS + 50));
+
+      expect(sendLog).toHaveBeenCalledOnce();
+      expect(attr(lastLog(), INTERACTION_KEY)).toEqual({ stringValue: "ArrowDown" });
+    });
+  });
+
   describe("startKeyPressInstrumentation (real capture-phase listener + isTrusted gate)", () => {
+    /**
+     * Filtered by event type rather than asserting a total call count: the
+     * unload hook also registers window-level pagehide/beforeunload listeners,
+     * and it registers only on the *first* start* in this file, so any count
+     * over all registrations would depend on test order. Same shape as
+     * scroll_test.ts.
+     */
+    function keydownRegistrations(addSpy: ReturnType<typeof vi.spyOn>) {
+      return addSpy.mock.calls.filter((call) => call[0] === "keydown");
+    }
+
     it("registers exactly one window-level capture-phase keydown listener", () => {
       const addSpy = vi.spyOn(globalWindow, "addEventListener");
 
       startKeyPressInstrumentation();
 
-      expect(addSpy).toHaveBeenCalledOnce();
+      expect(keydownRegistrations(addSpy)).toHaveLength(1);
       expect(addSpy).toHaveBeenCalledWith("keydown", expect.any(Function), { capture: true });
 
       addSpy.mockRestore();
@@ -176,7 +316,7 @@ describe("key press instrumentation", () => {
       startKeyPressInstrumentation();
       startKeyPressInstrumentation();
 
-      expect(addSpy).toHaveBeenCalledOnce();
+      expect(keydownRegistrations(addSpy)).toHaveLength(1);
       addSpy.mockRestore();
     });
 

--- a/src/instrumentations/interactions/scroll.ts
+++ b/src/instrumentations/interactions/scroll.ts
@@ -1,0 +1,151 @@
+import { doc, generateUniqueId, win, WEB_EVENT_ID_BYTES } from "../../utils";
+import { debug } from "../../utils/debug";
+import { setTimeout, clearTimeout } from "../../utils/timers";
+import { addAttribute } from "../../utils/otel";
+import { INTERACTION_DIRECTION } from "../../semantic-conventions";
+import { KeyValue } from "../../types/otlp";
+import { emitInteractionEvent, pagePath } from "./emit";
+
+/**
+ * Scroll events fire per frame, so emitting one telemetry event per DOM event
+ * would be pure noise. Instead a contiguous burst of scrolling is collapsed
+ * into ONE `browser.interaction` (type "scroll"): the burst starts on the
+ * first scroll event, and finalizes after SCROLL_SETTLE_MILLIS without
+ * further scrolling. The emitted direction is derived from the net position
+ * delta over the whole burst.
+ */
+const SCROLL_SETTLE_MILLIS = 300;
+
+/**
+ * Net movement (px) below which a burst is dropped entirely -- sub-pixel and
+ * micro-scrolls (trackpad jitter, momentum tails) are not meaningful user
+ * interactions.
+ */
+const MIN_SCROLL_DELTA_PX = 8;
+
+type ScrollBurst = {
+  element: Element;
+  startX: number;
+  startY: number;
+  settleTimeout: ReturnType<typeof setTimeout> | null;
+};
+
+let listenerAttached = false;
+let burst: ScrollBurst | undefined;
+
+function onWindowScroll(event: Event) {
+  if (!event.isTrusted) return;
+  handleScroll(event);
+}
+
+export function startScrollInstrumentation() {
+  if (listenerAttached) return;
+  if (!win) return;
+
+  // Capture phase on window sees both document scrolling and scrolling of
+  // nested overflow containers (scroll does not bubble, but capture works).
+  win.addEventListener("scroll", onWindowScroll, { capture: true, passive: true } as AddEventListenerOptions);
+  listenerAttached = true;
+}
+
+export function stopScrollInstrumentationForTests() {
+  if (!listenerAttached || !win) return;
+  win.removeEventListener("scroll", onWindowScroll, { capture: true } as EventListenerOptions);
+  if (burst?.settleTimeout != null) clearTimeout(burst.settleTimeout);
+  burst = undefined;
+  listenerAttached = false;
+}
+
+/** Resolves the scrolled element plus its current scroll position. */
+function scrollStateFor(event: Event): { element: Element; x: number; y: number } | undefined {
+  const target = event.target;
+
+  // Scrolling the page itself reports the document (or window) as target.
+  if (!target || target === doc || target === win) {
+    const root = doc?.scrollingElement ?? doc?.documentElement;
+    if (!root) return undefined;
+    return { element: root, x: win?.scrollX ?? root.scrollLeft, y: win?.scrollY ?? root.scrollTop };
+  }
+
+  if ((target as Node).nodeType !== 1) return undefined;
+  const element = target as Element;
+  return { element, x: element.scrollLeft, y: element.scrollTop };
+}
+
+/**
+ * Exported for tests (bypasses the isTrusted gate, same pattern as
+ * click.ts/handleClick).
+ */
+export function handleScroll(event: Event): void {
+  try {
+    const state = scrollStateFor(event);
+    if (!state) return;
+
+    if (!burst) {
+      burst = {
+        element: state.element,
+        startX: state.x,
+        startY: state.y,
+        settleTimeout: null,
+      };
+    } else if (burst.settleTimeout != null) {
+      clearTimeout(burst.settleTimeout);
+    }
+
+    // The burst tracks the element it started on; scrolls of other elements
+    // during the settle window just keep the burst alive.
+    burst.settleTimeout = setTimeout(() => finalizeBurst(), SCROLL_SETTLE_MILLIS);
+  } catch (err) {
+    debug("Dash0 interaction instrumentation failed to process a scroll event.", err);
+  }
+}
+
+function finalizeBurst(): void {
+  const finished = burst;
+  burst = undefined;
+  if (!finished) return;
+
+  try {
+    const element = finished.element;
+    const endX =
+      element === (doc?.scrollingElement ?? doc?.documentElement)
+        ? (win?.scrollX ?? element.scrollLeft)
+        : element.scrollLeft;
+    const endY =
+      element === (doc?.scrollingElement ?? doc?.documentElement)
+        ? (win?.scrollY ?? element.scrollTop)
+        : element.scrollTop;
+
+    const deltaX = endX - finished.startX;
+    const deltaY = endY - finished.startY;
+
+    if (Math.abs(deltaX) < MIN_SCROLL_DELTA_PX && Math.abs(deltaY) < MIN_SCROLL_DELTA_PX) {
+      return; // micro-scroll, not a meaningful interaction
+    }
+
+    const direction =
+      Math.abs(deltaY) >= Math.abs(deltaX) ? (deltaY > 0 ? "down" : "up") : deltaX > 0 ? "right" : "left";
+
+    const extraAttributes: KeyValue[] = [];
+    addAttribute(extraAttributes, INTERACTION_DIRECTION, direction);
+
+    emitInteractionEvent({
+      type: "scroll",
+      // Scroll down on /inventory/parts
+      title: `Scroll ${direction} on ${pagePath()}`,
+      id: generateUniqueId(WEB_EVENT_ID_BYTES),
+      name: "",
+      nameSource: "blank",
+      element,
+      extraAttributes,
+    });
+  } catch (err) {
+    debug("Dash0 interaction instrumentation failed to finalize a scroll burst.", err);
+  }
+}
+
+/** Test-only: force-finalize the in-flight burst without waiting for the settle timer. */
+export function flushScrollBurstForTests(): void {
+  if (burst?.settleTimeout != null) clearTimeout(burst.settleTimeout);
+  finalizeBurst();
+}

--- a/src/instrumentations/interactions/scroll.ts
+++ b/src/instrumentations/interactions/scroll.ts
@@ -13,6 +13,18 @@ import { emitInteractionEvent } from "./emit";
  * first scroll event, and finalizes after SCROLL_SETTLE_MILLIS without
  * further scrolling. The emitted direction is derived from the net position
  * delta over the whole burst.
+ *
+ * Both endpoints of that delta are sampled inside the event handler, never at
+ * finalize time:
+ *
+ * - The end position is the last position the handler observed. Re-reading the
+ *   element 300 ms later would report 0 for an element detached or reset in the
+ *   meantime (modal closed, route change), inverting the direction.
+ * - The start position is the last position observed for that element *before*
+ *   the burst. A scroll event fires after the offset has already changed, so
+ *   the burst's own first event is already too late to be its baseline; using
+ *   it would net a delta of 0 for single-event bursts (instant `scrollTo`,
+ *   anchor jump, `scrollIntoView`, Home/End) and drop them as micro-scrolls.
  */
 const SCROLL_SETTLE_MILLIS = 300;
 
@@ -23,15 +35,38 @@ const SCROLL_SETTLE_MILLIS = 300;
  */
 const MIN_SCROLL_DELTA_PX = 8;
 
+type ScrollPosition = { x: number; y: number };
+
 type ScrollBurst = {
   element: Element;
   startX: number;
   startY: number;
+  lastX: number;
+  lastY: number;
   settleTimeout: ReturnType<typeof setTimeout> | null;
 };
 
 let listenerAttached = false;
 let burst: ScrollBurst | undefined;
+
+/**
+ * Last position the handler saw for an element, which is where its next burst
+ * starts from. Weakly keyed, so remembering a position never keeps a removed
+ * element alive.
+ */
+let lastObservedPosition = new WeakMap<Element, ScrollPosition>();
+
+function rememberPosition(element: Element, x: number, y: number): void {
+  const known = lastObservedPosition.get(element);
+  // Mutated in place: this runs once per scroll event, i.e. per frame while
+  // scrolling, so it should not allocate.
+  if (known) {
+    known.x = x;
+    known.y = y;
+    return;
+  }
+  lastObservedPosition.set(element, { x, y });
+}
 
 function onWindowScroll(event: Event) {
   if (!event.isTrusted) return;
@@ -46,6 +81,14 @@ export function startScrollInstrumentation() {
   // nested overflow containers (scroll does not bubble, but capture works).
   win.addEventListener("scroll", onWindowScroll, { capture: true, passive: true } as AddEventListenerOptions);
   listenerAttached = true;
+
+  // Page scrolling is the common case, and it is also the one most likely to
+  // already be scrolled by the time the SDK attaches (deferred script,
+  // browser scroll restoration on back/forward). Recording the current
+  // position gives the first page burst a real baseline instead of the assumed
+  // 0 that unseen elements fall back to.
+  const root = doc?.scrollingElement ?? doc?.documentElement;
+  if (root) rememberPosition(root, win.scrollX ?? root.scrollLeft, win.scrollY ?? root.scrollTop);
 }
 
 export function stopScrollInstrumentationForTests() {
@@ -54,6 +97,9 @@ export function stopScrollInstrumentationForTests() {
   // pending settle timer leak into the next test.
   if (burst?.settleTimeout != null) clearTimeout(burst.settleTimeout);
   burst = undefined;
+  // The jsdom document root outlives a single test case, so a remembered page
+  // position would otherwise become the next test's baseline.
+  lastObservedPosition = new WeakMap();
   if (!listenerAttached || !win) return;
   win.removeEventListener("scroll", onWindowScroll, { capture: true } as EventListenerOptions);
   listenerAttached = false;
@@ -85,18 +131,31 @@ export function handleScroll(event: Event): void {
     if (!state) return;
 
     if (!burst) {
+      // An element nobody has seen scroll yet is assumed to have started at 0.
+      // If it was in fact already scrolled before the listener attached, its
+      // first upward burst reports "down" -- bounded to that one event, since
+      // its position is remembered from here on.
+      const baseline = lastObservedPosition.get(state.element);
       burst = {
         element: state.element,
-        startX: state.x,
-        startY: state.y,
+        startX: baseline?.x ?? 0,
+        startY: baseline?.y ?? 0,
+        lastX: state.x,
+        lastY: state.y,
         settleTimeout: null,
       };
-    } else if (burst.settleTimeout != null) {
-      clearTimeout(burst.settleTimeout);
+    } else {
+      if (burst.settleTimeout != null) clearTimeout(burst.settleTimeout);
+      // The burst tracks the element it started on; scrolls of other elements
+      // during the settle window just keep the burst alive.
+      if (state.element === burst.element) {
+        burst.lastX = state.x;
+        burst.lastY = state.y;
+      }
     }
 
-    // The burst tracks the element it started on; scrolls of other elements
-    // during the settle window just keep the burst alive.
+    rememberPosition(state.element, state.x, state.y);
+
     burst.settleTimeout = setTimeout(() => finalizeBurst(), SCROLL_SETTLE_MILLIS);
   } catch (err) {
     debug("Dash0 interaction instrumentation failed to process a scroll event.", err);
@@ -110,17 +169,8 @@ function finalizeBurst(): void {
 
   try {
     const element = finished.element;
-    const endX =
-      element === (doc?.scrollingElement ?? doc?.documentElement)
-        ? (win?.scrollX ?? element.scrollLeft)
-        : element.scrollLeft;
-    const endY =
-      element === (doc?.scrollingElement ?? doc?.documentElement)
-        ? (win?.scrollY ?? element.scrollTop)
-        : element.scrollTop;
-
-    const deltaX = endX - finished.startX;
-    const deltaY = endY - finished.startY;
+    const deltaX = finished.lastX - finished.startX;
+    const deltaY = finished.lastY - finished.startY;
 
     if (Math.abs(deltaX) < MIN_SCROLL_DELTA_PX && Math.abs(deltaY) < MIN_SCROLL_DELTA_PX) {
       return; // micro-scroll, not a meaningful interaction

--- a/src/instrumentations/interactions/scroll.ts
+++ b/src/instrumentations/interactions/scroll.ts
@@ -4,7 +4,7 @@ import { setTimeout, clearTimeout } from "../../utils/timers";
 import { addAttribute } from "../../utils/otel";
 import { INTERACTION_DIRECTION } from "../../semantic-conventions";
 import { KeyValue } from "../../types/otlp";
-import { emitInteractionEvent, pagePath } from "./emit";
+import { emitInteractionEvent } from "./emit";
 
 /**
  * Scroll events fire per frame, so emitting one telemetry event per DOM event
@@ -131,8 +131,8 @@ function finalizeBurst(): void {
 
     emitInteractionEvent({
       type: "scroll",
-      // Scroll down on /inventory/parts
-      title: `Scroll ${direction} on ${pagePath()}`,
+      // Scroll down   (emit appends ` on <scrubbed page path>`)
+      title: `Scroll ${direction}`,
       id: generateUniqueId(WEB_EVENT_ID_BYTES),
       name: "",
       nameSource: "blank",

--- a/src/instrumentations/interactions/scroll.ts
+++ b/src/instrumentations/interactions/scroll.ts
@@ -1,5 +1,6 @@
 import { doc, generateUniqueId, win, WEB_EVENT_ID_BYTES } from "../../utils";
 import { debug } from "../../utils/debug";
+import { onLastChance } from "../../utils/on-last-chance";
 import { setTimeout, clearTimeout } from "../../utils/timers";
 import { addAttribute } from "../../utils/otel";
 import { INTERACTION_DIRECTION } from "../../semantic-conventions";
@@ -26,7 +27,7 @@ import { emitInteractionEvent } from "./emit";
  *   it would net a delta of 0 for single-event bursts (instant `scrollTo`,
  *   anchor jump, `scrollIntoView`, Home/End) and drop them as micro-scrolls.
  */
-const SCROLL_SETTLE_MILLIS = 300;
+export const SCROLL_SETTLE_MILLIS = 300;
 
 /**
  * Net movement (px) below which a burst is dropped entirely -- sub-pixel and
@@ -47,6 +48,7 @@ type ScrollBurst = {
 };
 
 let listenerAttached = false;
+let unloadHookRegistered = false;
 let burst: ScrollBurst | undefined;
 
 /**
@@ -82,6 +84,31 @@ export function startScrollInstrumentation() {
   win.addEventListener("scroll", onWindowScroll, { capture: true, passive: true } as AddEventListenerOptions);
   listenerAttached = true;
 
+  // A burst is otherwise only emitted once the settle timer fires, so scrolling
+  // and then immediately navigating away or closing the tab drops it -- and the
+  // last burst before a navigation is often the most interesting one, since it
+  // is what preceded the click that left the page.
+  //
+  // The log this emits still reaches the wire even though the transport's own
+  // onLastChance(flush) is registered first (the batchers in transport/index.ts
+  // are created at module load, i.e. before any start* call), but for two
+  // separate reasons -- neither of which may be "simplified" away:
+  //   - on visibilitychange->hidden and on pagehide the document is no longer
+  //     visible, so batcher.send() transmits immediately instead of queueing
+  //     behind a scheduled flush that would never get to run;
+  //   - on beforeunload the document is still visible so the log does get
+  //     queued, but beforeunload always precedes pagehide, whose batcher flush
+  //     then drains it.
+  //
+  // Tracked separately from listenerAttached because onLastChance offers no way
+  // to unregister: stopScrollInstrumentationForTests() resets listenerAttached,
+  // and re-registering on every start* would leak a duplicate unload listener
+  // per test case.
+  if (!unloadHookRegistered) {
+    unloadHookRegistered = true;
+    onLastChance(flushBurst);
+  }
+
   // Page scrolling is the common case, and it is also the one most likely to
   // already be scrolled by the time the SDK attaches (deferred script,
   // browser scroll restoration on back/forward). Recording the current
@@ -100,6 +127,9 @@ export function stopScrollInstrumentationForTests() {
   // The jsdom document root outlives a single test case, so a remembered page
   // position would otherwise become the next test's baseline.
   lastObservedPosition = new WeakMap();
+  // unloadHookRegistered is deliberately NOT reset: the onLastChance listeners
+  // cannot be removed, so clearing the flag would only make the next start*
+  // register a second set of them.
   if (!listenerAttached || !win) return;
   win.removeEventListener("scroll", onWindowScroll, { capture: true } as EventListenerOptions);
   listenerAttached = false;
@@ -197,8 +227,13 @@ function finalizeBurst(): void {
   }
 }
 
-/** Test-only: force-finalize the in-flight burst without waiting for the settle timer. */
-export function flushScrollBurstForTests(): void {
+/** Finalizes the in-flight burst now, without waiting for the settle timer. */
+function flushBurst(): void {
   if (burst?.settleTimeout != null) clearTimeout(burst.settleTimeout);
   finalizeBurst();
+}
+
+/** Test-only: force-finalize the in-flight burst without waiting for the settle timer. */
+export function flushScrollBurstForTests(): void {
+  flushBurst();
 }

--- a/src/instrumentations/interactions/scroll.ts
+++ b/src/instrumentations/interactions/scroll.ts
@@ -49,10 +49,13 @@ export function startScrollInstrumentation() {
 }
 
 export function stopScrollInstrumentationForTests() {
-  if (!listenerAttached || !win) return;
-  win.removeEventListener("scroll", onWindowScroll, { capture: true } as EventListenerOptions);
+  // Before the guard below: module state has to be reset even for test cases
+  // that never attached the real listener, otherwise an in-flight burst and its
+  // pending settle timer leak into the next test.
   if (burst?.settleTimeout != null) clearTimeout(burst.settleTimeout);
   burst = undefined;
+  if (!listenerAttached || !win) return;
+  win.removeEventListener("scroll", onWindowScroll, { capture: true } as EventListenerOptions);
   listenerAttached = false;
 }
 

--- a/src/instrumentations/interactions/scroll_test.ts
+++ b/src/instrumentations/interactions/scroll_test.ts
@@ -1,0 +1,108 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { vars } from "../../vars";
+import { sendLog } from "../../transport";
+import { doc } from "../../utils/globals";
+import { INTERACTION_DIRECTION, INTERACTION_TYPE } from "../../semantic-conventions";
+import type { LogRecord } from "../../types/otlp";
+
+vi.mock("../../transport", () => ({
+  sendLog: vi.fn(),
+}));
+
+import { handleScroll, flushScrollBurstForTests, stopScrollInstrumentationForTests } from "./scroll";
+
+const dom = doc!;
+
+function scrollEventFor(el: Element): Event {
+  const event = new Event("scroll", { bubbles: false });
+  Object.defineProperty(event, "target", { value: el });
+  return event;
+}
+
+function lastLog(): LogRecord {
+  const calls = (sendLog as ReturnType<typeof vi.fn>).mock.calls;
+  expect(calls.length).toBeGreaterThan(0);
+  return calls[calls.length - 1]![0] as LogRecord;
+}
+
+function attr(log: LogRecord, key: string) {
+  return (log.attributes as { key: string; value: Record<string, unknown> }[]).find((kv) => kv.key === key)?.value;
+}
+
+/** jsdom elements have scrollTop/scrollLeft as plain settable properties. */
+function scrollable(): HTMLElement {
+  dom.body.innerHTML = `<div id="pane" class="pane" style="overflow:auto;height:100px"></div>`;
+  return dom.getElementById("pane")!;
+}
+
+describe("scroll instrumentation", () => {
+  beforeEach(() => {
+    vars.interactionInstrumentation = { enabled: true, actionNameAttribute: "data-dash0-action-name" };
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    stopScrollInstrumentationForTests();
+    vi.clearAllMocks();
+  });
+
+  it("collapses a burst of scroll events into a single event with the net direction", () => {
+    const pane = scrollable();
+
+    pane.scrollTop = 0;
+    handleScroll(scrollEventFor(pane));
+    pane.scrollTop = 40;
+    handleScroll(scrollEventFor(pane));
+    pane.scrollTop = 120;
+    handleScroll(scrollEventFor(pane));
+
+    flushScrollBurstForTests();
+
+    expect(sendLog).toHaveBeenCalledOnce();
+    const log = lastLog();
+    expect(log.body).toEqual({ stringValue: "Scroll down on /" });
+    expect(attr(log, INTERACTION_DIRECTION)).toEqual({ stringValue: "down" });
+    expect(attr(log, INTERACTION_TYPE)).toEqual({ stringValue: "scroll" });
+  });
+
+  it("reports upward scrolling", () => {
+    const pane = scrollable();
+
+    pane.scrollTop = 200;
+    handleScroll(scrollEventFor(pane));
+    pane.scrollTop = 20;
+    handleScroll(scrollEventFor(pane));
+
+    flushScrollBurstForTests();
+
+    const log = lastLog();
+    expect(log.body).toEqual({ stringValue: "Scroll up on /" });
+    expect(attr(log, INTERACTION_DIRECTION)).toEqual({ stringValue: "up" });
+  });
+
+  it("drops micro-scrolls below the noise threshold", () => {
+    const pane = scrollable();
+
+    pane.scrollTop = 100;
+    handleScroll(scrollEventFor(pane));
+    pane.scrollTop = 103; // 3px net movement
+    handleScroll(scrollEventFor(pane));
+
+    flushScrollBurstForTests();
+
+    expect(sendLog).not.toHaveBeenCalled();
+  });
+
+  it("emits nothing while a burst is still in flight", () => {
+    const pane = scrollable();
+
+    pane.scrollTop = 0;
+    handleScroll(scrollEventFor(pane));
+    pane.scrollTop = 500;
+    handleScroll(scrollEventFor(pane));
+
+    expect(sendLog).not.toHaveBeenCalled(); // settle timer still pending
+    flushScrollBurstForTests();
+    expect(sendLog).toHaveBeenCalledOnce();
+  });
+});

--- a/src/instrumentations/interactions/scroll_test.ts
+++ b/src/instrumentations/interactions/scroll_test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { vars } from "../../vars";
 import { sendLog } from "../../transport";
-import { doc } from "../../utils/globals";
+import { doc, win } from "../../utils/globals";
 import { INTERACTION_DIRECTION, INTERACTION_TYPE } from "../../semantic-conventions";
 import type { LogRecord } from "../../types/otlp";
 
@@ -9,9 +9,16 @@ vi.mock("../../transport", () => ({
   sendLog: vi.fn(),
 }));
 
-import { handleScroll, flushScrollBurstForTests, stopScrollInstrumentationForTests } from "./scroll";
+import {
+  handleScroll,
+  flushScrollBurstForTests,
+  startScrollInstrumentation,
+  stopScrollInstrumentationForTests,
+} from "./scroll";
 
+// Vitest runs these tests in jsdom, so the SSR-safe doc/win are always defined.
 const dom = doc!;
+const globalWindow = win!;
 
 function scrollEventFor(el: Element): Event {
   const event = new Event("scroll", { bubbles: false });
@@ -43,6 +50,9 @@ describe("scroll instrumentation", () => {
 
   afterEach(() => {
     stopScrollInstrumentationForTests();
+    // Restores any addEventListener spy even when an assertion failed before the
+    // test reached its own mockRestore, so the spy cannot leak into the next case.
+    vi.restoreAllMocks();
     vi.clearAllMocks();
   });
 
@@ -104,5 +114,132 @@ describe("scroll instrumentation", () => {
     expect(sendLog).not.toHaveBeenCalled(); // settle timer still pending
     flushScrollBurstForTests();
     expect(sendLog).toHaveBeenCalledOnce();
+  });
+
+  describe("startScrollInstrumentation (real capture-phase listener + isTrusted gate)", () => {
+    it("registers exactly one window-level capture-phase scroll listener", () => {
+      const addSpy = vi.spyOn(globalWindow, "addEventListener");
+
+      startScrollInstrumentation();
+
+      expect(addSpy).toHaveBeenCalledOnce();
+      // `passive: true` is load-bearing: scroll fires per frame on the input
+      // delay path, and a non-passive listener lets the SDK block scrolling.
+      expect(addSpy).toHaveBeenCalledWith("scroll", expect.any(Function), { capture: true, passive: true });
+
+      addSpy.mockRestore();
+    });
+
+    it("does not register a second listener if called twice (idempotent start)", () => {
+      const addSpy = vi.spyOn(globalWindow, "addEventListener");
+
+      startScrollInstrumentation();
+      startScrollInstrumentation();
+
+      expect(addSpy).toHaveBeenCalledOnce();
+      addSpy.mockRestore();
+    });
+
+    it("clears an in-flight burst on teardown even when the listener was never attached", () => {
+      const pane = scrollable();
+
+      pane.scrollTop = 0;
+      handleScroll(scrollEventFor(pane));
+      pane.scrollTop = 300;
+      handleScroll(scrollEventFor(pane));
+
+      // Most tests here drive handleScroll directly and never call start*, so the
+      // teardown has to reset module state above its listenerAttached guard --
+      // otherwise this burst and its pending settle timer bleed into the next test.
+      stopScrollInstrumentationForTests();
+
+      flushScrollBurstForTests();
+      expect(sendLog).not.toHaveBeenCalled();
+    });
+
+    it("ignores untrusted (synthetic) scrolls -- jsdom's dispatchEvent always yields isTrusted: false", () => {
+      const pane = scrollable();
+      startScrollInstrumentation();
+
+      pane.scrollTop = 0;
+      // scroll does not bubble, but a capture-phase listener on window is on the
+      // propagation path of every dispatch, so this really does reach the listener.
+      const event = new Event("scroll", { bubbles: false });
+      pane.dispatchEvent(event);
+      pane.scrollTop = 400;
+      pane.dispatchEvent(new Event("scroll", { bubbles: false }));
+
+      expect(event.isTrusted).toBe(false);
+      // Flushing is what makes this assertion mean "no burst was ever started"
+      // rather than "the settle timer has not fired yet".
+      flushScrollBurstForTests();
+      expect(sendLog).not.toHaveBeenCalled();
+    });
+
+    it("processes a scroll when isTrusted is stubbed true, proving the gate is the only thing blocking synthetic scrolls", () => {
+      // jsdom defines `isTrusted` as a non-configurable accessor on its Event
+      // prototype, so there is no way to construct a pre-trusted event -- see the
+      // long-form explanation in click_test.ts. Capture the real listener
+      // registered by startScrollInstrumentation and invoke it directly instead.
+      const pane = scrollable();
+      const addSpy = vi.spyOn(globalWindow, "addEventListener");
+      startScrollInstrumentation();
+
+      const listener = addSpy.mock.calls.find((call) => call[0] === "scroll")![1] as EventListener;
+      // Two events, not one: the burst baseline is sampled from the first event,
+      // so a single-event burst has a net delta of 0 and is dropped as a
+      // micro-scroll. This shape asserts the gate, not the sampling behaviour.
+      pane.scrollTop = 0;
+      listener({ isTrusted: true, target: pane } as unknown as Event);
+      pane.scrollTop = 120;
+      listener({ isTrusted: true, target: pane } as unknown as Event);
+
+      addSpy.mockRestore();
+      flushScrollBurstForTests();
+      expect(sendLog).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe("error handling", () => {
+    it("swallows errors while tracking a burst and starts no burst at all", () => {
+      const pane = scrollable();
+      Object.defineProperty(pane, "scrollTop", {
+        get() {
+          throw new Error("boom");
+        },
+      });
+
+      expect(() => handleScroll(scrollEventFor(pane))).not.toThrow();
+
+      flushScrollBurstForTests();
+      expect(sendLog).not.toHaveBeenCalled();
+    });
+
+    it("swallows errors while finalizing a burst and still resets burst state", () => {
+      const pane = scrollable();
+
+      pane.scrollTop = 0;
+      handleScroll(scrollEventFor(pane));
+      pane.scrollTop = 200;
+      handleScroll(scrollEventFor(pane));
+
+      (sendLog as ReturnType<typeof vi.fn>).mockImplementationOnce(() => {
+        throw new Error("boom");
+      });
+      // finalizeBurst runs inside the settle timer in production, where an
+      // uncaught throw is unrecoverable.
+      expect(() => flushScrollBurstForTests()).not.toThrow();
+
+      // The burst is cleared before the try block, so one poisoned burst must not
+      // wedge every subsequent scroll.
+      pane.scrollTop = 400;
+      handleScroll(scrollEventFor(pane));
+      pane.scrollTop = 600;
+      handleScroll(scrollEventFor(pane));
+      flushScrollBurstForTests();
+
+      expect(sendLog).toHaveBeenCalledTimes(2);
+      expect(lastLog().body).toEqual({ stringValue: "Scroll down on /" });
+    });
   });
 });

--- a/src/instrumentations/interactions/scroll_test.ts
+++ b/src/instrumentations/interactions/scroll_test.ts
@@ -56,11 +56,23 @@ describe("scroll instrumentation", () => {
     vi.clearAllMocks();
   });
 
+  /**
+   * Real dispatch order: the offset changes first, the scroll event follows. So
+   * every `scrollTop` assignment below is immediately followed by the event it
+   * caused, and the position a burst started from is never itself the subject of
+   * an event -- it is either remembered from an earlier burst, or assumed to be 0
+   * for an element nobody has seen scroll yet.
+   */
+  function settleBurstAt(pane: HTMLElement, top: number): void {
+    pane.scrollTop = top;
+    handleScroll(scrollEventFor(pane));
+    flushScrollBurstForTests();
+    vi.clearAllMocks();
+  }
+
   it("collapses a burst of scroll events into a single event with the net direction", () => {
     const pane = scrollable();
 
-    pane.scrollTop = 0;
-    handleScroll(scrollEventFor(pane));
     pane.scrollTop = 40;
     handleScroll(scrollEventFor(pane));
     pane.scrollTop = 120;
@@ -77,8 +89,9 @@ describe("scroll instrumentation", () => {
 
   it("reports upward scrolling", () => {
     const pane = scrollable();
+    settleBurstAt(pane, 200);
 
-    pane.scrollTop = 200;
+    pane.scrollTop = 120;
     handleScroll(scrollEventFor(pane));
     pane.scrollTop = 20;
     handleScroll(scrollEventFor(pane));
@@ -90,11 +103,72 @@ describe("scroll instrumentation", () => {
     expect(attr(log, INTERACTION_DIRECTION)).toEqual({ stringValue: "up" });
   });
 
-  it("drops micro-scrolls below the noise threshold", () => {
+  it("emits a single-event burst, measured from where the previous burst ended", () => {
     const pane = scrollable();
+    settleBurstAt(pane, 200);
 
+    // One event is all a programmatic jump (`scrollTo`, anchor navigation,
+    // `scrollIntoView`, Home/End) produces. Sampling the baseline from this very
+    // event would net a delta of 0 and drop the burst as a micro-scroll.
     pane.scrollTop = 100;
     handleScroll(scrollEventFor(pane));
+    flushScrollBurstForTests();
+
+    expect(sendLog).toHaveBeenCalledOnce();
+    expect(attr(lastLog(), INTERACTION_DIRECTION)).toEqual({ stringValue: "up" });
+  });
+
+  it("assumes an unseen element started at 0, so its very first burst is not lost either", () => {
+    const pane = scrollable();
+
+    pane.scrollTop = 400;
+    handleScroll(scrollEventFor(pane));
+    flushScrollBurstForTests();
+
+    expect(sendLog).toHaveBeenCalledOnce();
+    expect(attr(lastLog(), INTERACTION_DIRECTION)).toEqual({ stringValue: "down" });
+  });
+
+  it("keeps the observed end position when the element is reset or detached before the burst settles", () => {
+    const pane = scrollable();
+
+    pane.scrollTop = 200;
+    handleScroll(scrollEventFor(pane));
+
+    // A modal closing, a dropdown dismissing or a route change resets the
+    // container inside the settle window. Re-reading it here would see 0 and
+    // finalize a phantom "up".
+    pane.remove();
+    pane.scrollTop = 0;
+    flushScrollBurstForTests();
+
+    expect(sendLog).toHaveBeenCalledOnce();
+    expect(attr(lastLog(), INTERACTION_DIRECTION)).toEqual({ stringValue: "down" });
+  });
+
+  it("does not read the element at all while finalizing", () => {
+    const pane = scrollable();
+
+    pane.scrollTop = 200;
+    handleScroll(scrollEventFor(pane));
+
+    // Stronger than the reset case above: any DOM read at finalize time now
+    // throws, so the burst can only be finalized from what the handler saw.
+    Object.defineProperty(pane, "scrollTop", {
+      get() {
+        throw new Error("scrollTop must not be read at finalize time");
+      },
+    });
+    flushScrollBurstForTests();
+
+    expect(sendLog).toHaveBeenCalledOnce();
+    expect(attr(lastLog(), INTERACTION_DIRECTION)).toEqual({ stringValue: "down" });
+  });
+
+  it("drops micro-scrolls below the noise threshold", () => {
+    const pane = scrollable();
+    settleBurstAt(pane, 100);
+
     pane.scrollTop = 103; // 3px net movement
     handleScroll(scrollEventFor(pane));
 
@@ -106,8 +180,6 @@ describe("scroll instrumentation", () => {
   it("emits nothing while a burst is still in flight", () => {
     const pane = scrollable();
 
-    pane.scrollTop = 0;
-    handleScroll(scrollEventFor(pane));
     pane.scrollTop = 500;
     handleScroll(scrollEventFor(pane));
 
@@ -143,8 +215,6 @@ describe("scroll instrumentation", () => {
     it("clears an in-flight burst on teardown even when the listener was never attached", () => {
       const pane = scrollable();
 
-      pane.scrollTop = 0;
-      handleScroll(scrollEventFor(pane));
       pane.scrollTop = 300;
       handleScroll(scrollEventFor(pane));
 
@@ -161,13 +231,11 @@ describe("scroll instrumentation", () => {
       const pane = scrollable();
       startScrollInstrumentation();
 
-      pane.scrollTop = 0;
+      pane.scrollTop = 400;
       // scroll does not bubble, but a capture-phase listener on window is on the
       // propagation path of every dispatch, so this really does reach the listener.
       const event = new Event("scroll", { bubbles: false });
       pane.dispatchEvent(event);
-      pane.scrollTop = 400;
-      pane.dispatchEvent(new Event("scroll", { bubbles: false }));
 
       expect(event.isTrusted).toBe(false);
       // Flushing is what makes this assertion mean "no burst was ever started"
@@ -186,11 +254,6 @@ describe("scroll instrumentation", () => {
       startScrollInstrumentation();
 
       const listener = addSpy.mock.calls.find((call) => call[0] === "scroll")![1] as EventListener;
-      // Two events, not one: the burst baseline is sampled from the first event,
-      // so a single-event burst has a net delta of 0 and is dropped as a
-      // micro-scroll. This shape asserts the gate, not the sampling behaviour.
-      pane.scrollTop = 0;
-      listener({ isTrusted: true, target: pane } as unknown as Event);
       pane.scrollTop = 120;
       listener({ isTrusted: true, target: pane } as unknown as Event);
 
@@ -218,8 +281,6 @@ describe("scroll instrumentation", () => {
     it("swallows errors while finalizing a burst and still resets burst state", () => {
       const pane = scrollable();
 
-      pane.scrollTop = 0;
-      handleScroll(scrollEventFor(pane));
       pane.scrollTop = 200;
       handleScroll(scrollEventFor(pane));
 

--- a/src/instrumentations/interactions/scroll_test.ts
+++ b/src/instrumentations/interactions/scroll_test.ts
@@ -12,6 +12,7 @@ vi.mock("../../transport", () => ({
 import {
   handleScroll,
   flushScrollBurstForTests,
+  SCROLL_SETTLE_MILLIS,
   startScrollInstrumentation,
   stopScrollInstrumentationForTests,
 } from "./scroll";
@@ -188,13 +189,44 @@ describe("scroll instrumentation", () => {
     expect(sendLog).toHaveBeenCalledOnce();
   });
 
+  /**
+   * The only test that drives the production settle timer instead of calling
+   * flushScrollBurstForTests(); without it, deleting the setTimeout in
+   * handleScroll would keep every other test in this file green.
+   *
+   * It really does wait: utils/timers captures win.setTimeout at module load,
+   * so vi.useFakeTimers() cannot intercept the timer this code schedules.
+   */
+  it("emits after the settle timer, with no test-only flush", async () => {
+    const pane = scrollable();
+
+    pane.scrollTop = 200;
+    handleScroll(scrollEventFor(pane));
+    expect(sendLog).not.toHaveBeenCalled();
+
+    await new Promise((resolve) => globalThis.setTimeout(resolve, SCROLL_SETTLE_MILLIS + 50));
+
+    expect(sendLog).toHaveBeenCalledOnce();
+    expect(attr(lastLog(), INTERACTION_DIRECTION)).toEqual({ stringValue: "down" });
+  });
+
   describe("startScrollInstrumentation (real capture-phase listener + isTrusted gate)", () => {
+    /**
+     * Filtered by event type rather than asserting a total call count: the
+     * unload hook also registers window-level pagehide/beforeunload listeners,
+     * and it registers only on the *first* start* in this file, so any count
+     * over all registrations would depend on test order.
+     */
+    function scrollRegistrations(addSpy: ReturnType<typeof vi.spyOn>) {
+      return addSpy.mock.calls.filter((call) => call[0] === "scroll");
+    }
+
     it("registers exactly one window-level capture-phase scroll listener", () => {
       const addSpy = vi.spyOn(globalWindow, "addEventListener");
 
       startScrollInstrumentation();
 
-      expect(addSpy).toHaveBeenCalledOnce();
+      expect(scrollRegistrations(addSpy)).toHaveLength(1);
       // `passive: true` is load-bearing: scroll fires per frame on the input
       // delay path, and a non-passive listener lets the SDK block scrolling.
       expect(addSpy).toHaveBeenCalledWith("scroll", expect.any(Function), { capture: true, passive: true });
@@ -208,7 +240,7 @@ describe("scroll instrumentation", () => {
       startScrollInstrumentation();
       startScrollInstrumentation();
 
-      expect(addSpy).toHaveBeenCalledOnce();
+      expect(scrollRegistrations(addSpy)).toHaveLength(1);
       addSpy.mockRestore();
     });
 
@@ -258,6 +290,65 @@ describe("scroll instrumentation", () => {
       listener({ isTrusted: true, target: pane } as unknown as Event);
 
       addSpy.mockRestore();
+      flushScrollBurstForTests();
+      expect(sendLog).toHaveBeenCalledOnce();
+    });
+  });
+
+  /**
+   * None of these call a flush helper -- the burst has to be finalized by the
+   * unload hook alone, otherwise the assertion would pass with the hook removed.
+   */
+  describe("flushes an in-flight burst on unload", () => {
+    function startBurst(): void {
+      const pane = scrollable();
+      startScrollInstrumentation();
+      pane.scrollTop = 200;
+      handleScroll(scrollEventFor(pane));
+      expect(sendLog).not.toHaveBeenCalled();
+    }
+
+    it("finalizes the burst on pagehide", () => {
+      startBurst();
+
+      globalWindow.dispatchEvent(new Event("pagehide"));
+
+      expect(sendLog).toHaveBeenCalledOnce();
+      expect(attr(lastLog(), INTERACTION_DIRECTION)).toEqual({ stringValue: "down" });
+    });
+
+    it("finalizes the burst on beforeunload", () => {
+      startBurst();
+
+      globalWindow.dispatchEvent(new Event("beforeunload"));
+
+      expect(sendLog).toHaveBeenCalledOnce();
+      expect(attr(lastLog(), INTERACTION_DIRECTION)).toEqual({ stringValue: "down" });
+    });
+
+    it("finalizes the burst once the document is no longer visible", () => {
+      startBurst();
+
+      // jsdom defines visibilityState as a configurable getter on
+      // Document.prototype, so it can be stubbed; the afterEach
+      // restoreAllMocks() puts it back.
+      vi.spyOn(dom, "visibilityState", "get").mockReturnValue("hidden");
+      dom.dispatchEvent(new Event("visibilitychange"));
+
+      expect(sendLog).toHaveBeenCalledOnce();
+      expect(attr(lastLog(), INTERACTION_DIRECTION)).toEqual({ stringValue: "down" });
+    });
+
+    it("keeps the burst in flight on a visibilitychange that leaves the document visible", () => {
+      startBurst();
+
+      // Proves the hook is driven by the visibility check rather than the bare
+      // event: a tab regaining focus must not chop the burst in two.
+      expect(dom.visibilityState).toBe("visible");
+      dom.dispatchEvent(new Event("visibilitychange"));
+
+      expect(sendLog).not.toHaveBeenCalled();
+      // Still finalizable, i.e. the burst survived rather than being dropped.
       flushScrollBurstForTests();
       expect(sendLog).toHaveBeenCalledOnce();
     });

--- a/src/semantic-conventions.ts
+++ b/src/semantic-conventions.ts
@@ -42,13 +42,32 @@ export const EXCEPTION_MESSAGE = "exception.message";
 export const EXCEPTION_TYPE = "exception.type";
 export const EXCEPTION_STACKTRACE = "exception.stacktrace";
 
-// Interaction Attribute Keys
-export const INTERACTION_TYPE = "type";
-export const INTERACTION_NAME = "name";
-export const INTERACTION_NAME_SOURCE = "name_source";
-export const INTERACTION_TARGET_SELECTOR = "target.selector";
-export const INTERACTION_TARGET_TAG = "target.tag";
-export const INTERACTION_TARGET_ID = "target.id";
+// Interaction Attribute Keys. These are LOG RECORD attributes (namespaced like
+// page.* / user_agent.*), NOT body keys: the browser.interaction body is a
+// plain human-readable string ("Click \"Save Part\" on /inventory/parts") so
+// UIs without a dedicated renderer for this event type display something
+// readable, while the structured fields stay individually filterable.
+export const INTERACTION_ID = "interaction.id";
+export const INTERACTION_TYPE = "interaction.type";
+export const INTERACTION_NAME = "interaction.name";
+export const INTERACTION_NAME_SOURCE = "interaction.name_source";
+export const INTERACTION_TARGET_SELECTOR = "interaction.target.selector";
+export const INTERACTION_TARGET_TAG = "interaction.target.tag";
+export const INTERACTION_TARGET_ID = "interaction.target.id";
+/** key_press events: the captured key (allow-listed control keys only). */
+export const INTERACTION_KEY = "interaction.key";
+/** scroll events: net direction of the scroll burst (up/down/left/right). */
+export const INTERACTION_DIRECTION = "interaction.direction";
+/** change events: length of the new value; the value itself is never read. */
+export const INTERACTION_VALUE_LENGTH = "interaction.value_length";
+/** change events on selects: number of selected options. */
+export const INTERACTION_SELECTED_COUNT = "interaction.selected_count";
+
+// Span attribute keys linking an HTTP request span to the user interaction
+// (click) that triggered it. Stamped on XHR/fetch spans started while an
+// interaction is active, mirroring the "user action" concept of RUM products.
+export const USER_INTERACTION_ID = "user_interaction.id";
+export const USER_INTERACTION_NAME = "user_interaction.name";
 
 // Error Attribute Keys
 export const ERROR_TYPE = "error.type";

--- a/src/semantic-conventions.ts
+++ b/src/semantic-conventions.ts
@@ -42,6 +42,14 @@ export const EXCEPTION_MESSAGE = "exception.message";
 export const EXCEPTION_TYPE = "exception.type";
 export const EXCEPTION_STACKTRACE = "exception.stacktrace";
 
+// Interaction Attribute Keys
+export const INTERACTION_TYPE = "type";
+export const INTERACTION_NAME = "name";
+export const INTERACTION_NAME_SOURCE = "name_source";
+export const INTERACTION_TARGET_SELECTOR = "target.selector";
+export const INTERACTION_TARGET_TAG = "target.tag";
+export const INTERACTION_TARGET_ID = "target.id";
+
 // Error Attribute Keys
 export const ERROR_TYPE = "error.type";
 
@@ -68,6 +76,7 @@ export const EVENT_NAMES = {
   NAVIGATION_TIMING: "browser.navigation_timing",
   WEB_VITAL: "browser.web_vital",
   ERROR: "browser.error",
+  INTERACTION: "browser.interaction",
 };
 export const SPAN_EVENT_NAME_EXCEPTION = "exception";
 

--- a/src/semantic-conventions.ts
+++ b/src/semantic-conventions.ts
@@ -56,6 +56,11 @@ export const INTERACTION_TARGET_TAG = "interaction.target.tag";
 export const INTERACTION_TARGET_ID = "interaction.target.id";
 /** key_press events: the captured key (allow-listed control keys only). */
 export const INTERACTION_KEY = "interaction.key";
+/**
+ * key_press events: how many presses of that key the coalesced burst covers.
+ * Only present when greater than 1.
+ */
+export const INTERACTION_REPEAT_COUNT = "interaction.repeat_count";
 /** scroll events: net direction of the scroll burst (up/down/left/right). */
 export const INTERACTION_DIRECTION = "interaction.direction";
 /** change events: length of the new value; the value itself is never read. */

--- a/src/transport/index.ts
+++ b/src/transport/index.ts
@@ -3,6 +3,7 @@ import { send } from "./fetch";
 import { vars } from "../vars";
 import { debug, error, createRateLimiter } from "../utils";
 import { ExportLogsServiceRequest, ExportTraceServiceRequest, LogRecord, Span } from "../types/otlp";
+import { MAX_TRANSPORT_CALLS_PER_TEN_MINUTES, MAX_TRANSPORT_CALLS_PER_TEN_SECONDS } from "./limits";
 
 const logBatcher = newBatcher<LogRecord>(sendLogs);
 const spanBatcher = newBatcher<Span>(sendSpans);
@@ -12,8 +13,8 @@ let rateLimiter: (() => boolean) | undefined;
 function isRateLimited() {
   if (!rateLimiter) {
     rateLimiter = createRateLimiter({
-      maxCallsPerTenMinutes: 4096,
-      maxCallsPerTenSeconds: 128,
+      maxCallsPerTenMinutes: MAX_TRANSPORT_CALLS_PER_TEN_MINUTES,
+      maxCallsPerTenSeconds: MAX_TRANSPORT_CALLS_PER_TEN_SECONDS,
     });
   }
 

--- a/src/transport/limits.ts
+++ b/src/transport/limits.ts
@@ -1,0 +1,12 @@
+/**
+ * Ceilings for the transport-wide rate limiter, shared by every signal the SDK
+ * emits (see ./index.ts).
+ *
+ * They live in their own module rather than in the transport barrel so that
+ * producers keeping their own sub-budget -- currently
+ * instrumentations/interactions/emit.ts -- can clamp against the real limit
+ * instead of duplicating the number, without having to reach through a module
+ * that unit tests routinely replace with a `sendLog` stub.
+ */
+export const MAX_TRANSPORT_CALLS_PER_TEN_SECONDS = 128;
+export const MAX_TRANSPORT_CALLS_PER_TEN_MINUTES = 4096;

--- a/src/types/options.ts
+++ b/src/types/options.ts
@@ -7,7 +7,8 @@ export type InstrumentationName =
   | "@dash0/web-vitals"
   | "@dash0/error"
   | "@dash0/fetch"
-  | "@dash0/xhr";
+  | "@dash0/xhr"
+  | "@dash0/interactions";
 
 /**
  * VCS (version control) context describing the build the SDK is running
@@ -141,6 +142,7 @@ export type InitOptions = {
     | "headersToCapture"
     | "urlAttributeScrubber"
     | "pageViewInstrumentation"
+    | "interactionInstrumentation"
     | "enableTransportCompression"
   >
 >;

--- a/src/utils/dom.ts
+++ b/src/utils/dom.ts
@@ -1,0 +1,61 @@
+// Clobber-safe element reads.
+//
+// `HTMLFormElement` is declared `[LegacyOverrideBuiltIns]`, so a named form control
+// shadows built-in properties *on the form element itself*: given
+// `<form id="real"><input name="id"></form>`, `form.id` returns the input element
+// rather than "real". `<input name="id">` is ordinary markup, so any code reading
+// `.id` off a DOM element it did not create can receive an Element instead of a
+// string. `tagName`, `classList` and even `getAttribute` are shadowable the same
+// way -- which is why switching to `element.getAttribute("id")` is not a fix on its
+// own: with `<input name="getAttribute">` the method itself is an element and
+// calling it throws.
+//
+// Reading through the `Element.prototype` accessors sidesteps all of it, because the
+// form's named getter only ever creates own properties on the form instance. Only
+// `<form>` is affected -- a `<div>` containing `<input name="id">` reads normally --
+// but the safe accessors cost nothing on other elements, so they are used
+// unconditionally.
+//
+// Note that jsdom does not implement this shadowing, so unit tests have to simulate
+// it with `Object.defineProperty`; the real behaviour is only observable in a browser.
+
+// Resolved once. It is important to check via typeof here because Element might not
+// even be declared when imported in ssr.
+const elementProto = typeof Element !== "undefined" ? Element.prototype : undefined;
+const protoGetAttribute = elementProto?.getAttribute;
+const protoTagName = elementProto
+  ? (Object.getOwnPropertyDescriptor(elementProto, "tagName")?.get as ((this: Element) => string) | undefined)
+  : undefined;
+
+/**
+ * `element.getAttribute(name)`, immune to a shadowed `getAttribute`.
+ */
+export function elementAttribute(element: Element, name: string): string | null {
+  return protoGetAttribute ? protoGetAttribute.call(element, name) : element.getAttribute(name);
+}
+
+/**
+ * `element.tagName`, immune to a shadowed `tagName`. Uppercase for HTML elements in
+ * HTML documents, matching the property it replaces.
+ */
+export function elementTag(element: Element): string {
+  return protoTagName ? protoTagName.call(element) : element.tagName;
+}
+
+/**
+ * `element.id`, immune to a shadowed `id`. Returns "" when the element has no id,
+ * matching the property it replaces.
+ */
+export function elementId(element: Element): string {
+  return elementAttribute(element, "id") ?? "";
+}
+
+/**
+ * The first of the element's class names, immune to a shadowed `classList`.
+ * Equivalent to `element.classList.item(0)`, undefined when there is none.
+ */
+export function elementFirstClass(element: Element): string | undefined {
+  const classes = elementAttribute(element, "class");
+  if (!classes) return undefined;
+  return classes.trim().split(/\s+/)[0] || undefined;
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,4 +1,5 @@
 export * from "./debug";
+export * from "./dom";
 export * from "./obj";
 export * from "./fn";
 export * from "./globals";

--- a/src/utils/otel/attributes.ts
+++ b/src/utils/otel/attributes.ts
@@ -92,6 +92,23 @@ export function removeAttribute(attributes: KeyValue[], key: string) {
   }
 }
 
+/**
+ * Finds an attribute in the provided attributes array by its key.
+ *
+ * Scans backwards, so the most recently added value wins over any earlier entry
+ * carrying the same key. That matters for arrays assembled by
+ * `addCommonAttributes`, which splices in user-supplied `signalAttributes`
+ * before deriving the SDK's own attributes.
+ */
+export function findLastAttribute(attributes: KeyValue[], key: string): KeyValue | undefined {
+  for (let i = attributes.length - 1; i >= 0; i--) {
+    if (attributes[i]!["key"] === key) {
+      return attributes[i];
+    }
+  }
+  return undefined;
+}
+
 export type AttrPrefix = string | string[];
 export function withPrefix(prefix?: AttrPrefix): (attr: string) => string {
   if (!prefix) return (attr) => attr;

--- a/src/utils/otel/attributes_test.ts
+++ b/src/utils/otel/attributes_test.ts
@@ -1,5 +1,5 @@
 import { expect, describe, it } from "vitest";
-import { addAttribute, toAnyValue } from "./attributes";
+import { addAttribute, findLastAttribute, toAnyValue } from "./attributes";
 import { AnyValue, KeyValue } from "../../types/otlp";
 
 describe("toAnyValue", () => {
@@ -195,5 +195,40 @@ describe("toAnyValue", () => {
 
       expect(attributes).toHaveLength(0);
     });
+  });
+});
+
+describe("findLastAttribute", () => {
+  it("finds an attribute by key", () => {
+    const attributes: KeyValue[] = [];
+    addAttribute(attributes, "a", "first");
+    addAttribute(attributes, "b", "second");
+
+    expect(findLastAttribute(attributes, "b")).toEqual({ key: "b", value: { stringValue: "second" } });
+  });
+
+  it("returns the last entry when a key appears more than once", () => {
+    // Callers rely on this: addCommonAttributes splices user-supplied
+    // signalAttributes in before deriving the SDK's own attributes, so the
+    // SDK-derived value must win.
+    const attributes: KeyValue[] = [];
+    addAttribute(attributes, "page.url.path", "/spoofed");
+    addAttribute(attributes, "page.url.path", "/derived");
+
+    expect(findLastAttribute(attributes, "page.url.path")).toEqual({
+      key: "page.url.path",
+      value: { stringValue: "/derived" },
+    });
+  });
+
+  it("returns undefined for a missing key", () => {
+    const attributes: KeyValue[] = [];
+    addAttribute(attributes, "a", "first");
+
+    expect(findLastAttribute(attributes, "missing")).toBeUndefined();
+  });
+
+  it("returns undefined for an empty attribute set", () => {
+    expect(findLastAttribute([], "a")).toBeUndefined();
   });
 });

--- a/src/vars.ts
+++ b/src/vars.ts
@@ -62,6 +62,8 @@ export type InteractionInstrumentationSettings = {
   /**
    * Whether the SDK should automatically capture click interactions.
    * Opt-in: disabled by default.
+   * Also requires "@dash0/interactions" to be present in enabledInstrumentations
+   * (or enabledInstrumentations left undefined).
    *
    * @default false
    */

--- a/src/vars.ts
+++ b/src/vars.ts
@@ -78,6 +78,33 @@ export type InteractionInstrumentationSettings = {
    * @default "data-dash0-action-name"
    */
   actionNameAttribute?: string;
+
+  /**
+   * Whether scroll interactions are captured (one event per scroll burst,
+   * with the net direction). Only applies when `enabled` is true.
+   *
+   * @default true
+   */
+  captureScrolls?: boolean;
+
+  /**
+   * Whether key presses are captured. Only navigation/activation keys
+   * (Enter, Tab, Escape, Space, arrows, ...) are ever recorded; printable
+   * characters never are. Only applies when `enabled` is true.
+   *
+   * @default true
+   */
+  captureKeyPresses?: boolean;
+
+  /**
+   * Whether form-field changes are captured. The field value is never read:
+   * text fields report only the value length, selects only the selected
+   * count, and password fields report neither. Only applies when `enabled`
+   * is true.
+   *
+   * @default true
+   */
+  captureChanges?: boolean;
 };
 
 export type Vars = {
@@ -234,6 +261,9 @@ export const vars: Vars = {
   interactionInstrumentation: {
     enabled: false,
     actionNameAttribute: "data-dash0-action-name",
+    captureScrolls: true,
+    captureKeyPresses: true,
+    captureChanges: true,
   },
   enableTransportCompression: false,
   isSessionSampled: true,

--- a/src/vars.ts
+++ b/src/vars.ts
@@ -58,6 +58,26 @@ export type PageViewInstrumentationSettings = {
   includeParts?: Array<"HASH" | "SEARCH">;
 };
 
+export type InteractionInstrumentationSettings = {
+  /**
+   * Whether the SDK should automatically capture click interactions.
+   * Opt-in: disabled by default.
+   *
+   * @default false
+   */
+  enabled?: boolean;
+
+  /**
+   * The element attribute the SDK checks first (on the clicked element or any
+   * ancestor) when deriving a human-readable interaction name. Set this
+   * attribute on interactive elements to fully control the captured name,
+   * e.g. `<button data-dash0-action-name="Save Settings">`.
+   *
+   * @default "data-dash0-action-name"
+   */
+  actionNameAttribute?: string;
+};
+
 export type Vars = {
   /**
    * Telemetry endpoints to which the generated telemetry should be sent
@@ -167,6 +187,12 @@ export type Vars = {
   pageViewInstrumentation: PageViewInstrumentationSettings;
 
   /**
+   * Configures automatic user-interaction (click) instrumentation. Opt-in --
+   * disabled by default. See {@link InteractionInstrumentationSettings}.
+   */
+  interactionInstrumentation: InteractionInstrumentationSettings;
+
+  /**
    * Enables telemetry transport compression using gzip.
    * experimental - in rare cases causes Chrome to crash to use at your own risk.
    */
@@ -202,6 +228,10 @@ export const vars: Vars = {
   pageViewInstrumentation: {
     trackVirtualPageViews: true,
     includeParts: [],
+  },
+  interactionInstrumentation: {
+    enabled: false,
+    actionNameAttribute: "data-dash0-action-name",
   },
   enableTransportCompression: false,
   isSessionSampled: true,

--- a/src/vars.ts
+++ b/src/vars.ts
@@ -80,29 +80,29 @@ export type InteractionInstrumentationSettings = {
   actionNameAttribute?: string;
 
   /**
-   * Whether scroll interactions are captured (one event per scroll burst,
+   * Opt in to capturing scroll interactions (one event per scroll burst,
    * with the net direction). Only applies when `enabled` is true.
    *
-   * @default true
+   * @default false
    */
   captureScrolls?: boolean;
 
   /**
-   * Whether key presses are captured. Only navigation/activation keys
+   * Opt in to capturing key presses. Only navigation/activation keys
    * (Enter, Tab, Escape, Space, arrows, ...) are ever recorded; printable
    * characters never are. Only applies when `enabled` is true.
    *
-   * @default true
+   * @default false
    */
   captureKeyPresses?: boolean;
 
   /**
-   * Whether form-field changes are captured. The field value is never read:
+   * Opt in to capturing form-field changes. The field value is never read:
    * text fields report only the value length, selects only the selected
    * count, and password fields report neither. Only applies when `enabled`
    * is true.
    *
-   * @default true
+   * @default false
    */
   captureChanges?: boolean;
 };
@@ -261,9 +261,9 @@ export const vars: Vars = {
   interactionInstrumentation: {
     enabled: false,
     actionNameAttribute: "data-dash0-action-name",
-    captureScrolls: true,
-    captureKeyPresses: true,
-    captureChanges: true,
+    captureScrolls: false,
+    captureKeyPresses: false,
+    captureChanges: false,
   },
   enableTransportCompression: false,
   isSessionSampled: true,

--- a/src/vars.ts
+++ b/src/vars.ts
@@ -66,6 +66,13 @@ export type PageViewInstrumentationSettings = {
  */
 export const DEFAULT_ACTION_NAME_ATTRIBUTE = "data-dash0-action-name";
 
+/**
+ * Fallback for `InteractionInstrumentationSettings.maxEventsPerTenSeconds`, for
+ * the same reason as the constant above. A quarter of the transport's
+ * per-ten-second budget, so interaction volume leaves the other signals room.
+ */
+export const DEFAULT_MAX_INTERACTION_EVENTS_PER_TEN_SECONDS = 32;
+
 export type InteractionInstrumentationSettings = {
   /**
    * Whether the SDK should automatically capture click interactions.
@@ -113,6 +120,23 @@ export type InteractionInstrumentationSettings = {
    * @default false
    */
   captureChanges?: boolean;
+
+  /**
+   * Maximum number of interaction events emitted per ten seconds.
+   *
+   * Interaction capture gets its own budget rather than competing for the
+   * transport-wide one, so a burst of interactions can never evict spans,
+   * errors, page views or web vitals. The ten-minute allowance is derived as 16x
+   * this value, which keeps interactions at the same share of the transport
+   * budget in both windows. Events over the budget are dropped at the source.
+   *
+   * Clamped to [1, 128] -- 128 being the transport's own per-ten-second
+   * ceiling, at which point interactions may consume the entire budget. The
+   * default leaves three quarters of it to the other signals.
+   *
+   * @default 32
+   */
+  maxEventsPerTenSeconds?: number;
 
   /**
    * Last-chance hook to replace or drop a derived interaction name. Runs as the
@@ -293,6 +317,7 @@ export const vars: Vars = {
     captureScrolls: false,
     captureKeyPresses: false,
     captureChanges: false,
+    maxEventsPerTenSeconds: DEFAULT_MAX_INTERACTION_EVENTS_PER_TEN_SECONDS,
   },
   enableTransportCompression: false,
   isSessionSampled: true,

--- a/src/vars.ts
+++ b/src/vars.ts
@@ -1,6 +1,7 @@
 import { AttributeValueType } from "./utils/otel";
 import { AnyValue, InstrumentationScope, KeyValue, Resource } from "./types/otlp";
 import { UrlAttributeScrubber } from "./attributes";
+import type { ActionNameScrubber } from "./instrumentations/interactions/action-name";
 import { identity } from "./utils";
 
 export type PropagatorType = "traceparent" | "xray";
@@ -58,6 +59,13 @@ export type PageViewInstrumentationSettings = {
   includeParts?: Array<"HASH" | "SEARCH">;
 };
 
+/**
+ * Fallback for `InteractionInstrumentationSettings.actionNameAttribute`. Lives
+ * here rather than in the interactions module so that module can import it
+ * without vars.ts needing a runtime import back (which would be a cycle).
+ */
+export const DEFAULT_ACTION_NAME_ATTRIBUTE = "data-dash0-action-name";
+
 export type InteractionInstrumentationSettings = {
   /**
    * Whether the SDK should automatically capture click interactions.
@@ -105,6 +113,27 @@ export type InteractionInstrumentationSettings = {
    * @default false
    */
   captureChanges?: boolean;
+
+  /**
+   * Last-chance hook to replace or drop a derived interaction name. Runs as the
+   * final step of name derivation, so it covers every place the name is
+   * emitted: the `interaction.name` attribute, the human-readable event body,
+   * and `user_interaction.name` on correlated HTTP spans.
+   *
+   * Receives the name the SDK would otherwise emit (already whitespace
+   * normalized and truncated), how it was derived, and the interaction target.
+   * Return a replacement, or an empty string to drop the name entirely. The
+   * return value is normalized and truncated again.
+   *
+   * Only invoked when a name was actually derived -- it cannot invent a name
+   * for an interaction the SDK could not name.
+   *
+   * Fails closed: if the scrubber throws or returns a non-string, the name is
+   * dropped rather than emitted unscrubbed.
+   *
+   * @default undefined
+   */
+  actionNameScrubber?: ActionNameScrubber;
 };
 
 export type Vars = {
@@ -260,7 +289,7 @@ export const vars: Vars = {
   },
   interactionInstrumentation: {
     enabled: false,
-    actionNameAttribute: "data-dash0-action-name",
+    actionNameAttribute: DEFAULT_ACTION_NAME_ATTRIBUTE,
     captureScrolls: false,
     captureKeyPresses: false,
     captureChanges: false,

--- a/src/vars_test.ts
+++ b/src/vars_test.ts
@@ -6,6 +6,9 @@ describe("vars defaults", () => {
     expect(vars.interactionInstrumentation).toEqual({
       enabled: false,
       actionNameAttribute: "data-dash0-action-name",
+      captureScrolls: true,
+      captureKeyPresses: true,
+      captureChanges: true,
     });
   });
 });

--- a/src/vars_test.ts
+++ b/src/vars_test.ts
@@ -6,9 +6,9 @@ describe("vars defaults", () => {
     expect(vars.interactionInstrumentation).toEqual({
       enabled: false,
       actionNameAttribute: "data-dash0-action-name",
-      captureScrolls: true,
-      captureKeyPresses: true,
-      captureChanges: true,
+      captureScrolls: false,
+      captureKeyPresses: false,
+      captureChanges: false,
     });
   });
 });

--- a/src/vars_test.ts
+++ b/src/vars_test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "vitest";
+import { vars } from "./vars";
+
+describe("vars defaults", () => {
+  it("defaults interactionInstrumentation to disabled with the standard action-name attribute", () => {
+    expect(vars.interactionInstrumentation).toEqual({
+      enabled: false,
+      actionNameAttribute: "data-dash0-action-name",
+    });
+  });
+});

--- a/src/vars_test.ts
+++ b/src/vars_test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { vars } from "./vars";
+import { DEFAULT_MAX_INTERACTION_EVENTS_PER_TEN_SECONDS, vars } from "./vars";
+import { MAX_TRANSPORT_CALLS_PER_TEN_SECONDS } from "./transport/limits";
 
 describe("vars defaults", () => {
   it("defaults interactionInstrumentation to disabled with the standard action-name attribute", () => {
@@ -9,6 +10,13 @@ describe("vars defaults", () => {
       captureScrolls: false,
       captureKeyPresses: false,
       captureChanges: false,
+      maxEventsPerTenSeconds: DEFAULT_MAX_INTERACTION_EVENTS_PER_TEN_SECONDS,
     });
+  });
+
+  it("leaves the majority of the transport budget to the other signals", () => {
+    // A default that met or exceeded the transport ceiling would let interaction
+    // volume evict spans, errors, page views and web vitals.
+    expect(DEFAULT_MAX_INTERACTION_EVENTS_PER_TEN_SECONDS).toBeLessThan(MAX_TRANSPORT_CALLS_PER_TEN_SECONDS / 2);
   });
 });

--- a/test/e2e/spec/10-interactions/10-interactions.test.ts
+++ b/test/e2e/spec/10-interactions/10-interactions.test.ts
@@ -1,14 +1,16 @@
-import { sharedAfterEach, sharedBeforeEach } from "../shared";
+import { getOTLPRequests, sharedAfterEach, sharedBeforeEach } from "../shared";
+import { generateUniqueId } from "../../../../src/utils";
 import { browser } from "@wdio/globals";
 import { loadPage, retry } from "../utils";
-import { expectLogMatching, expectNoLogMatching } from "../expectations";
+import { expectLogMatching, expectNoBrowserErrors, expectNoLogMatching } from "../expectations";
 
 describe("Interaction Instrumentation", () => {
   beforeEach(sharedBeforeEach);
   afterEach(sharedAfterEach);
 
   it("emits a browser.interaction log with the custom action name when a data-dash0-action-name button is clicked", async () => {
-    await loadPage("/e2e/spec/10-interactions/page.html");
+    const testId = generateUniqueId(16);
+    await loadPage(`/e2e/spec/10-interactions/page.html?testId=${testId}`);
     await expect(await browser.getTitle()).toMatch(/interactions test/);
 
     const btn = await $("#save-button");
@@ -41,10 +43,13 @@ describe("Interaction Instrumentation", () => {
         })
       );
     });
+
+    expectNoBrowserErrors();
   });
 
   it("derives the name from visible text when no custom attribute or aria-label is present", async () => {
-    await loadPage("/e2e/spec/10-interactions/page.html");
+    const testId = generateUniqueId(16);
+    await loadPage(`/e2e/spec/10-interactions/page.html?testId=${testId}`);
 
     const btn = await $("#plain-button");
     await btn.click();
@@ -65,10 +70,13 @@ describe("Interaction Instrumentation", () => {
         })
       );
     });
+
+    expectNoBrowserErrors();
   });
 
   it("derives the name from aria-label for an icon-only button with no visible text", async () => {
-    await loadPage("/e2e/spec/10-interactions/page.html");
+    const testId = generateUniqueId(16);
+    await loadPage(`/e2e/spec/10-interactions/page.html?testId=${testId}`);
 
     const btn = await $("#icon-button");
     await btn.click();
@@ -89,10 +97,13 @@ describe("Interaction Instrumentation", () => {
         })
       );
     });
+
+    expectNoBrowserErrors();
   });
 
   it("never derives a name from a text input's value, even though it has a pre-filled value", async () => {
-    await loadPage("/e2e/spec/10-interactions/page.html");
+    const testId = generateUniqueId(16);
+    await loadPage(`/e2e/spec/10-interactions/page.html?testId=${testId}`);
 
     const input = await $("#text-input");
     await input.click();
@@ -118,7 +129,7 @@ describe("Interaction Instrumentation", () => {
         })
       );
 
-      const requests = await (await import("../shared")).getOTLPRequests();
+      const requests = await getOTLPRequests();
       const logRequests = requests.filter((r) => r.path === "/v1/logs");
       const bodies = logRequests.flatMap((r) =>
         "resourceLogs" in r.body
@@ -136,10 +147,13 @@ describe("Interaction Instrumentation", () => {
         "pre-filled secret"
       );
     });
+
+    expectNoBrowserErrors();
   });
 
   it("emits no browser.interaction logs when interactionInstrumentation is left at its default (disabled)", async () => {
-    await loadPage("/e2e/spec/10-interactions/page-disabled.html");
+    const testId = generateUniqueId(16);
+    await loadPage(`/e2e/spec/10-interactions/page-disabled.html?testId=${testId}`);
 
     const btn = await $("#save-button");
     await btn.click();
@@ -153,5 +167,7 @@ describe("Interaction Instrumentation", () => {
         })
       );
     });
+
+    expectNoBrowserErrors();
   });
 });

--- a/test/e2e/spec/10-interactions/10-interactions.test.ts
+++ b/test/e2e/spec/10-interactions/10-interactions.test.ts
@@ -1,0 +1,157 @@
+import { sharedAfterEach, sharedBeforeEach } from "../shared";
+import { browser } from "@wdio/globals";
+import { loadPage, retry } from "../utils";
+import { expectLogMatching, expectNoLogMatching } from "../expectations";
+
+describe("Interaction Instrumentation", () => {
+  beforeEach(sharedBeforeEach);
+  afterEach(sharedAfterEach);
+
+  it("emits a browser.interaction log with the custom action name when a data-dash0-action-name button is clicked", async () => {
+    await loadPage("/e2e/spec/10-interactions/page.html");
+    await expect(await browser.getTitle()).toMatch(/interactions test/);
+
+    const btn = await $("#save-button");
+    await btn.click();
+
+    await retry(async () => {
+      await expectLogMatching(
+        expect.objectContaining({
+          attributes: expect.arrayContaining([
+            { key: "event.name", value: { stringValue: "browser.interaction" } },
+            { key: "page.load.id", value: { stringValue: expect.any(String) } },
+            { key: "session.id", value: { stringValue: expect.any(String) } },
+            { key: "the_answer", value: { doubleValue: 42 } },
+          ]),
+          body: {
+            kvlistValue: {
+              values: expect.arrayContaining([
+                { key: "type", value: { stringValue: "click" } },
+                { key: "name", value: { stringValue: "Save Settings" } },
+                { key: "name_source", value: { stringValue: "custom_attribute" } },
+                { key: "target.tag", value: { stringValue: "button" } },
+                { key: "target.id", value: { stringValue: "save-button" } },
+                { key: "target.selector", value: { stringValue: "button#save-button" } },
+              ]),
+            },
+          },
+          severityNumber: 9,
+          severityText: "INFO",
+          timeUnixNano: expect.any(String),
+        })
+      );
+    });
+  });
+
+  it("derives the name from visible text when no custom attribute or aria-label is present", async () => {
+    await loadPage("/e2e/spec/10-interactions/page.html");
+
+    const btn = await $("#plain-button");
+    await btn.click();
+
+    await retry(async () => {
+      await expectLogMatching(
+        expect.objectContaining({
+          body: {
+            kvlistValue: {
+              values: expect.arrayContaining([
+                { key: "name", value: { stringValue: "Continue" } },
+                { key: "name_source", value: { stringValue: "text_content" } },
+                { key: "target.id", value: { stringValue: "plain-button" } },
+                { key: "target.selector", value: { stringValue: "button#plain-button" } },
+              ]),
+            },
+          },
+        })
+      );
+    });
+  });
+
+  it("derives the name from aria-label for an icon-only button with no visible text", async () => {
+    await loadPage("/e2e/spec/10-interactions/page.html");
+
+    const btn = await $("#icon-button");
+    await btn.click();
+
+    await retry(async () => {
+      await expectLogMatching(
+        expect.objectContaining({
+          body: {
+            kvlistValue: {
+              values: expect.arrayContaining([
+                { key: "name", value: { stringValue: "Close Dialog" } },
+                { key: "name_source", value: { stringValue: "standard_attribute" } },
+                { key: "target.id", value: { stringValue: "icon-button" } },
+                { key: "target.selector", value: { stringValue: "button#icon-button" } },
+              ]),
+            },
+          },
+        })
+      );
+    });
+  });
+
+  it("never derives a name from a text input's value, even though it has a pre-filled value", async () => {
+    await loadPage("/e2e/spec/10-interactions/page.html");
+
+    const input = await $("#text-input");
+    await input.click();
+
+    await retry(async () => {
+      await expectLogMatching(
+        expect.objectContaining({
+          body: {
+            kvlistValue: {
+              values: expect.arrayContaining([
+                { key: "target.id", value: { stringValue: "text-input" } },
+                { key: "target.tag", value: { stringValue: "input" } },
+                // The input's only available name source is its `placeholder` attribute
+                // (INPUT targets never fall back to reading their own value or text
+                // content -- see TEXT_FALLBACK_EXCLUDED_TAGS / VALUE_READABLE_INPUT_TYPES
+                // in src/instrumentations/interactions/action-name.ts). The pre-filled
+                // `value="pre-filled secret"` must never leak into the emitted log.
+                { key: "name", value: { stringValue: "Type here" } },
+                { key: "name_source", value: { stringValue: "standard_attribute" } },
+              ]),
+            },
+          },
+        })
+      );
+
+      const requests = await (await import("../shared")).getOTLPRequests();
+      const logRequests = requests.filter((r) => r.path === "/v1/logs");
+      const bodies = logRequests.flatMap((r) =>
+        "resourceLogs" in r.body
+          ? r.body.resourceLogs.flatMap((rl) => rl.scopeLogs.flatMap((sl) => sl.logRecords.map((lr) => lr.body)))
+          : []
+      );
+      const interactionBody = bodies.find((b: any) =>
+        b?.kvlistValue?.values?.some((kv: any) => kv.key === "target.id" && kv.value.stringValue === "text-input")
+      ) as any;
+
+      expect(interactionBody.kvlistValue.values.map((kv: any) => kv.value?.stringValue)).not.toContain(
+        "pre-filled secret"
+      );
+      expect(interactionBody.kvlistValue.values.find((kv: any) => kv.key === "name")?.value.stringValue).not.toBe(
+        "pre-filled secret"
+      );
+    });
+  });
+
+  it("emits no browser.interaction logs when interactionInstrumentation is left at its default (disabled)", async () => {
+    await loadPage("/e2e/spec/10-interactions/page-disabled.html");
+
+    const btn = await $("#save-button");
+    await btn.click();
+    const otherBtn = await $("#plain-button");
+    await otherBtn.click();
+
+    await retry(async () => {
+      await expectNoLogMatching(
+        expect.objectContaining({
+          attributes: expect.arrayContaining([{ key: "event.name", value: { stringValue: "browser.interaction" } }]),
+        })
+      );
+    });
+  });
+});

--- a/test/e2e/spec/10-interactions/10-interactions.test.ts
+++ b/test/e2e/spec/10-interactions/10-interactions.test.ts
@@ -4,13 +4,15 @@ import { browser } from "@wdio/globals";
 import { loadPage, retry } from "../utils";
 import { expectLogMatching, expectNoBrowserErrors, expectNoLogMatching } from "../expectations";
 
+const PAGE_PATH = "/e2e/spec/10-interactions/page.html";
+
 describe("Interaction Instrumentation", () => {
   beforeEach(sharedBeforeEach);
   afterEach(sharedAfterEach);
 
   it("emits a browser.interaction log with the custom action name when a data-dash0-action-name button is clicked", async () => {
     const testId = generateUniqueId(16);
-    await loadPage(`/e2e/spec/10-interactions/page.html?testId=${testId}`);
+    await loadPage(`${PAGE_PATH}?testId=${testId}`);
     await expect(await browser.getTitle()).toMatch(/interactions test/);
 
     const btn = await $("#save-button");
@@ -24,19 +26,15 @@ describe("Interaction Instrumentation", () => {
             { key: "page.load.id", value: { stringValue: expect.any(String) } },
             { key: "session.id", value: { stringValue: expect.any(String) } },
             { key: "the_answer", value: { doubleValue: 42 } },
+            { key: "interaction.id", value: { stringValue: expect.any(String) } },
+            { key: "interaction.type", value: { stringValue: "click" } },
+            { key: "interaction.name", value: { stringValue: "Save Settings" } },
+            { key: "interaction.name_source", value: { stringValue: "custom_attribute" } },
+            { key: "interaction.target.tag", value: { stringValue: "button" } },
+            { key: "interaction.target.id", value: { stringValue: "save-button" } },
+            { key: "interaction.target.selector", value: { stringValue: "button#save-button" } },
           ]),
-          body: {
-            kvlistValue: {
-              values: expect.arrayContaining([
-                { key: "type", value: { stringValue: "click" } },
-                { key: "name", value: { stringValue: "Save Settings" } },
-                { key: "name_source", value: { stringValue: "custom_attribute" } },
-                { key: "target.tag", value: { stringValue: "button" } },
-                { key: "target.id", value: { stringValue: "save-button" } },
-                { key: "target.selector", value: { stringValue: "button#save-button" } },
-              ]),
-            },
-          },
+          body: { stringValue: `Click "Save Settings" on ${PAGE_PATH}` },
           severityNumber: 9,
           severityText: "INFO",
           timeUnixNano: expect.any(String),
@@ -49,7 +47,7 @@ describe("Interaction Instrumentation", () => {
 
   it("derives the name from visible text when no custom attribute or aria-label is present", async () => {
     const testId = generateUniqueId(16);
-    await loadPage(`/e2e/spec/10-interactions/page.html?testId=${testId}`);
+    await loadPage(`${PAGE_PATH}?testId=${testId}`);
 
     const btn = await $("#plain-button");
     await btn.click();
@@ -57,16 +55,13 @@ describe("Interaction Instrumentation", () => {
     await retry(async () => {
       await expectLogMatching(
         expect.objectContaining({
-          body: {
-            kvlistValue: {
-              values: expect.arrayContaining([
-                { key: "name", value: { stringValue: "Continue" } },
-                { key: "name_source", value: { stringValue: "text_content" } },
-                { key: "target.id", value: { stringValue: "plain-button" } },
-                { key: "target.selector", value: { stringValue: "button#plain-button" } },
-              ]),
-            },
-          },
+          attributes: expect.arrayContaining([
+            { key: "interaction.name", value: { stringValue: "Continue" } },
+            { key: "interaction.name_source", value: { stringValue: "text_content" } },
+            { key: "interaction.target.id", value: { stringValue: "plain-button" } },
+            { key: "interaction.target.selector", value: { stringValue: "button#plain-button" } },
+          ]),
+          body: { stringValue: `Click "Continue" on ${PAGE_PATH}` },
         })
       );
     });
@@ -76,7 +71,7 @@ describe("Interaction Instrumentation", () => {
 
   it("derives the name from aria-label for an icon-only button with no visible text", async () => {
     const testId = generateUniqueId(16);
-    await loadPage(`/e2e/spec/10-interactions/page.html?testId=${testId}`);
+    await loadPage(`${PAGE_PATH}?testId=${testId}`);
 
     const btn = await $("#icon-button");
     await btn.click();
@@ -84,16 +79,13 @@ describe("Interaction Instrumentation", () => {
     await retry(async () => {
       await expectLogMatching(
         expect.objectContaining({
-          body: {
-            kvlistValue: {
-              values: expect.arrayContaining([
-                { key: "name", value: { stringValue: "Close Dialog" } },
-                { key: "name_source", value: { stringValue: "standard_attribute" } },
-                { key: "target.id", value: { stringValue: "icon-button" } },
-                { key: "target.selector", value: { stringValue: "button#icon-button" } },
-              ]),
-            },
-          },
+          attributes: expect.arrayContaining([
+            { key: "interaction.name", value: { stringValue: "Close Dialog" } },
+            { key: "interaction.name_source", value: { stringValue: "standard_attribute" } },
+            { key: "interaction.target.id", value: { stringValue: "icon-button" } },
+            { key: "interaction.target.selector", value: { stringValue: "button#icon-button" } },
+          ]),
+          body: { stringValue: `Click "Close Dialog" on ${PAGE_PATH}` },
         })
       );
     });
@@ -103,7 +95,7 @@ describe("Interaction Instrumentation", () => {
 
   it("never derives a name from a text input's value, even though it has a pre-filled value", async () => {
     const testId = generateUniqueId(16);
-    await loadPage(`/e2e/spec/10-interactions/page.html?testId=${testId}`);
+    await loadPage(`${PAGE_PATH}?testId=${testId}`);
 
     const input = await $("#text-input");
     await input.click();
@@ -111,41 +103,31 @@ describe("Interaction Instrumentation", () => {
     await retry(async () => {
       await expectLogMatching(
         expect.objectContaining({
-          body: {
-            kvlistValue: {
-              values: expect.arrayContaining([
-                { key: "target.id", value: { stringValue: "text-input" } },
-                { key: "target.tag", value: { stringValue: "input" } },
-                // The input's only available name source is its `placeholder` attribute
-                // (INPUT targets never fall back to reading their own value or text
-                // content -- see TEXT_FALLBACK_EXCLUDED_TAGS / VALUE_READABLE_INPUT_TYPES
-                // in src/instrumentations/interactions/action-name.ts). The pre-filled
-                // `value="pre-filled secret"` must never leak into the emitted log.
-                { key: "name", value: { stringValue: "Type here" } },
-                { key: "name_source", value: { stringValue: "standard_attribute" } },
-              ]),
-            },
-          },
+          attributes: expect.arrayContaining([
+            { key: "interaction.target.id", value: { stringValue: "text-input" } },
+            { key: "interaction.target.tag", value: { stringValue: "input" } },
+            // The input's only available name source is its `placeholder` attribute
+            // (INPUT targets never fall back to reading their own value or text
+            // content -- see TEXT_FALLBACK_EXCLUDED_TAGS / VALUE_READABLE_INPUT_TYPES
+            // in src/instrumentations/interactions/action-name.ts). The pre-filled
+            // `value="pre-filled secret"` must never leak into the emitted log.
+            { key: "interaction.name", value: { stringValue: "Type here" } },
+            { key: "interaction.name_source", value: { stringValue: "standard_attribute" } },
+          ]),
         })
       );
 
       const requests = await getOTLPRequests();
       const logRequests = requests.filter((r) => r.path === "/v1/logs");
-      const bodies = logRequests.flatMap((r) =>
-        "resourceLogs" in r.body
-          ? r.body.resourceLogs.flatMap((rl) => rl.scopeLogs.flatMap((sl) => sl.logRecords.map((lr) => lr.body)))
-          : []
+      const logRecords = logRequests.flatMap((r) =>
+        "resourceLogs" in r.body ? r.body.resourceLogs.flatMap((rl) => rl.scopeLogs.flatMap((sl) => sl.logRecords)) : []
       );
-      const interactionBody = bodies.find((b: any) =>
-        b?.kvlistValue?.values?.some((kv: any) => kv.key === "target.id" && kv.value.stringValue === "text-input")
+      const interactionRecord = logRecords.find((lr: any) =>
+        lr.attributes?.some((kv: any) => kv.key === "interaction.target.id" && kv.value.stringValue === "text-input")
       ) as any;
 
-      expect(interactionBody.kvlistValue.values.map((kv: any) => kv.value?.stringValue)).not.toContain(
-        "pre-filled secret"
-      );
-      expect(interactionBody.kvlistValue.values.find((kv: any) => kv.key === "name")?.value.stringValue).not.toBe(
-        "pre-filled secret"
-      );
+      expect(interactionRecord.attributes.map((kv: any) => kv.value?.stringValue)).not.toContain("pre-filled secret");
+      expect(interactionRecord.body?.stringValue).not.toContain("pre-filled secret");
     });
 
     expectNoBrowserErrors();

--- a/test/e2e/spec/10-interactions/10-interactions.test.ts
+++ b/test/e2e/spec/10-interactions/10-interactions.test.ts
@@ -107,10 +107,11 @@ describe("Interaction Instrumentation", () => {
             { key: "interaction.target.id", value: { stringValue: "text-input" } },
             { key: "interaction.target.tag", value: { stringValue: "input" } },
             // The input's only available name source is its `placeholder` attribute
-            // (INPUT targets never fall back to reading their own value or text
-            // content -- see TEXT_FALLBACK_EXCLUDED_TAGS / VALUE_READABLE_INPUT_TYPES
-            // in src/instrumentations/interactions/action-name.ts). The pre-filled
-            // `value="pre-filled secret"` must never leak into the emitted log.
+            // (an input's value is only ever read for button/submit/reset types, and
+            // its text is never collected -- see VALUE_READABLE_INPUT_TYPES /
+            // TEXT_EXCLUDED_TAGS in src/instrumentations/interactions/action-name.ts).
+            // The pre-filled `value="pre-filled secret"` must never leak into the
+            // emitted log.
             { key: "interaction.name", value: { stringValue: "Type here" } },
             { key: "interaction.name_source", value: { stringValue: "standard_attribute" } },
           ]),
@@ -128,6 +129,64 @@ describe("Interaction Instrumentation", () => {
 
       expect(interactionRecord.attributes.map((kv: any) => kv.value?.stringValue)).not.toContain("pre-filled secret");
       expect(interactionRecord.body?.stringValue).not.toContain("pre-filled secret");
+    });
+
+    expectNoBrowserErrors();
+  });
+
+  it("never leaks a wrapped control's value when the name comes from an ancestor label's text", async () => {
+    const testId = generateUniqueId(16);
+    await loadPage(`${PAGE_PATH}?testId=${testId}`);
+
+    const labelText = await $("#notes-label-text");
+    await labelText.click();
+
+    await retry(async () => {
+      // Positive signal FIRST: retry() resolves on the first success, so a bare
+      // negative assertion would pass vacuously before any log arrived. The
+      // exact-match body assertion is itself part of the privacy check.
+      await expectLogMatching(
+        expect.objectContaining({
+          attributes: expect.arrayContaining([
+            { key: "interaction.target.id", value: { stringValue: "notes-label-text" } },
+            { key: "interaction.name", value: { stringValue: "Notes" } },
+            { key: "interaction.name_source", value: { stringValue: "text_content" } },
+          ]),
+          body: { stringValue: `Click "Notes" on ${PAGE_PATH}` },
+        })
+      );
+
+      // Only meaningful now that the expected record has been received: the
+      // wrapped textarea's value must appear nowhere we transmitted -- not in a
+      // log attribute, not in a body, and not on a span's user_interaction.name.
+      const requests = await getOTLPRequests();
+      expect(JSON.stringify(requests)).not.toContain("TEXTAREA-SECRET-4471");
+    });
+
+    expectNoBrowserErrors();
+  });
+
+  it("never leaks a control nested inside an aria-labelledby target", async () => {
+    const testId = generateUniqueId(16);
+    await loadPage(`${PAGE_PATH}?testId=${testId}`);
+
+    const btn = await $("#upload-button");
+    await btn.click();
+
+    await retry(async () => {
+      await expectLogMatching(
+        expect.objectContaining({
+          attributes: expect.arrayContaining([
+            { key: "interaction.target.id", value: { stringValue: "upload-button" } },
+            { key: "interaction.name", value: { stringValue: "Upload" } },
+            { key: "interaction.name_source", value: { stringValue: "standard_attribute" } },
+          ]),
+          body: { stringValue: `Click "Upload" on ${PAGE_PATH}` },
+        })
+      );
+
+      const requests = await getOTLPRequests();
+      expect(JSON.stringify(requests)).not.toContain("LABELLEDBY-SECRET-8814");
     });
 
     expectNoBrowserErrors();

--- a/test/e2e/spec/10-interactions/10-interactions.test.ts
+++ b/test/e2e/spec/10-interactions/10-interactions.test.ts
@@ -216,6 +216,43 @@ describe("Interaction Instrumentation", () => {
     expectNoBrowserErrors();
   });
 
+  it("emits one interaction event per label click, not one per browser-synthesized click", async () => {
+    const testId = generateUniqueId(16);
+    await loadPage(`${PAGE_PATH}?testId=${testId}`);
+
+    // #notes-label wraps a <textarea>, so activating the label makes the browser
+    // fire a second, also trusted, click at the labeled control -- one gesture,
+    // two clicks reaching the SDK's window-level capture listener.
+    const labelText = await $("#notes-label-text");
+    await labelText.click();
+
+    await retry(async () => {
+      // Positive gate first: retry() resolves on the first success, so the
+      // absence check below would pass vacuously before any log arrived. The
+      // forwarded click is dispatched in the same task as the label's own, so by
+      // the time this record has arrived its duplicate would have arrived with it.
+      await expectLogMatching(
+        expect.objectContaining({
+          attributes: expect.arrayContaining([
+            { key: "event.name", value: { stringValue: "browser.interaction" } },
+            { key: "interaction.target.id", value: { stringValue: "notes-label-text" } },
+          ]),
+        })
+      );
+
+      const targetIds = (await getLogRecords())
+        .filter((lr: any) => getStringAttribute(lr, "event.name") === "browser.interaction")
+        .map((lr: any) => getStringAttribute(lr, "interaction.target.id"));
+
+      // The click forwarded to the <textarea> must have been dropped: the event
+      // describes the element the user actually clicked.
+      expect(targetIds).not.toContain("notes");
+      expect(targetIds.filter((id: string | undefined) => id === "notes-label-text")).toHaveLength(1);
+    });
+
+    expectNoBrowserErrors();
+  });
+
   it("attributes a fetch fired from a click handler to the interaction that caused it", async () => {
     const testId = generateUniqueId(16);
     await loadPage(`${PAGE_PATH}?testId=${testId}`);

--- a/test/e2e/spec/10-interactions/10-interactions.test.ts
+++ b/test/e2e/spec/10-interactions/10-interactions.test.ts
@@ -2,9 +2,37 @@ import { getOTLPRequests, sharedAfterEach, sharedBeforeEach } from "../shared";
 import { generateUniqueId } from "../../../../src/utils";
 import { browser } from "@wdio/globals";
 import { loadPage, retry } from "../utils";
-import { expectLogMatching, expectNoBrowserErrors, expectNoLogMatching } from "../expectations";
+import {
+  expectLogMatching,
+  expectNoBrowserErrors,
+  expectNoLogMatching,
+  expectSpanMatching,
+  getLogRecords,
+  getSpans,
+  getStringAttribute,
+} from "../expectations";
 
 const PAGE_PATH = "/e2e/spec/10-interactions/page.html";
+const DISABLED_PAGE_PATH = "/e2e/spec/10-interactions/page-disabled.html";
+
+/**
+ * Resolves the `interaction.id` the `browser.interaction` event for a given
+ * click target carried, throwing when the event has not arrived yet so the
+ * caller's retry() keeps polling.
+ */
+async function getInteractionIdForTarget(targetId: string): Promise<string> {
+  const record = (await getLogRecords()).find(
+    (lr: any) =>
+      getStringAttribute(lr, "event.name") === "browser.interaction" &&
+      getStringAttribute(lr, "interaction.target.id") === targetId
+  );
+
+  const interactionId = record && getStringAttribute(record, "interaction.id");
+  if (!interactionId) {
+    throw new Error(`No browser.interaction event with an interaction.id for target #${targetId} received yet`);
+  }
+  return interactionId;
+}
 
 describe("Interaction Instrumentation", () => {
   beforeEach(sharedBeforeEach);
@@ -118,13 +146,9 @@ describe("Interaction Instrumentation", () => {
         })
       );
 
-      const requests = await getOTLPRequests();
-      const logRequests = requests.filter((r) => r.path === "/v1/logs");
-      const logRecords = logRequests.flatMap((r) =>
-        "resourceLogs" in r.body ? r.body.resourceLogs.flatMap((rl) => rl.scopeLogs.flatMap((sl) => sl.logRecords)) : []
-      );
-      const interactionRecord = logRecords.find((lr: any) =>
-        lr.attributes?.some((kv: any) => kv.key === "interaction.target.id" && kv.value.stringValue === "text-input")
+      const logRecords = await getLogRecords();
+      const interactionRecord = logRecords.find(
+        (lr: any) => getStringAttribute(lr, "interaction.target.id") === "text-input"
       ) as any;
 
       expect(interactionRecord.attributes.map((kv: any) => kv.value?.stringValue)).not.toContain("pre-filled secret");
@@ -192,9 +216,86 @@ describe("Interaction Instrumentation", () => {
     expectNoBrowserErrors();
   });
 
+  it("attributes a fetch fired from a click handler to the interaction that caused it", async () => {
+    const testId = generateUniqueId(16);
+    await loadPage(`${PAGE_PATH}?testId=${testId}`);
+
+    const btn = await $("#fetch-button");
+    await btn.click();
+
+    await retry(async () => {
+      // Both halves are positive assertions, so retry() cannot succeed before the
+      // interaction event and its request span have both arrived.
+      const interactionId = await getInteractionIdForTarget("fetch-button");
+
+      await expectSpanMatching(
+        expect.objectContaining({
+          name: "HTTP GET",
+          attributes: expect.arrayContaining([
+            { key: "url.path", value: { stringValue: "/ajax" } },
+            { key: "user_interaction.id", value: { stringValue: interactionId } },
+            { key: "user_interaction.name", value: { stringValue: "Load Report" } },
+          ]),
+        })
+      );
+    });
+
+    expectNoBrowserErrors();
+  });
+
+  it("attributes an XMLHttpRequest fired from a click handler to the interaction that caused it", async () => {
+    const testId = generateUniqueId(16);
+    await loadPage(`${PAGE_PATH}?testId=${testId}`);
+
+    const btn = await $("#xhr-button");
+    await btn.click();
+
+    await retry(async () => {
+      const interactionId = await getInteractionIdForTarget("xhr-button");
+
+      await expectSpanMatching(
+        expect.objectContaining({
+          name: "HTTP GET",
+          attributes: expect.arrayContaining([
+            { key: "url.path", value: { stringValue: "/ajax" } },
+            { key: "user_interaction.id", value: { stringValue: interactionId } },
+            { key: "user_interaction.name", value: { stringValue: "Refresh Table" } },
+          ]),
+        })
+      );
+    });
+
+    expectNoBrowserErrors();
+  });
+
+  it("stamps no user_interaction attributes on request spans when interactionInstrumentation is disabled", async () => {
+    const testId = generateUniqueId(16);
+    await loadPage(`${DISABLED_PAGE_PATH}?testId=${testId}`);
+
+    const btn = await $("#fetch-button");
+    await btn.click();
+
+    await retry(async () => {
+      // Positive gate first: without waiting for the request span to actually
+      // arrive, the absence check below would pass vacuously.
+      await expectSpanMatching(
+        expect.objectContaining({
+          name: "HTTP GET",
+          attributes: expect.arrayContaining([{ key: "url.path", value: { stringValue: "/ajax" } }]),
+        })
+      );
+
+      const attributeKeys = (await getSpans()).flatMap((span: any) => (span.attributes ?? []).map((kv: any) => kv.key));
+      expect(attributeKeys).not.toContain("user_interaction.id");
+      expect(attributeKeys).not.toContain("user_interaction.name");
+    });
+
+    expectNoBrowserErrors();
+  });
+
   it("emits no browser.interaction logs when interactionInstrumentation is left at its default (disabled)", async () => {
     const testId = generateUniqueId(16);
-    await loadPage(`/e2e/spec/10-interactions/page-disabled.html?testId=${testId}`);
+    await loadPage(`${DISABLED_PAGE_PATH}?testId=${testId}`);
 
     const btn = await $("#save-button");
     await btn.click();

--- a/test/e2e/spec/10-interactions/10-interactions.test.ts
+++ b/test/e2e/spec/10-interactions/10-interactions.test.ts
@@ -15,6 +15,9 @@ import {
 const PAGE_PATH = "/e2e/spec/10-interactions/page.html";
 const DISABLED_PAGE_PATH = "/e2e/spec/10-interactions/page-disabled.html";
 
+/** Mirrors MAX_TARGET_VALUE_LENGTH in src/instrumentations/interactions/emit.ts. */
+const MAX_TARGET_VALUE_LENGTH = 128;
+
 /**
  * Resolves the `interaction.id` the `browser.interaction` event for a given
  * click target carried, throwing when the event has not arrived yet so the
@@ -153,6 +156,93 @@ describe("Interaction Instrumentation", () => {
 
       expect(interactionRecord.attributes.map((kv: any) => kv.value?.stringValue)).not.toContain("pre-filled secret");
       expect(interactionRecord.body?.stringValue).not.toContain("pre-filled secret");
+    });
+
+    expectNoBrowserErrors();
+  });
+
+  it("describes a form target by its real id, which its own hidden id field clobbers", async () => {
+    // Only testable here: HTMLFormElement's named getter shadows `form.id` in real
+    // browsers and jsdom does not implement it, so the unit tests have to simulate
+    // the shadowing. Reading `.id` naively yields the <input> element, which ships
+    // as an empty kvlistValue instead of a string.
+    const testId = generateUniqueId(16);
+    await loadPage(`${PAGE_PATH}?testId=${testId}`);
+
+    const form = await $("#checkout-form");
+    await form.click();
+
+    await retry(async () => {
+      await expectLogMatching(
+        expect.objectContaining({
+          attributes: expect.arrayContaining([
+            { key: "event.name", value: { stringValue: "browser.interaction" } },
+            { key: "interaction.type", value: { stringValue: "click" } },
+            { key: "interaction.name", value: { stringValue: "Checkout" } },
+            { key: "interaction.name_source", value: { stringValue: "custom_attribute" } },
+            { key: "interaction.target.id", value: { stringValue: "checkout-form" } },
+            { key: "interaction.target.tag", value: { stringValue: "form" } },
+            { key: "interaction.target.selector", value: { stringValue: "form#checkout-form" } },
+          ]),
+          body: { stringValue: `Click "Checkout" on ${PAGE_PATH}` },
+        })
+      );
+    });
+
+    expectNoBrowserErrors();
+  });
+
+  it("names a click from an enclosing form whose getAttribute method is clobbered", async () => {
+    const testId = generateUniqueId(16);
+    await loadPage(`${PAGE_PATH}?testId=${testId}`);
+
+    const btn = await $("#wrapped-button");
+    await btn.click();
+
+    await retry(async () => {
+      await expectLogMatching(
+        expect.objectContaining({
+          attributes: expect.arrayContaining([
+            // The custom attribute lives on the form, so deriving this name means
+            // reading an attribute off an element whose `getAttribute` is shadowed.
+            // Naively that throws and the interaction never arrives at all.
+            { key: "interaction.name", value: { stringValue: "Wrapped Form" } },
+            { key: "interaction.name_source", value: { stringValue: "custom_attribute" } },
+            { key: "interaction.target.id", value: { stringValue: "wrapped-button" } },
+            { key: "interaction.target.selector", value: { stringValue: "button#wrapped-button" } },
+          ]),
+          body: { stringValue: `Click "Wrapped Form" on ${PAGE_PATH}` },
+        })
+      );
+    });
+
+    expectNoBrowserErrors();
+  });
+
+  it("caps interaction.target.id and the selector at 128 characters", async () => {
+    const testId = generateUniqueId(16);
+    await loadPage(`${PAGE_PATH}?testId=${testId}`);
+
+    // Selected by its action-name attribute rather than its id: both expectations
+    // below only depend on the id being longer than the cap, so the fixture's exact
+    // id length stays irrelevant to the assertions.
+    const btn = await $('[data-dash0-action-name="Long Id"]');
+    await btn.click();
+
+    await retry(async () => {
+      await expectLogMatching(
+        expect.objectContaining({
+          attributes: expect.arrayContaining([
+            { key: "interaction.name", value: { stringValue: "Long Id" } },
+            { key: "interaction.target.id", value: { stringValue: "a".repeat(MAX_TARGET_VALUE_LENGTH) } },
+            {
+              key: "interaction.target.selector",
+              // "button#" plus as many id characters as fit inside the same cap.
+              value: { stringValue: `button#${"a".repeat(MAX_TARGET_VALUE_LENGTH - "button#".length)}` },
+            },
+          ]),
+        })
+      );
     });
 
     expectNoBrowserErrors();

--- a/test/e2e/spec/10-interactions/10-interactions.test.ts
+++ b/test/e2e/spec/10-interactions/10-interactions.test.ts
@@ -303,6 +303,19 @@ describe("Interaction Instrumentation", () => {
     await otherBtn.click();
 
     await retry(async () => {
+      // Positive gates first. Each button's own onclick sends a marker event, which the
+      // capture-phase interaction listener would have preceded within the same dispatch
+      // task and hence the same log batch (see page-disabled.html). Once both markers have
+      // arrived, a browser.interaction log would have arrived alongside them -- without
+      // this the absence check below succeeds on retry()'s first probe and proves nothing.
+      for (const marker of ["e2e.marker.save", "e2e.marker.plain"]) {
+        await expectLogMatching(
+          expect.objectContaining({
+            attributes: expect.arrayContaining([{ key: "event.name", value: { stringValue: marker } }]),
+          })
+        );
+      }
+
       await expectNoLogMatching(
         expect.objectContaining({
           attributes: expect.arrayContaining([{ key: "event.name", value: { stringValue: "browser.interaction" } }]),

--- a/test/e2e/spec/10-interactions/page-disabled.html
+++ b/test/e2e/spec/10-interactions/page-disabled.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <title>interactions disabled test</title>
+
+    <script>
+      (function (d, a, s, h, z, e, r, o) {
+        d[a] ||
+          ((z = d[a] =
+            function () {
+              h.push(arguments);
+            }),
+          (z._t = new Date()),
+          (z._v = 1),
+          (h = z._q = []));
+      })(window, "dash0");
+      dash0("init", {
+        serviceName: "dash0.com",
+        serviceVersion: "1.2.3",
+        environment: "prod",
+        endpoint: {
+          url: `http://${window.location.hostname}:8011?cors=true`,
+          authToken: "auth_abc123",
+          dataset: "production",
+        },
+      });
+      dash0("addSignalAttribute", "the_answer", 42);
+    </script>
+    <script defer crossorigin="anonymous" src="/dist/dash0.iife.js"></script>
+  </head>
+  <body>
+    <button id="save-button" data-dash0-action-name="Save Settings">Save</button>
+    <button id="plain-button">Continue</button>
+  </body>
+</html>

--- a/test/e2e/spec/10-interactions/page-disabled.html
+++ b/test/e2e/spec/10-interactions/page-disabled.html
@@ -28,9 +28,18 @@
       dash0("addSignalAttribute", "the_answer", 42);
     </script>
     <script defer crossorigin="anonymous" src="/dist/dash0.iife.js"></script>
+    <script>
+      function onFetchClick() {
+        return fetch(`/ajax?cacheBust=${Date.now()}`).catch(() => {});
+      }
+    </script>
   </head>
   <body>
     <button id="save-button" data-dash0-action-name="Save Settings">Save</button>
     <button id="plain-button">Continue</button>
+
+    <!-- With interaction instrumentation off, this request's span must carry no
+         user_interaction.* attributes at all. -->
+    <button id="fetch-button" data-dash0-action-name="Load Report" onclick="onFetchClick()">Load</button>
   </body>
 </html>

--- a/test/e2e/spec/10-interactions/page-disabled.html
+++ b/test/e2e/spec/10-interactions/page-disabled.html
@@ -32,11 +32,23 @@
       function onFetchClick() {
         return fetch(`/ajax?cacheBust=${Date.now()}`).catch(() => {});
       }
+
+      // Marker event emitted from the bubble phase of the very click whose capture-phase
+      // browser.interaction log the test asserts the absence of. Both go through the same
+      // log batcher within the same event-dispatch task, so they end up in the same OTLP
+      // request: once the marker has arrived at the test server, an interaction log would
+      // have arrived with it. Without such a positive gate the absence assertion inside
+      // retry() succeeds on the first probe and proves nothing.
+      function onMarkerClick(name) {
+        dash0("sendEvent", name);
+      }
     </script>
   </head>
   <body>
-    <button id="save-button" data-dash0-action-name="Save Settings">Save</button>
-    <button id="plain-button">Continue</button>
+    <button id="save-button" data-dash0-action-name="Save Settings" onclick="onMarkerClick('e2e.marker.save')">
+      Save
+    </button>
+    <button id="plain-button" onclick="onMarkerClick('e2e.marker.plain')">Continue</button>
 
     <!-- With interaction instrumentation off, this request's span must carry no
          user_interaction.* attributes at all. -->

--- a/test/e2e/spec/10-interactions/page.html
+++ b/test/e2e/spec/10-interactions/page.html
@@ -1,0 +1,41 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <title>interactions test</title>
+
+    <script>
+      (function (d, a, s, h, z, e, r, o) {
+        d[a] ||
+          ((z = d[a] =
+            function () {
+              h.push(arguments);
+            }),
+          (z._t = new Date()),
+          (z._v = 1),
+          (h = z._q = []));
+      })(window, "dash0");
+      dash0("init", {
+        serviceName: "dash0.com",
+        serviceVersion: "1.2.3",
+        environment: "prod",
+        endpoint: {
+          url: `http://${window.location.hostname}:8011?cors=true`,
+          authToken: "auth_abc123",
+          dataset: "production",
+        },
+        interactionInstrumentation: {
+          enabled: true,
+        },
+      });
+      dash0("addSignalAttribute", "the_answer", 42);
+    </script>
+    <script defer crossorigin="anonymous" src="/dist/dash0.iife.js"></script>
+  </head>
+  <body>
+    <button id="save-button" data-dash0-action-name="Save Settings">Save</button>
+    <button id="plain-button">Continue</button>
+    <button id="icon-button" aria-label="Close Dialog">&times;</button>
+    <input id="text-input" type="text" value="pre-filled secret" placeholder="Type here" />
+  </body>
+</html>

--- a/test/e2e/spec/10-interactions/page.html
+++ b/test/e2e/spec/10-interactions/page.html
@@ -37,5 +37,18 @@
     <button id="plain-button">Continue</button>
     <button id="icon-button" aria-label="Close Dialog">&times;</button>
     <input id="text-input" type="text" value="pre-filled secret" placeholder="Type here" />
+
+    <!--
+      Privacy fixtures. A <label> wrapping its control is the dominant form
+      markup, so label.textContent contains the control's value; the click target
+      is a dedicated inner span so WebDriver's centre-click cannot land on the
+      textarea itself.
+    -->
+    <label id="notes-label"
+      ><span id="notes-label-text">Notes</span>
+      <textarea id="notes">TEXTAREA-SECRET-4471</textarea>
+    </label>
+    <span id="upload-label">Upload <textarea id="upload-draft">LABELLEDBY-SECRET-8814</textarea></span>
+    <button id="upload-button" aria-labelledby="upload-label">&uarr;</button>
   </body>
 </html>

--- a/test/e2e/spec/10-interactions/page.html
+++ b/test/e2e/spec/10-interactions/page.html
@@ -31,6 +31,21 @@
       dash0("addSignalAttribute", "the_answer", 42);
     </script>
     <script defer crossorigin="anonymous" src="/dist/dash0.iife.js"></script>
+    <script>
+      // Requests fired from a click handler. The cache bust keeps every click's
+      // request distinct so each one produces its own resource timing, and the
+      // rejections are swallowed so a failed request cannot show up as a browser
+      // error in expectNoBrowserErrors().
+      function onFetchClick() {
+        return fetch(`/ajax?cacheBust=${Date.now()}`).catch(() => {});
+      }
+
+      function onXhrClick() {
+        const xhr = new XMLHttpRequest();
+        xhr.open("GET", `/ajax?cacheBust=${Date.now()}`);
+        xhr.send();
+      }
+    </script>
   </head>
   <body>
     <button id="save-button" data-dash0-action-name="Save Settings">Save</button>
@@ -50,5 +65,10 @@
     </label>
     <span id="upload-label">Upload <textarea id="upload-draft">LABELLEDBY-SECRET-8814</textarea></span>
     <button id="upload-button" aria-labelledby="upload-label">&uarr;</button>
+
+    <!-- Click-to-request attribution: the span of the request fired by the handler
+         must carry the id of the click that caused it. -->
+    <button id="fetch-button" data-dash0-action-name="Load Report" onclick="onFetchClick()">Load</button>
+    <button id="xhr-button" data-dash0-action-name="Refresh Table" onclick="onXhrClick()">Refresh</button>
   </body>
 </html>

--- a/test/e2e/spec/10-interactions/page.html
+++ b/test/e2e/spec/10-interactions/page.html
@@ -70,5 +70,55 @@
          must carry the id of the click that caused it. -->
     <button id="fetch-button" data-dash0-action-name="Load Report" onclick="onFetchClick()">Load</button>
     <button id="xhr-button" data-dash0-action-name="Refresh Table" onclick="onXhrClick()">Refresh</button>
+
+    <!--
+      DOM clobbering. HTMLFormElement is [LegacyOverrideBuiltIns], so a named form
+      control shadows the form's own same-named property: here `checkoutForm.id`
+      returns the <input> rather than "checkout-form". jsdom does not implement the
+      shadowing, so these two fixtures are the only place the SDK's clobber-safe
+      reads (src/utils/dom.ts) are exercised for real.
+
+      Only `id` is shadowed on this one -- a hidden `id` field is ordinary CRUD
+      markup -- and deliberately nothing else: shadowing `tagName`/`getAttribute`
+      breaks ChromeDriver's own in-page automation atoms, which makes WebDriver's
+      click a silent no-op, so a form clobbered any harder cannot be clicked by the
+      test driver at all. Those shadows are covered by the unit tests instead.
+
+      The form is the click target itself: its only child is a hidden input, so the
+      form's own padding is all there is to click and a centre-click cannot land on
+      a descendant. onsubmit is blocked so a click can never navigate the page away
+      mid-test.
+    -->
+    <form
+      id="checkout-form"
+      class="checkout wide"
+      data-dash0-action-name="Checkout"
+      style="padding: 30px"
+      onsubmit="return false"
+    >
+      <input type="hidden" name="id" value="4711" />
+    </form>
+
+    <!--
+      The naming walk's view of a clobbered form: the click target is a plain button
+      the driver can interact with, and the name has to come from the enclosing
+      form's data-dash0-action-name -- i.e. from an attribute read on an element
+      whose `getAttribute` is shadowed. Reading it naively throws, and the handler's
+      try/catch would swallow that into no event at all.
+    -->
+    <form id="wrapped-form" data-dash0-action-name="Wrapped Form" onsubmit="return false">
+      <input type="hidden" name="getAttribute" value="clobbered" />
+      <button id="wrapped-button" type="button">Go</button>
+    </form>
+
+    <!-- interaction.target.id is capped at 128 characters like the selector, so a
+         page with generated or state-carrying ids cannot send unbounded strings on
+         every interaction. This id is well past the cap. -->
+    <button
+      id="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      data-dash0-action-name="Long Id"
+    >
+      Long id
+    </button>
   </body>
 </html>

--- a/test/e2e/spec/expectations.ts
+++ b/test/e2e/spec/expectations.ts
@@ -118,6 +118,37 @@ export async function expectNoLogMatching(matcher: ExpectWebdriverIO.PartialMatc
   withFullDepthDiff(logRequests, () => expect(logRequests).not.toEqual(getLogMatcher(matcher)));
 }
 
+/**
+ * Flattens the recorded OTLP payloads down to the individual records.
+ *
+ * The expect*Matching helpers above cover everything that can be expressed as a
+ * matcher. These exist for assertions that need a transmitted *value* rather
+ * than a shape -- e.g. correlating a span's `user_interaction.id` with the id
+ * the `browser.interaction` event carried, where the id is only known at
+ * assertion time.
+ */
+export async function getLogRecords() {
+  const requests = await getOTLPRequests();
+  return requests
+    .filter((r) => r.path === "/v1/logs")
+    .flatMap((r) =>
+      "resourceLogs" in r.body ? r.body.resourceLogs.flatMap((rl) => rl.scopeLogs.flatMap((sl) => sl.logRecords)) : []
+    );
+}
+
+export async function getSpans() {
+  const requests = await getOTLPRequests();
+  return requests
+    .filter((r) => r.path === "/v1/traces")
+    .flatMap((r) =>
+      "resourceSpans" in r.body ? r.body.resourceSpans.flatMap((rs) => rs.scopeSpans.flatMap((ss) => ss.spans)) : []
+    );
+}
+
+export function getStringAttribute(record: { attributes?: any[] }, key: string): string | undefined {
+  return record.attributes?.find((kv) => kv.key === key)?.value?.stringValue;
+}
+
 export function expectNoBrowserErrors() {
   // bidi is required to subscribe to browser logs
   if (!browser.isBidi) {


### PR DESCRIPTION
In-repo replacement for #98 (originally opened from a fork, where the LambdaTest secrets are unavailable so the e2e job cannot run). Same approach as #99 (XHR) and #101 (startView).

**Authorship is preserved** — all 17 feature commits carry their original authors: @parker-edwards (Parker Hyland) and @seanpeterkin (Sean Peterkin). Please credit them on merge.

## What

Adds an opt-in `@dash0/interactions` instrumentation: automatic `browser.interaction` events for clicks (with individually opt-in scroll / key-press / change capture), plus click-to-request correlation that stamps `user_interaction.*` onto fetch and XHR spans.

Disabled by default. See `docs/sdk/configuration.md > Interaction instrumentation` for the full option surface.

## How this differs from #98

#98 was stacked on the XHR branch, so its diff included those commits. Since #99 landed, only the 17 interaction-specific commits are rebased here. Four conflicts were resolved by hand:

| File | Resolution |
|------|------------|
| `src/instrumentations/http/utils.ts` | Merged import lists; added `addInteractionAttributes()` |
| `src/instrumentations/http/fetch.ts` | `main` moved span setup into `onFetchStart()` — call placed there |
| `src/instrumentations/http/xhr.ts` | `main` moved span setup into `onSend()` — call placed there |
| `docs/sdk/configuration.md` | `main` split `INSTALL.md` into `docs/sdk/*` — docs ported into the new structure |

One additional commit on top (`docs(interactions): align ported docs with shipped behavior`) corrects the ported documentation, which had been written against the click-only era of the series and did not describe the shipped feature.

## Verification

`pnpm run ci` green (lint, prettier, 412 unit tests across 30 files, build — 24.3 kB gzip ESM). `pnpm run test:e2e:local` green: 11/11 spec files including the new `10-interactions`.

## Review status

A structured review has been run against this branch and the findings are posted as review comments below, each in conventional-commit style so they can be addressed individually. Summary: **no P0s**, but several P1s worth resolving before merge — most notably a privacy-contract gap in action-name derivation (verified by execution), and missing coverage on both the click-to-request correlation and the disabled-by-default guarantee.

🤖 Generated with [Claude Code](https://claude.com/claude-code)