### PR TITLE
ci: skip E2E matrix on docs-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,12 @@ jobs:
 
           # --no-renames: a rename into docs/ (e.g. `git mv src/foo.ts docs/foo.md`) would otherwise report
           # only the destination path and be misclassified as a docs-only change.
+          #
+          # Two-dot diff (not three-dot/`base...head`) is required, not a style choice: three-dot needs a
+          # merge base, which doesn't exist on this shallow (--depth=1) fetch of just the base commit — it
+          # fails with "fatal: no merge base" on every PR. That failure would be caught by the fail-open
+          # guard below, so switching to three-dot wouldn't be unsafe, just silently useless: every PR would
+          # fall back to only_docs=false and the E2E skip would never fire again.
           if ! changed_files=$(git diff --no-renames --name-only "$base" "${{ github.sha }}"); then
             echo "git diff against base $base failed, treating as non-docs-only"
             echo "only_docs=false" >> "$GITHUB_OUTPUT"
@@ -93,7 +99,13 @@ jobs:
           if [ "${{ steps.docs-only.outputs.only_docs }}" = "true" ]; then
             echo "capabilities=[]" >> $GITHUB_OUTPUT
           else
-            echo "capabilities=$(pnpm exec tsx ./test/e2e/scripts/get-wdio-capabilities.ts)" >> $GITHUB_OUTPUT
+            # Assigning to a variable first (rather than embedding the substitution in `echo`'s argument)
+            # matters here: `echo "x=$(cmd)"` always succeeds regardless of cmd's exit status, so a crash in
+            # get-wdio-capabilities.ts would otherwise silently write an empty capabilities value instead of
+            # failing this step — which the test-e2e `if:` guard would then read as "nothing to run" and
+            # skip E2E entirely, turning a real failure into a false green.
+            capabilities=$(pnpm exec tsx ./test/e2e/scripts/get-wdio-capabilities.ts)
+            echo "capabilities=$capabilities" >> $GITHUB_OUTPUT
           fi
 
   test-e2e:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,11 @@ jobs:
 
   test-e2e:
     needs: build
+    # An empty capabilities array is a valid, deliberate signal (docs-only change), but handing `strategy.matrix`
+    # an empty array directly causes GitHub to fail the run at strategy-evaluation time ("Matrix vector
+    # 'capability' does not contain any values") instead of cleanly skipping the job. Gating with `if:` here
+    # means the job — and its matrix — is never evaluated at all when there's nothing to run.
+    if: ${{ needs.build.outputs.capabilities != '[]' && needs.build.outputs.capabilities != '' }}
     runs-on: ubuntu-latest
     strategy:
       max-parallel: 1
@@ -135,11 +140,15 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     needs:
+      - build
       - test-e2e
