### PR TITLE
test: verify E2E matrix is skipped for docs-only changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Dash0 Web SDK
 
-This SDK enables users of Dash0's web monitoring features to instrument a website or single-page-application to capture
+This SDK enables users of Dash0's web monitoring features to instrument a website or single-page application to capture
 and transmit telemetry to Dash0.
 
 Features include:


### PR DESCRIPTION
## Summary
Throwaway PR to validate the docs-only detection added in #104. This PR only touches `README.md`, so `test-e2e` should show 0 matrix jobs and `check-e2e-tests` should still pass.

Not meant to be merged — close after verifying the Actions run.

## Test plan
- [ ] `test-e2e` job shows as skipped (empty matrix)
- [ ] `check-e2e-tests` passes