### PR TITLE
Update titles for Web SDK documentation

### DIFF
--- a/.github/workflows/sync-docs/transformations.yaml
+++ b/.github/workflows/sync-docs/transformations.yaml
@@ -30,12 +30,12 @@ nav:
   order: 72.7
   id: web-sdk
   parentPath: Tooling
-  title: Web SDK
+  title: Dash0 Web SDK
 
 files:
   - source: README.md
     target: dash0/miscellaneous/tooling/web-sdk/overview.md
-    title: About the Web SDK
+    title: About the Dash0 Web SDK
     description: Introduction to the Dash0 Web SDK — what it instruments, its features, and how to get started capturing frontend telemetry.
     transformations:
       - description: rewrite the relative INSTALL.md link to the Installation sub-page


### PR DESCRIPTION
This pull request makes a small update to the documentation navigation for the Web SDK. The change is to clarify the naming of the SDK throughout the navigation and overview.

* Changed the navigation and overview titles from "Web SDK" to "Dash0 Web SDK" for clarity and consistency. Updating the title of Web SDK to Dash0 Web SDK to make it consistent with the other tooling sections.