-    # test-e2e is skipped (not 'success') when the E2E matrix is empty for a docs-only change; without
-    # `always()` here, GitHub's default needs-cascade would skip this job too, so its own pass/fail logic
-    # below (which does account for 'skipped') would never run.
-    if: ${{ always() }}
+    # test-e2e is skipped (not 'success') when the E2E matrix is empty for a docs-only change; without an
+    # `if:` here, GitHub's default needs-cascade would skip this job too, so its own pass/fail logic below
+    # (which does account for 'skipped') would never run. `!cancelled()` (rather than `always()`) still lets a
+    # cancelled run skip this gate instead of reporting a false pass. `build` is included in `needs` so a
+    # failed `build` shows up as 'failure' in `needs.*.result` below instead of this job passing on the
+    # strength of test-e2e being merely skipped-due-to-upstream-failure.
+    if: ${{ !cancelled() }}
     steps:
       - name: Successful tests
         if: ${{ !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,10 +41,45 @@ jobs:
       - name: build
         run: pnpm run build
 
+      # E2E tests exercise runtime behavior, so a change that only touches docs (README.md, INSTALL.md,
+      # docs/) can't affect their outcome. Detect that case via a plain git diff (no extra actions/deps needed)
+      # and skip the E2E matrix by handing it an empty capability list; check-e2e-tests still passes since a
+      # skipped test-e2e run isn't a 'failure' or 'cancelled' result.
+      - name: Determine if only documentation changed
+        id: docs-only
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            git fetch --no-tags --depth=1 origin "${{ github.event.pull_request.base.sha }}"
+            base="${{ github.event.pull_request.base.sha }}"
+          else
+            base="${{ github.event.before }}"
+          fi
+
+          # base is all-zeros on a new branch's first push (no prior commit to diff against); run the full
+          # pipeline in that case rather than guessing.
+          if [ -z "$base" ] || [ "$base" = "0000000000000000000000000000000000000000" ]; then
+            echo "only_docs=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          changed_files=$(git diff --name-only "$base" "${{ github.sha }}")
+          echo "Changed files:"
+          echo "$changed_files"
+
+          if [ -n "$changed_files" ] && ! echo "$changed_files" | grep -qvE '^(docs/|README\.md|INSTALL\.md)'; then
+            echo "only_docs=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "only_docs=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Get capabilities for E2E tests
         id: get-capabilities
         run: |
-          echo "capabilities=$(pnpm exec tsx ./test/e2e/scripts/get-wdio-capabilities.ts)" >> $GITHUB_OUTPUT
+          if [ "${{ steps.docs-only.outputs.only_docs }}" = "true" ]; then
+            echo "capabilities=[]" >> $GITHUB_OUTPUT
+          else
+            echo "capabilities=$(pnpm exec tsx ./test/e2e/scripts/get-wdio-capabilities.ts)" >> $GITHUB_OUTPUT
+          fi
 
   test-e2e:
     needs: build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,11 +45,13 @@ jobs:
       # docs/) can't affect their outcome. Detect that case via a plain git diff (no extra actions/deps needed)
       # and skip the E2E matrix by handing it an empty capability list; check-e2e-tests still passes since a
       # skipped test-e2e run isn't a 'failure' or 'cancelled' result.
+      #
+      # This must fail open: any error here (unreachable base, GC'd object, network blip) falls back to
+      # only_docs=false rather than erroring the build job, since build gates every other job in this workflow.
       - name: Determine if only documentation changed
         id: docs-only
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then
-            git fetch --no-tags --depth=1 origin "${{ github.event.pull_request.base.sha }}"
             base="${{ github.event.pull_request.base.sha }}"
           else
             base="${{ github.event.before }}"
@@ -62,11 +64,24 @@ jobs:
             exit 0
           fi
 
-          changed_files=$(git diff --name-only "$base" "${{ github.sha }}")
+          if ! git fetch --no-tags --depth=1 origin "$base"; then
+            echo "Could not fetch base $base, treating as non-docs-only"
+            echo "only_docs=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # --no-renames: a rename into docs/ (e.g. `git mv src/foo.ts docs/foo.md`) would otherwise report
+          # only the destination path and be misclassified as a docs-only change.
+          if ! changed_files=$(git diff --no-renames --name-only "$base" "${{ github.sha }}"); then
+            echo "git diff against base $base failed, treating as non-docs-only"
+            echo "only_docs=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           echo "Changed files:"
           echo "$changed_files"
 
-          if [ -n "$changed_files" ] && ! echo "$changed_files" | grep -qvE '^(docs/|README\.md|INSTALL\.md)'; then
+          if [ -n "$changed_files" ] && ! echo "$changed_files" | grep -qvE '^(docs/|README\.md$|INSTALL\.md$)'; then
             echo "only_docs=true" >> "$GITHUB_OUTPUT"
           else
             echo "only_docs=false" >> "$GITHUB_OUTPUT"
@@ -121,6 +136,10 @@ jobs:
     timeout-minutes: 5
     needs:
       - test-e2e
+    # test-e2e is skipped (not 'success') when the E2E matrix is empty for a docs-only change; without
+    # `always()` here, GitHub's default needs-cascade would skip this job too, so its own pass/fail logic
+    # below (which does account for 'skipped') would never run.
+    if: ${{ always() }}
     steps:
       - name: Successful tests
         if: ${{ !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}


### PR DESCRIPTION
## Summary
- Skips the E2E test matrix when a push/PR touches only `docs/`, `README.md`, or `INSTALL.md`, since those changes can't affect runtime behavior.
- Detects this via a plain `git diff` in the `build` job (no new dependencies) and hands the matrix strategy an empty capability list in that case.
- `check-e2e-tests` still passes on a skipped `test-e2e` run, since it only fails on `failure`/`cancelled` results.

## Test plan
- [ ] Open a PR that only touches a doc file and confirm `test-e2e` shows as skipped while `check-e2e-tests` passes.
- [ ] Open a PR that touches source code and confirm the E2E matrix runs as before.
- [ ] Push to `main` and confirm the `before`-SHA diff path works the same way.