### PR TITLE
PROBE: empty capabilities (delete me)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,7 @@ jobs:
           if [ "${{ steps.docs-only.outputs.only_docs }}" = "true" ]; then
             echo "capabilities=[]" >> $GITHUB_OUTPUT
           else
-            echo "capabilities=$(pnpm exec tsx ./test/e2e/scripts/get-wdio-capabilities.ts)" >> $GITHUB_OUTPUT
+            echo "capabilities=$(bash -c 'echo simulated-script-failure >&2; exit 1')" >> $GITHUB_OUTPUT
           fi
 
   test-e2e:


### PR DESCRIPTION
Throwaway probe: simulates get-wdio-capabilities.ts failing so capabilities=''. Checking whether the E2E gate silently goes green. Will be deleted.